### PR TITLE
raise more legible error if the word embedding dimensions don't match

### DIFF
--- a/application/requirements.txt
+++ b/application/requirements.txt
@@ -104,3 +104,4 @@ urllib3==1.26.17
 vine==5.0.0
 wcwidth==0.2.6
 yarl==1.8.2
+sentence-transformers==2.2.2

--- a/application/vectorstore/faiss.py
+++ b/application/vectorstore/faiss.py
@@ -1,5 +1,5 @@
-from application.vectorstore.base import BaseVectorStore
 from langchain.vectorstores import FAISS
+from application.vectorstore.base import BaseVectorStore
 from application.core.settings import settings
 
 class FaissStore(BaseVectorStore):
@@ -23,11 +23,11 @@ class FaissStore(BaseVectorStore):
 
     def add_texts(self, *args, **kwargs):
         return self.docsearch.add_texts(*args, **kwargs)
-    
+
     def save_local(self, *args, **kwargs):
         return self.docsearch.save_local(*args, **kwargs)
 
-    def assert_embedding_dimensions(self, embeddings, *args, **kwargs):
+    def assert_embedding_dimensions(self, embeddings):
         """
         Check that the word embedding dimension of the docsearch index matches
         the dimension of the word embeddings used 

--- a/application/vectorstore/faiss.py
+++ b/application/vectorstore/faiss.py
@@ -2,31 +2,21 @@ from application.vectorstore.base import BaseVectorStore
 from langchain.vectorstores import FAISS
 from application.core.settings import settings
 
-HUGGINGFACE_MODEL_NAME = "huggingface_sentence-transformers/all-mpnet-base-v2"
 class FaissStore(BaseVectorStore):
 
     def __init__(self, path, embeddings_key, docs_init=None):
         super().__init__()
         self.path = path
+        embeddings = self._get_embeddings(settings.EMBEDDINGS_NAME, embeddings_key)
         if docs_init:
             self.docsearch = FAISS.from_documents(
-                docs_init, self._get_embeddings(settings.EMBEDDINGS_NAME, embeddings_key)
+                docs_init, embeddings 
             )
         else:
-            embeddings = self._get_embeddings(settings.EMBEDDINGS_NAME, embeddings_key)
             self.docsearch = FAISS.load_local(
                 self.path, embeddings
             )
-            
-            # Check that the word_embedding_dimension of the index matches 
-            # the word_embedding_dimension of the embeddings
-            if settings.EMBEDDINGS_NAME == HUGGINGFACE_MODEL_NAME:
-                try:
-                    word_embedding_dimension = embeddings.client[1].word_embedding_dimension
-                except AttributeError as e:
-                    raise AttributeError("word_embedding_dimension not found in embeddings.client[1]") from e
-                if word_embedding_dimension != self.docsearch.index.d:
-                    raise ValueError("word_embedding_dimension != docsearch_index_word_embedding_dimension")
+        self.assert_embedding_dimensions(embeddings)
 
     def search(self, *args, **kwargs):
         return self.docsearch.similarity_search(*args, **kwargs)
@@ -36,3 +26,19 @@ class FaissStore(BaseVectorStore):
     
     def save_local(self, *args, **kwargs):
         return self.docsearch.save_local(*args, **kwargs)
+
+    def assert_embedding_dimensions(self, embeddings, *args, **kwargs):
+        """
+        Check that the word embedding dimension of the docsearch index matches
+        the dimension of the word embeddings used 
+        """
+        if settings.EMBEDDINGS_NAME == "huggingface_sentence-transformers/all-mpnet-base-v2":
+            try:
+                word_embedding_dimension = embeddings.client[1].word_embedding_dimension
+            except AttributeError as e:
+                raise AttributeError("word_embedding_dimension not found in embeddings.client[1]") from e
+            docsearch_index_dimension = self.docsearch.index.d
+            if word_embedding_dimension != docsearch_index_dimension:
+                raise ValueError(f"word_embedding_dimension ({word_embedding_dimension}) " +
+                                 f"!= docsearch_index_word_embedding_dimension ({docsearch_index_dimension})")
+

--- a/application/vectorstore/faiss.py
+++ b/application/vectorstore/faiss.py
@@ -18,7 +18,8 @@ class FaissStore(BaseVectorStore):
                 self.path, embeddings
             )
             
-            # Check that the word_embedding_dimension of the index matches the word_embedding_dimension of the embeddings
+            # Check that the word_embedding_dimension of the index matches 
+            # the word_embedding_dimension of the embeddings
             if settings.EMBEDDINGS_NAME == HUGGINGFACE_MODEL_NAME:
                 try:
                     word_embedding_dimension = embeddings.client[1].word_embedding_dimension

--- a/application/vectorstore/faiss.py
+++ b/application/vectorstore/faiss.py
@@ -10,7 +10,7 @@ class FaissStore(BaseVectorStore):
         embeddings = self._get_embeddings(settings.EMBEDDINGS_NAME, embeddings_key)
         if docs_init:
             self.docsearch = FAISS.from_documents(
-                docs_init, embeddings 
+                docs_init, embeddings
             )
         else:
             self.docsearch = FAISS.load_local(

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,6 +1,4 @@
 import pytest
-from flask import Flask
-from application.error import bad_request, response_error
 from application.vectorstore.faiss import FaissStore
 from application.core.settings import settings
 

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,0 +1,16 @@
+import pytest
+from flask import Flask
+from application.error import bad_request, response_error
+from application.vectorstore.faiss import FaissStore
+from application.core.settings import settings
+
+def test_init_local_faiss_store_huggingface():
+    """
+    Test that asserts that trying to initialize a FaissStore with
+    the huggingface sentence transformer below together with the
+    index.faiss file in the application/ folder results in a
+    dimension mismatch error.
+    """
+    settings.EMBEDDINGS_NAME = "huggingface_sentence-transformers/all-mpnet-base-v2"
+    with pytest.raises(ValueError):
+        FaissStore("application/", "", None)

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,3 +1,8 @@
+"""
+Tests regarding the vector store class, including checking
+compatibility between different transformers and local vector
+stores (index.faiss)
+"""
 import pytest
 from application.vectorstore.faiss import FaissStore
 from application.core.settings import settings


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
I want this PR to address this issue: https://github.com/arc53/DocsGPT/issues/550 and raise a more legible error if the embeddings have a different length of `word_embedding_dimension` than the `docsearch.index` dimension.

- **Why was this change needed?** (You can also link to an open issue here)
It's needed because not checking the different vector embedding lengths can lead to unexpected and unwanted behaviour.

- **Other information**:
The initial solution I have for this is pretty ugly so I welcome a discussion in order to find the best solution and hopefully fix the more general problem of word embedding dimension checking for all models.