### PR TITLE
Enhance backdrop modal effect

### DIFF
--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -12,7 +12,7 @@ module.exports = {
         'eerie-black': '#212121',
         'black-1000': '#343541',
         jet: '#343541',
-        'gray-alpha': 'rgba(0,0,0, .1)',
+        'gray-alpha': 'rgba(0,0,0, .64)',
         'gray-1000': '#F6F6F6',
         'gray-2000': 'rgba(0, 0, 0, 0.5)',
         'gray-3000': 'rgba(243, 243, 243, 1)',


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
**Enhancing**, backdrop color effect in when _trigger upload new document modal_ and _trigger upgrade modal_ both using tailwind utility class named `gray-alpha` enhanced the opacity from `.1` to `.64`
- **Why was this change needed?** (You can also link to an open issue here)
**Design Consistency**, refer to when _trigger sign up or sign in modal_ their backdrop color is darker than other modals (the difference is in the opacity value)
- **Other information**: