### PR TITLE
fix: Remove extra spaces in response

### DIFF
--- a/frontend/src/conversation/Conversation.tsx
+++ b/frontend/src/conversation/Conversation.tsx
@@ -95,13 +95,12 @@ export default function Conversation() {
         ></ConversationBubble>
       );
     } else if (query.response) {
-      const trimmedResponse = query.response.trim();
       responseView = (
         <ConversationBubble
           ref={endMessageRef}
           className={`${index === queries.length - 1 ? 'mb-32' : 'mb-7'}`}
           key={`${index}ANSWER`}
-          message={trimmedResponse.length > 0 ? trimmedResponse : 'No answer found.'}
+          message={query.response}
           type={'ANSWER'}
           sources={query.sources}
           feedback={query.feedback}

--- a/frontend/src/conversation/Conversation.tsx
+++ b/frontend/src/conversation/Conversation.tsx
@@ -101,7 +101,7 @@ export default function Conversation() {
           ref={endMessageRef}
           className={`${index === queries.length - 1 ? 'mb-32' : 'mb-7'}`}
           key={`${index}ANSWER`}
-          message={trimmedResponse.length > 0 ? trimmedResponse : 'No answer found.x'}
+          message={trimmedResponse.length > 0 ? trimmedResponse : 'No answer found.'}
           type={'ANSWER'}
           sources={query.sources}
           feedback={query.feedback}

--- a/frontend/src/conversation/Conversation.tsx
+++ b/frontend/src/conversation/Conversation.tsx
@@ -95,12 +95,13 @@ export default function Conversation() {
         ></ConversationBubble>
       );
     } else if (query.response) {
+      const trimmedResponse = query.response.trim();
       responseView = (
         <ConversationBubble
           ref={endMessageRef}
           className={`${index === queries.length - 1 ? 'mb-32' : 'mb-7'}`}
           key={`${index}ANSWER`}
-          message={query.response}
+          message={trimmedResponse.length > 0 ? trimmedResponse : 'No answer found.x'}
           type={'ANSWER'}
           sources={query.sources}
           feedback={query.feedback}

--- a/frontend/src/conversation/ConversationBubble.tsx
+++ b/frontend/src/conversation/ConversationBubble.tsx
@@ -74,7 +74,7 @@ const ConversationBubble = forwardRef<
         <div className="flex self-start">
           <Avatar className="mt-2 text-2xl" avatar="🦖"></Avatar>
           <div
-            className={`ml-2 mr-5 flex flex-col items-center rounded-3xl bg-gray-1000 p-3.5 ${
+            className={`ml-2 mr-5 flex flex-col rounded-3xl bg-gray-1000 p-3.5 ${
               type === 'ERROR'
                 ? 'flex-row rounded-full border border-transparent bg-[#FFE7E7] p-2 py-5 text-sm font-normal text-red-3000  dark:border-red-2000 dark:text-white'
                 : 'flex-col rounded-3xl'

--- a/frontend/src/conversation/ConversationBubble.tsx
+++ b/frontend/src/conversation/ConversationBubble.tsx
@@ -118,7 +118,7 @@ const ConversationBubble = forwardRef<
               <>
                 <span className="mt-3 h-px w-full bg-[#DEDEDE]"></span>
                 <div className="mt-3 flex w-full flex-row flex-wrap items-center justify-start gap-2">
-                  <div className="py-1 px-2 text-base font-semibold">
+                  <div className="py-1 text-base font-semibold">
                     Sources:
                   </div>
                   <div className="flex flex-row flex-wrap items-center justify-start gap-2">


### PR DESCRIPTION
## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
-  **Bug Fix**


## **Why was this change needed?** (You can also link to an open issue here)
- Issue: #533 
- Remove the extra (leading) spaces from the response



## **Other information**:

### Changes made:
- Added ```const trimmedResponse = query.response.trim();``` to trim the response
- Return the trimmed response if ```trimmedResponse.length > 0```, else ```No answer found.```

<br>

### Files changed:
- **Conversation.tsx** (frontend/src/conversation/Conversation.tsx)

<br>

### Total changes: 2