### PR TITLE
Huggingface quantisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You can find our [Roadmap](https://github.com/orgs/arc53/projects/2) here. Pleas
 | [Docsgpt-40b-falcon](https://huggingface.co/Arc53/docsgpt-40b-falcon)       | falcon-40b     | 8xA10G gpu's  |
 
 
-If you don't have enough resources to run it you can use bitsnbytes to quantize
+If you don't have enough resources to run it you can use [bitsnbytes](https://colab.research.google.com/drive/1VoYNfYDKcKRQRor98Zbf2-9VQTtGJ24k) to quantize
 
 
 ## Features


### PR DESCRIPTION

- **Documentation Update**

- **Why was this update required?**: Difficult to load model with such high parameters so needs to be loaded via bitsnbytes

- **Other information**: Added link to hugging face's official bits-n-bytes notebook for reference
