### PR TITLE
revert introduction of the coverage note addition to pull requests as…

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,18 +1,12 @@
 name: Run python tests with pytest
-
 on: [push, pull_request]
-
 jobs:
   pytest_and_coverage:
     name: Run tests and count coverage
-    permissions:
-      contents: read
-      pull-requests: write
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
-
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -25,15 +19,6 @@ jobs:
           pip install pytest pytest-cov
           cd application
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      - name: Test with pytest
+      - name: Test with pytest and generate coverage report
         run: |
           python -m pytest --cov=application --cov=scripts --cov=extensions --cov-report xml:/tmp/coverage.xml
-      - name: Coverage
-        if: github.event_name == 'pull_request' && matrix.python-version == '3.11'
-        uses: orgoro/coverage@v3
-        with:
-          coverageFile: /tmp/coverage.xml
-          token: ${{ secrets.GITHUB_TOKEN }}
-          thresholdAll: 0.1
-          thresholdNew: 0.01
-          thresholdModified: 0.01


### PR DESCRIPTION
revert introduction of the coverage note addition to pull requests as it doesn't work for pull requests from public forks. see GitHub documentation: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token