### PR TITLE
Fix: adjust left margin on content container

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,7 +19,7 @@ export default function App() {
         className={`transition-all duration-200 ${
           !isMobile
             ? `ml-0 ${
-                !navOpen ? '-mt-5 md:mx-auto lg:mx-auto' : 'md:ml-72 lg:ml-60'
+                !navOpen ? '-mt-5 md:mx-auto lg:mx-auto' : 'md:ml-72'
               }`
             : 'ml-0 md:ml-16'
         }`}


### PR DESCRIPTION
- **What kind of change does this PR introduce?**

This very small PR fixes a bug for the wrong left margin on the content container which was not in line with the sidebar width.

- **Why was this change needed?**

Part of the content was hidden behind the sidebar on certain viewport sizes.

| Before | After |
|--------|-------|
|![docsgpt arc53 com](https://github.com/arc53/DocsGPT/assets/15653065/7547dedb-ba82-423f-b97f-2e3cc8704d2f) | ![docsgpt arc53 com (1)](https://github.com/arc53/DocsGPT/assets/15653065/a7b570bb-2fe4-466b-806f-c7c7b528b413) |