### PR TITLE
Added css attribute placeholder for search div

### DIFF
--- a/frontend/src/conversation/Conversation.tsx
+++ b/frontend/src/conversation/Conversation.tsx
@@ -149,6 +149,7 @@ export default function Conversation() {
         <div className="flex w-full">
           <div
             ref={inputRef}
+            placeholder="Type your message here..."
             contentEditable
             onPaste={handlePaste}
             className={`border-000000 overflow-x-hidden; max-h-24 min-h-[2.6rem] w-full overflow-y-auto whitespace-pre-wrap rounded-xl border bg-white py-2 pl-4 pr-9 leading-7 opacity-100 focus:outline-none`}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -358,3 +358,9 @@ template {
 [hidden] {
   display: none;
 }
+
+[contentEditable]:empty:before {
+  content: attr(placeholder);
+  color: #9ca3af;
+  opacity: 1;
+}


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR aims to add a placeholder in the search div using css attributes
- **Why was this change needed?** (You can also link to an open issue here)
#422 
- **Other information**:
The search div before changes 
![Screenshot from 2023-10-05 09-35-34](https://github.com/arc53/DocsGPT/assets/85943021/71c034c7-47f1-469d-960c-01f87b17abeb)
After changes

https://github.com/arc53/DocsGPT/assets/85943021/0c069f64-2eac-4662-b8d0-8e80e4e4abf3

