### PR TITLE
Fix(frontend):  fix Navigation component z-index for small devices

### DIFF
--- a/frontend/src/Navigation.tsx
+++ b/frontend/src/Navigation.tsx
@@ -362,7 +362,7 @@ export default function Navigation({ navOpen, setNavOpen }: NavigationProps) {
           </a>
         </div>
       </div>
-      <div className="fixed h-16 w-full border-b-2 bg-gray-50 md:hidden">
+      <div className="fixed z-10 h-16 w-full border-b-2 bg-gray-50 md:hidden">
         <button
           className="mt-5 ml-6 h-6 w-6 md:hidden"
           onClick={() => setNavOpen(true)}

--- a/frontend/src/conversation/ConversationBubble.tsx
+++ b/frontend/src/conversation/ConversationBubble.tsx
@@ -118,9 +118,7 @@ const ConversationBubble = forwardRef<
               <>
                 <span className="mt-3 h-px w-full bg-[#DEDEDE]"></span>
                 <div className="mt-3 flex w-full flex-row flex-wrap items-center justify-start gap-2">
-                  <div className="py-1 text-base font-semibold">
-                    Sources:
-                  </div>
+                  <div className="py-1 text-base font-semibold">Sources:</div>
                   <div className="flex flex-row flex-wrap items-center justify-start gap-2">
                     {sources?.map((source, index) => (
                       <div

--- a/frontend/src/upload/Upload.tsx
+++ b/frontend/src/upload/Upload.tsx
@@ -55,8 +55,9 @@ export default function Upload({
             setProgress(undefined);
             setModalState('INACTIVE');
           }}
-          className={`rounded-3xl bg-purple-30 px-4 py-2 text-sm font-medium text-white ${isCancellable ? '' : 'hidden'
-            }`}
+          className={`rounded-3xl bg-purple-30 px-4 py-2 text-sm font-medium text-white ${
+            isCancellable ? '' : 'hidden'
+          }`}
         >
           Finish
         </button>
@@ -205,9 +206,10 @@ export default function Upload({
         <div className="flex flex-row-reverse">
           <button
             onClick={uploadFile}
-            className={`ml-6 rounded-3xl bg-purple-30 text-white ${files.length > 0 ? '' : 'bg-opacity-75 text-opacity-80'
-              } py-2 px-6`}
-            disabled={files.length === 0}  // Disable the button if no file is selected
+            className={`ml-6 rounded-3xl bg-purple-30 text-white ${
+              files.length > 0 ? '' : 'bg-opacity-75 text-opacity-80'
+            } py-2 px-6`}
+            disabled={files.length === 0} // Disable the button if no file is selected
           >
             Train
           </button>
@@ -228,8 +230,9 @@ export default function Upload({
 
   return (
     <article
-      className={`${modalState === 'ACTIVE' ? 'visible' : 'hidden'
-        } absolute z-30  h-screen w-screen  bg-gray-alpha`}
+      className={`${
+        modalState === 'ACTIVE' ? 'visible' : 'hidden'
+      } absolute z-30  h-screen w-screen  bg-gray-alpha`}
     >
       <article className="mx-auto mt-24 flex w-[90vw] max-w-lg  flex-col gap-4 rounded-lg bg-white p-6 shadow-lg">
         {view}


### PR DESCRIPTION
This PR fixes #618 

Changes the `frontend/src/Navigation.tsx` component's `z-index`. 

This was needed because the content that should be below the header was flowing over it in small screens. See below:

![image](https://github.com/arc53/DocsGPT/assets/88842947/42eb01b0-451b-4fac-81b4-396dec652b6a)
