### PR TITLE
[Fix] Source selection overflow issue 

### DIFF
--- a/frontend/src/Navigation.tsx
+++ b/frontend/src/Navigation.tsx
@@ -227,11 +227,11 @@ export default function Navigation() {
         <div className="flex flex-col-reverse border-b-2">
           <div className="relative my-4 flex gap-2 px-2">
             <div
-              className="flex h-12 w-full cursor-pointer justify-between rounded-3xl rounded-md border-2 bg-white"
+              className="flex h-12 min-w-[85%] cursor-pointer justify-between rounded-3xl rounded-md border-2 bg-white"
               onClick={() => setIsDocsListOpen(!isDocsListOpen)}
             >
               {selectedDocs && (
-                <p className="my-3 mx-4">
+                <p className="my-3 mx-4 overflow-hidden text-ellipsis	whitespace-nowrap">
                   {selectedDocs.name} {selectedDocs.version}
                 </p>
               )}

--- a/frontend/src/Navigation.tsx
+++ b/frontend/src/Navigation.tsx
@@ -231,7 +231,7 @@ export default function Navigation() {
               onClick={() => setIsDocsListOpen(!isDocsListOpen)}
             >
               {selectedDocs && (
-                <p className="my-3 mx-4 overflow-hidden text-ellipsis	whitespace-nowrap">
+                <p className="my-3 mx-4 overflow-hidden text-ellipsis whitespace-nowrap">
                   {selectedDocs.name} {selectedDocs.version}
                 </p>
               )}


### PR DESCRIPTION
- **What kind of change does this PR introduce?** 
       Bug Fix- Close #452 

- **Why was this change needed?** 
      - Actually, when you select the source file from the dropdown, It affects the UI, if, the source file name is large. 

- **Other information**:
          **Before Fix:** 
![Text Overflow](https://github.com/arc53/DocsGPT/assets/79417096/9c6deb3d-bf33-4f69-bbf4-20f47a63aaf2)
          **After Fix:**
![After fix](https://github.com/arc53/DocsGPT/assets/79417096/42dc0667-4366-47e1-9f4b-183630a2835a)

              