### PR TITLE
Add Llama2, AI21, Aleph Alpha, Palm, Cohere, TogetherAI, Huggingface, etc. streaming

### DIFF
--- a/application/app.py
+++ b/application/app.py
@@ -171,6 +171,9 @@ def home():
         "index.html", api_key_set=api_key_set, llm_choice=settings.LLM_NAME, embeddings_choice=settings.EMBEDDINGS_NAME
     )
 
+def llm_call(model, messages, stream, max_tokens, temperature):
+    response = completion(model=model, messages=messages, stream=stream, max_tokens=max_tokens, temperature=temperature)
+    return response
 
 def complete_stream(question, docsearch, chat_history, api_key, conversation_id):
     openai.api_key = api_key
@@ -217,7 +220,7 @@ def complete_stream(question, docsearch, chat_history, api_key, conversation_id)
     messages_combine.append({"role": "user", "content": question})
     if settings.AZURE_DEPLOYMENT_NAME:
         gpt_model="azure/" + settings.AZURE_DEPLOYMENT_NAME
-    response = completion(model=gpt_model, messages=messages_combine, stream=True, max_tokens=500, temperature=0)
+    response = llm_call(model=gpt_model, messages=messages_combine, stream=True, max_tokens=500, temperature=0)
     reponse_full = ""
     for line in response:
         if "content" in line["choices"][0]["delta"]:
@@ -245,7 +248,7 @@ def complete_stream(question, docsearch, chat_history, api_key, conversation_id)
                                                         "system"}]
         if settings.AZURE_DEPLOYMENT_NAME:
             gpt_model="azure/" + settings.AZURE_DEPLOYMENT_NAME
-        response = completion(model=gpt_model, messages=messages_summary, stream=True, max_tokens=500, temperature=0)
+        response = llm_call(model=gpt_model, messages=messages_summary, stream=True, max_tokens=500, temperature=0)
         conversation_id = conversations_collection.insert_one(
             {"user": "local",
              "date": datetime.datetime.utcnow(),

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,4 @@
-from application.app import get_vectorstore
+from application.app import get_vectorstore, llm_call
 import os
 
 
@@ -26,3 +26,16 @@ def test_default_active_docs():
 def test_complex_active_docs():
     data = {"active_docs": "local/other/path"}
     assert get_vectorstore(data) == os.path.join("application", "indexes/local/other/path")
+
+def test_llm_call():
+    messages = [{"role": "user", "content": "Hey, how's it going?"}]
+    response = llm_call(model="gpt-3.5-turbo", messages=messages, stream=True, max_tokens=256, temperature=0)
+    complete_response = ""
+    for chunk in response:
+        print(chunk["choices"][0]["delta"])
+        complete_response += chunk["choices"][0]["delta"]["content"]
+    if complete_response == "": 
+        raise Exception("Empty response received")
+    assert len(complete_response) > 0
+
+test_llm_call()


### PR DESCRIPTION
Hi @larinam @dartpain.

This PR adds support for Llama2, AI21, Aleph Alpha, Palm, Cohere, TogetherAI, Huggingface inference endpoints for *streaming* using LiteLLM (https://github.com/BerriAI/litellm).

In addition, we also enable easy A/B testing of new LLM models in production: 

https://docs.litellm.ai/docs/tutorials/ab_test_llms

Happy to add additional tests / update documentation, if the initial PR looks good to you.