### PR TITLE
Update requirements.txt

### DIFF
--- a/application/requirements.txt
+++ b/application/requirements.txt
@@ -58,7 +58,7 @@ numpy==1.24.2
 openai==0.27.8
 packaging==23.0
 pathos==0.3.0
-Pillow==9.4.0
+Pillow==9.4.0 // Upgrade to pillow@10.0.1 
 pox==0.3.2
 ppft==1.7.6.6
 prompt-toolkit==3.0.38


### PR DESCRIPTION
CVE-2023-4863

Heap buffer overflow in libwebp in Google Chrome prior to 116.0.5845.187 and libwebp 1.3.2 allowed a remote attacker to perform an out of bounds memory write via a crafted HTML page. (Chromium security severity: Critical)

For more info , please refer to the link below:

https://www.cve.org/CVERecord?id=CVE-2023-4863