### PR TITLE
[Bug]:About section not Aligned.

### DIFF
--- a/frontend/src/About.tsx
+++ b/frontend/src/About.tsx
@@ -4,7 +4,7 @@
 export default function About() {
   return (
     <div className="mx-5 grid min-h-screen md:mx-36">
-      <article className="place-items-left mx-auto my-auto mt-20 flex w-full max-w-6xl flex-col gap-6 rounded-3xl bg-gray-100 p-6 text-jet lg:p-10 xl:p-16">
+      <article className="place-items-left mx-auto my-auto my-10 mt-20 flex w-full max-w-6xl flex-col gap-6 rounded-3xl bg-gray-100 p-6 text-jet lg:p-10 xl:p-16">
         <div className="flex items-center">
           <p className="mr-2 text-3xl">About DocsGPT</p>
           <p className="text-[21px]">🦖</p>


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix - The about-section was not properly aligned in the center on the About page.

- **Why was this change needed?** (You can also link to an open issue here)
- [x] fixes #645 

- **Other information**:
![image](https://github.com/arc53/DocsGPT/assets/74039834/14b4c2b4-cd93-4367-a58b-edcdf6bb394b)
