### PR TITLE
Train button Disabled Before Selecting File

### DIFF
--- a/frontend/src/upload/Upload.tsx
+++ b/frontend/src/upload/Upload.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { useDispatch } from 'react-redux';
@@ -55,9 +55,8 @@ export default function Upload({
             setProgress(undefined);
             setModalState('INACTIVE');
           }}
-          className={`rounded-3xl bg-purple-30 px-4 py-2 text-sm font-medium text-white ${
-            isCancellable ? '' : 'hidden'
-          }`}
+          className={`rounded-3xl bg-purple-30 px-4 py-2 text-sm font-medium text-white ${isCancellable ? '' : 'hidden'
+            }`}
         >
           Finish
         </button>
@@ -189,6 +188,7 @@ export default function Upload({
           <span className="bg-white px-2 text-xs text-gray-4000">Name</span>
         </div>
         <div {...getRootProps()}>
+          <span className="text-red-500">*  </span>
           <span className="rounded-3xl border border-purple-30 px-4 py-2 font-medium text-purple-30 hover:cursor-pointer">
             <input type="button" {...getInputProps()} />
             Choose Files
@@ -206,7 +206,9 @@ export default function Upload({
         <div className="flex flex-row-reverse">
           <button
             onClick={uploadFile}
-            className="ml-6 rounded-3xl bg-purple-30 py-2 px-6 text-white"
+            className={`ml-6 rounded-3xl ${files.length > 0 ? 'bg-purple-30 text-white' : 'bg-gray-500'
+              } py-2 px-6`}
+            disabled={files.length === 0}  // Disable the button if no file is selected
           >
             Train
           </button>
@@ -227,9 +229,8 @@ export default function Upload({
 
   return (
     <article
-      className={`${
-        modalState === 'ACTIVE' ? 'visible' : 'hidden'
-      } absolute z-30  h-screen w-screen  bg-gray-alpha`}
+      className={`${modalState === 'ACTIVE' ? 'visible' : 'hidden'
+        } absolute z-30  h-screen w-screen  bg-gray-alpha`}
     >
       <article className="mx-auto mt-24 flex w-[90vw] max-w-lg  flex-col gap-4 rounded-lg bg-white p-6 shadow-lg">
         {view}

--- a/frontend/src/upload/Upload.tsx
+++ b/frontend/src/upload/Upload.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { useDispatch } from 'react-redux';

--- a/frontend/src/upload/Upload.tsx
+++ b/frontend/src/upload/Upload.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { useDispatch } from 'react-redux';
@@ -188,7 +188,6 @@ export default function Upload({
           <span className="bg-white px-2 text-xs text-gray-4000">Name</span>
         </div>
         <div {...getRootProps()}>
-          <span className="text-red-500">*  </span>
           <span className="rounded-3xl border border-purple-30 px-4 py-2 font-medium text-purple-30 hover:cursor-pointer">
             <input type="button" {...getInputProps()} />
             Choose Files
@@ -206,7 +205,7 @@ export default function Upload({
         <div className="flex flex-row-reverse">
           <button
             onClick={uploadFile}
-            className={`ml-6 rounded-3xl ${files.length > 0 ? 'bg-purple-30 text-white' : 'bg-gray-500'
+            className={`ml-6 rounded-3xl bg-purple-30 text-white ${files.length > 0 ? '' : 'bg-opacity-75 text-opacity-80'
               } py-2 px-6`}
             disabled={files.length === 0}  // Disable the button if no file is selected
           >


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- It solved issue #539 

- Before File Selection:

<img width="380" alt="before" src="https://github.com/arc53/DocsGPT/assets/116418856/cff287d8-ea58-4cdd-8bf0-e618c2ba4d54">

I introduced two changes in it i added a red asterisk denoting user must choose file in order to enable train button as no file is selected above it's disabled above


After File Selection:

<img width="960" alt="after" src="https://github.com/arc53/DocsGPT/assets/116418856/079b4de3-c7b3-4835-83c4-0884de54a6a0">

After selecting some file the Train button will be enabled and pointer will be cursor on it 

- **Why was this change needed?** (You can also link to an open issue here)
This change is needed because if a user trains without giving any file then the website is staying idle in uploading state 
- **Other information**: