### PR TITLE
Krishvsoni patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Make sure you have Python 3.10 or 3.11 installed.
 (check out [`application/core/settings.py`](application/core/settings.py) if you want to see more config options.)
 
 2. (optional) Create a Python virtual environment:
-You can follow the official Python documentation for virtual environments [here](https://docs.python.org/3/tutorial/venv.html).
+You can follow the [Python official documentation](https://docs.python.org/3/tutorial/venv.html) for virtual environments .
 
 3. Change to the `application/` subdir and install dependencies for the backend:
 ```commandline

--- a/README.md
+++ b/README.md
@@ -126,7 +126,18 @@ Make sure you have Python 3.10 or 3.11 installed.
 2. (optional) Create a Python virtual environment:
 You can follow the [Python official documentation](https://docs.python.org/3/tutorial/venv.html) for virtual environments .
 
-3. Change to the `application/` subdir and install dependencies for the backend:
+a) On Mac OS and Linux
+```commandline
+python -m venv venv
+. venv/bin/activate
+```
+b) On Windows
+```commandline
+python -m venv venv
+ venv/Scripts/activate
+```
+
+4. Change to the `application/` subdir and install dependencies for the backend:
 ```commandline
 pip install -r application/requirements.txt
 ```

--- a/README.md
+++ b/README.md
@@ -124,9 +124,15 @@ Make sure you have Python 3.10 or 3.11 installed.
 (check out [`application/core/settings.py`](application/core/settings.py) if you want to see more config options.)
 
 2. (optional) Create a Python virtual environment:
+ On Mac OS or Linux 
 ```commandline
 python -m venv venv
 . venv/bin/activate
+```
+On Windows
+```commandline
+python -m venv venv
+venv/Scripts/activate
 ```
 3. Change to the `application/` subdir and install dependencies for the backend:
 ```commandline

--- a/README.md
+++ b/README.md
@@ -126,17 +126,6 @@ Make sure you have Python 3.10 or 3.11 installed.
 2. (optional) Create a Python virtual environment:
 You can follow the official Python documentation for virtual environments [here](https://docs.python.org/3/tutorial/venv.html).
 
-On Mac OS or Linux 
-```commandline
-python -m venv venv
-. venv/bin/activate
-```
-On Windows
-```commandline
-python -m venv venv
-venv/Scripts/activate
-```
-
 3. Change to the `application/` subdir and install dependencies for the backend:
 ```commandline
 pip install -r application/requirements.txt

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Make sure you have Python 3.10 or 3.11 installed.
 (check out [`application/core/settings.py`](application/core/settings.py) if you want to see more config options.)
 
 2. (optional) Create a Python virtual environment:
+You can follow the official Python documentation for virtual environments [here](https://docs.python.org/3/tutorial/venv.html).
 
 On Mac OS or Linux 
 ```commandline
@@ -135,6 +136,7 @@ On Windows
 python -m venv venv
 venv/Scripts/activate
 ```
+
 3. Change to the `application/` subdir and install dependencies for the backend:
 ```commandline
 pip install -r application/requirements.txt

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ Make sure you have Python 3.10 or 3.11 installed.
 (check out [`application/core/settings.py`](application/core/settings.py) if you want to see more config options.)
 
 2. (optional) Create a Python virtual environment:
- On Mac OS or Linux 
+
+On Mac OS or Linux 
 ```commandline
 python -m venv venv
 . venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ python -m venv venv
  venv/Scripts/activate
 ```
 
-4. Change to the `application/` subdir and install dependencies for the backend:
+3. Change to the `application/` subdir and install dependencies for the backend:
 ```commandline
 pip install -r application/requirements.txt
 ```


### PR DESCRIPTION
- **What kind of change does this PR introduce?**   -  Docs Update

- **Why was this change needed?** - Adding both activation commands (venv/Scripts/activate and . venv/bin/activate) is necessary to accommodate users on different operating systems (Windows, Unix-based) and provide clear, error-free instructions in the Readme markdown file.

- **Other information**:
I initially attempted to use the default command . venv/bin/activate, but it didn't work for me. This prompted me to include the alternative venv/Scripts/activate command in the README for Windows users like me.