### PR TITLE
fix: restore index back when continue process

### DIFF
--- a/scripts/parser/open_ai_func.py
+++ b/scripts/parser/open_ai_func.py
@@ -36,8 +36,8 @@ def call_openai_api(docs):
             store.index = None
             with open("faiss_store.pkl", "wb") as f:
                 pickle.dump(store, f)
-            print("Sleeping for 10 seconds and trying again")
-            time.sleep(10)
+            print("Sleeping for 60 seconds and trying again")
+            time.sleep(60)
             faiss.write_index(store_index_bak, "docs.index")
             store.index = store_index_bak
             store.add_texts([i.page_content], metadatas=[i.metadata])

--- a/scripts/parser/open_ai_func.py
+++ b/scripts/parser/open_ai_func.py
@@ -32,11 +32,14 @@ def call_openai_api(docs):
             print("Saving progress")
             print(f"stopped at {c1} out of {len(docs)}")
             faiss.write_index(store.index, "docs.index")
+            store_index_bak = store.index
             store.index = None
             with open("faiss_store.pkl", "wb") as f:
                 pickle.dump(store, f)
             print("Sleeping for 10 seconds and trying again")
             time.sleep(10)
+            faiss.write_index(store_index_bak, "docs.index")
+            store.index = store_index_bak
             store.add_texts([i.page_content], metadatas=[i.metadata])
         c1 += 1
 


### PR DESCRIPTION
I don't know why there needs to be a `store.index = None`, but I got an error when continuing the process, so I restored the index before continuing;

But that's only fixed the index issue.

Another problem is there is no error catch for the `store.add_texts([i.page_content], metadatas=[i.metadata])` in the `except` block, so if 10 seconds is not enough (maybe set it to 60?), then the second error will be thrown out, and this time, no `try/except` for this one
