### PR TITLE
Support Anthropic, Palm, Huggingface, Ollama, TogetherAI, Replicate, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,29 @@ npm install vite -g
 3. Install dependencies by running `npm install --include=dev`.
 4. Run the app using `npm run dev`.
 
+# Use Anthropic,Huggingface,Palm,Ollama, etc.[Full List](https://docs.litellm.ai/docs/providers)
+
+## Create OpenAI-proxy
+We'll use [LiteLLM](https://docs.litellm.ai/docs/) to create an OpenAI-compatible endpoint, that translates OpenAI calls to any of the [supported providers](https://docs.litellm.ai/docs/providers).
+
+```python
+pip install litellm
+```
+```python
+$ litellm --model ollama/codellama
+
+#INFO: Ollama running on http://0.0.0.0:8000
+```
+
+[Docs](https://docs.litellm.ai/docs/proxy_server)
+
+## Update DocsGPT
+In your .env set the openai endpoint to your local server. 
+
+```
+OPENAI_ENDPOINT=http://0.0.0.0:8000
+OPENAI_API_KEY=my-fake-key
+```
 
 ## Contributing
 Please refer to the [CONTRIBUTING.md](CONTRIBUTING.md) file for information about how to get involved. We welcome issues, questions, and pull requests. 


### PR DESCRIPTION
Hey @larinam @dartpain, 

Following @dartpain's feedback on this PR - https://github.com/arc53/DocsGPT/pull/394. 

I thought it might be easier if we just let the user use our cli tool to switch models without needing to make code changes to DocsGPT.

My PR shows users how to call their LLM providers (bedrock, togetherai, huggingface tgi, replicate, ai21, cohere, ai21 etc.) by pointing your openai base to a [local proxy](https://docs.litellm.ai/docs/proxy_server) they can use for experimentation.

Here's the suggested update to the ReadMe: 

# Use Anthropic,Huggingface,Palm,Ollama, etc.[Full List](https://docs.litellm.ai/docs/providers)

## Create OpenAI-proxy
We'll use [LiteLLM](https://docs.litellm.ai/docs/) to create an OpenAI-compatible endpoint, that translates OpenAI calls to any of the [supported providers](https://docs.litellm.ai/docs/providers).

```python
pip install litellm
```
```python
$ litellm --model ollama/codellama

#INFO: Ollama running on http://0.0.0.0:8000
```

[Docs](https://docs.litellm.ai/docs/proxy_server)

## Update DocsGPT
In your .env set the openai endpoint to your local server. 

```
OPENAI_ENDPOINT=http://0.0.0.0:8000
OPENAI_API_KEY=my-fake-key
```