### PR TITLE
prevent this action from running on forks as it fails anyway.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   deploy:
+    if: github.repository == 'arc53/DocsGPT'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Avoid unnecessary and failing GHA build runs on forks.