### PR TITLE
I have aligned about page in the center.

### DIFF
--- a/frontend/src/About.tsx
+++ b/frontend/src/About.tsx
@@ -4,7 +4,7 @@
 export default function About() {
   return (
     <div className="mx-5 grid min-h-screen md:mx-36">
-      <article className="place-items-left mx-auto my-auto mt-20 flex w-full max-w-6xl flex-col gap-6 rounded-3xl bg-gray-100 p-6 text-jet lg:p-10 xl:p-16">
+      <article className="place-items-left mx-auto my-auto flex w-full max-w-6xl flex-col gap-4 rounded-3xl bg-gray-100 p-6 text-jet lg:p-6 xl:p-10">
         <div className="flex items-center">
           <p className="mr-2 text-3xl">About DocsGPT</p>
           <p className="text-[21px]">🦖</p>
@@ -54,7 +54,7 @@ export default function About() {
           Currently It uses{' '}
           <span className="text-blue-950 font-medium">DocsGPT</span>{' '}
           documentation, so it will respond to information relevant to{' '}
-          <span className="text-blue-950 font-medium">DocsGPT</span> . If you
+          <span className="text-blue-950 font-medium">DocsGPT</span>. If you
           want to train it on different documentation - please follow
           <a
             className="text-blue-500"


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  Bug Fixed : I have aligned about-section (on the about page) in the center as per Figma design.
- **Why was this change needed?** (You can also link to an open issue here)
 Fixed an bug #645
- **It is properly aligned in the center, as shown below**:

![aboutPage](https://github.com/arc53/DocsGPT/assets/146843890/cc0e02e2-93cb-43d2-aa6b-d770a64021ab)
