### PR TITLE
Fixed Overflowing Text messages with long strings without spaces

### DIFF
--- a/frontend/src/conversation/ConversationBubble.tsx
+++ b/frontend/src/conversation/ConversationBubble.tsx
@@ -43,7 +43,7 @@ const ConversationBubble = forwardRef<
       <div ref={ref} className={`flex flex-row-reverse self-end ${className}`}>
         <Avatar className="mt-2 text-2xl" avatar="🧑‍💻"></Avatar>
         <div className="mr-2 ml-10 flex items-center rounded-3xl bg-blue-1000 p-3.5 text-white">
-          <ReactMarkdown className="whitespace-pre-wrap break-words">
+          <ReactMarkdown className="whitespace-pre-wrap break-all">
             {message}
           </ReactMarkdown>
         </div>


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix)

- **Why was this change needed?** (You can also link to an open issue here)
#426 
- **Other information**:
- By giving a style of **"break-all"** to add line breaks whenever necessary, without trying to preserve whole words.

Before
![lonh string](https://github.com/arc53/DocsGPT/assets/113178195/f229f0b5-e39c-400b-9f5d-4f38a4301455)
After
![Fixed long](https://github.com/arc53/DocsGPT/assets/113178195/634f713c-9964-44e3-9ffa-d19312d1b4be)
