### PR TITLE
Fix: Conversations tabs overlapping

### DIFF
--- a/frontend/src/Navigation.tsx
+++ b/frontend/src/Navigation.tsx
@@ -201,7 +201,9 @@ export default function Navigation() {
                     <div className="flex gap-4">
                       <img src={Message} className="ml-2 w-5"></img>
                       <p className="my-auto text-eerie-black">
-                        {conversation.name}
+                        {conversation.name.length > 45
+                          ? conversation.name.substring(0, 45) + '...'
+                          : conversation.name}
                       </p>
                     </div>
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixed: Tabs overlapping due to text overflow by limiting the text length.
- **Why was this change needed?** (You can also link to an open issue here)
[Tabs overlap issue](https://github.com/arc53/DocsGPT/issues/444)
- **Other information**:
- before :
![Screenshot 2023-10-06 231343](https://github.com/arc53/DocsGPT/assets/87007373/6a65dd67-f6e7-4925-b59f-1bb8dff50e5e)
-after :
![Screenshot 2023-10-06 230713](https://github.com/arc53/DocsGPT/assets/87007373/e29f31b1-b5e9-485c-b3a9-e148c246a3a1)
