### PR TITLE
Update .env-template

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -1,2 +1,2 @@
-API_KEY=<LLM api key (for example, open ai key)>
+OPENAI_API_KEY=<LLM api key (for example, open ai key)>
 EMBEDDINGS_KEY=<LLM embeddings api key (for example, open ai key)>


### PR DESCRIPTION
Rename env var name to OPENAI_API_KEY.
This was needed for me to run the docker-compose (prod) setup.

Few questions:
- what about API_KEY? is it used anywhere else than inside the docker containers?
- what about EMBEDDINGS_KEY? is it needed? also see that it is used in containes (only?)