### PR TITLE
Add Bedrock, Ollama, Claude2, Cohere, Replicate [100+ LLMs] - using LiteLLM 

### DIFF
--- a/application/llm/openai.py
+++ b/application/llm/openai.py
@@ -4,20 +4,21 @@ from application.core.settings import settings
 class OpenAILLM(BaseLLM):
 
     def __init__(self, api_key):
-        global openai
-        import openai
-        openai.api_key = api_key
+        global litellm
+        import litellm
+
+        litellm.api_key = api_key
         self.api_key = api_key  # Save the API key to be used later
 
     def _get_openai(self):
         # Import openai when needed
-        import openai
-        # Set the API key every time you import openai
-        openai.api_key = self.api_key
-        return openai
+        import litellm
+        # Set the API key every time you import litellm
+        litellm.api_key = self.api_key
+        return litellm
 
     def gen(self, model, engine, messages, stream=False, **kwargs):
-        response = openai.ChatCompletion.create(
+        response = litellm.completion(
             model=model,
             engine=engine,
             messages=messages,
@@ -28,7 +29,7 @@ class OpenAILLM(BaseLLM):
         return response["choices"][0]["message"]["content"]
 
     def gen_stream(self, model, engine, messages, stream=True, **kwargs):
-        response = openai.ChatCompletion.create(
+        response = litellm.completion(
             model=model,
             engine=engine,
             messages=messages,
@@ -50,8 +51,8 @@ class AzureOpenAILLM(OpenAILLM):
         self.deployment_name = settings.AZURE_DEPLOYMENT_NAME,
 
     def _get_openai(self):
-        openai = super()._get_openai()
-        openai.api_base = self.api_base
-        openai.api_version = self.api_version
-        openai.api_type = "azure"
-        return openai
+        litellm = super()._get_openai()
+        litellm.api_base = self.api_base
+        litellm.api_version = self.api_version
+        litellm.api_type = "azure"
+        return litellm

--- a/application/requirements.txt
+++ b/application/requirements.txt
@@ -57,6 +57,7 @@ nltk==3.8.1
 numcodecs==0.11.0
 numpy==1.24.2
 openai==0.27.8
+litellm>=0.1.817
 packaging==23.0
 pathos==0.3.0
 Pillow==9.4.0


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Uses litellm https://github.com/BerriAI/litellm for llm completion calls 
Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```

- **Why was this change needed?** (You can also link to an open issue here)
Add support for more LLMs 
- **Other information**: