### PR TITLE
PR coverage with barecheck github app

### DIFF
--- a/.github/workflows/pr_coverage.yml
+++ b/.github/workflows/pr_coverage.yml
@@ -1,0 +1,67 @@
+name: Code Coverage
+
+on: [pull_request]
+
+jobs:
+  base_branch_cov:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.base_ref }}
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-cov
+          cd application
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Test with pytest and generate coverage report
+        run: |
+          python -m pytest --cov=application --cov=scripts --cov=extensions --cov-report lcov:ref-lcov.info
+
+      - name: Upload code coverage for ref branch
+        uses: actions/upload-artifact@v3
+        with:
+          name: ref-lcov.info
+          path: ./ref-lcov.info
+
+  checks:
+    runs-on: ubuntu-latest
+    needs: base_branch_cov
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Download code coverage report from base branch
+        uses: actions/download-artifact@v3
+        with:
+          name: ref-lcov.info
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-cov
+          cd application
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Test with pytest and generate coverage report
+        run: |
+          python -m pytest --cov=application --cov=scripts --cov=extensions --cov-report lcov:lcov.info
+
+      #  Compares two code coverage files and generates report as a comment
+      - name: Generate Code Coverage report
+        id: code-coverage
+        uses: barecheck/code-coverage-action@v1
+        with:
+          barecheck-github-app-token: ${{ secrets.BARECHECK_GITHUB_APP_TOKEN }}
+          lcov-file: "./lcov.info"
+          base-lcov-file: "./ref-lcov.info"
+          minimum-ratio: 0 # Fails Github action once code coverage is decreasing
+          send-summary-comment: true
+          show-annotations: "warning" # Possible options warning|error

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,5 +1,5 @@
 name: Run python tests with pytest
-on: [push, pull_request]
+on: [push]
 jobs:
   pytest_and_coverage:
     name: Run tests and count coverage
@@ -21,4 +21,4 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Test with pytest and generate coverage report
         run: |
-          python -m pytest --cov=application --cov=scripts --cov=extensions --cov-report xml:/tmp/coverage.xml
+          python -m pytest


### PR DESCRIPTION
This approach uses the GitHub application https://github.com/apps/barecheck to acquire pull-request write permissions.

To make it work, please follow the next steps:
1. Install the GitHub application https://github.com/apps/barecheck for the repository DocsGPT.
2. Write down the token that the application produces.
3. Copy the token provided on the authorization confirmation page and [add it to your build environment](https://docs.github.com/en/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository) as BARECHECK_GITHUB_APP_TOKEN. I recommend adding it **as a secret** rather than as a variable.
4. After that feel free to rerun the new GitHub action workflow.
5. Merge the PR :)

Happy to clarify or answer any questions.

The build will fail if the coverage decreases after the commit. Also, a similar comment will be added to each Pull Request:
<img width="391" alt="Screenshot 2023-09-03 at 21 34 23" src="https://github.com/arc53/DocsGPT/assets/233310/a71a3162-fbae-478b-aa5d-3a16eeda05ce">
