### PR TITLE
Added link to OpenAI API key page

### DIFF
--- a/frontend/src/preferences/APIKeyModal.tsx
+++ b/frontend/src/preferences/APIKeyModal.tsx
@@ -64,7 +64,16 @@ export default function APIKeyModal({
             <p className="text-md leading-6 text-gray-500">
               Before you can start using DocsGPT we need you to provide an API
               key for llm. Currently, we support only OpenAI but soon many more.
-              You can find it here.
+              You can find it{' '}
+              <a
+                href="https://platform.openai.com/account/api-keys"
+                target="_blank"
+                className="underline"
+                rel="noreferrer"
+              >
+                here
+              </a>
+              .
             </p>
             <input
               type="text"


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Added link to the OpenAI API page in the 'APIKeyModal' 
- **Why was this change needed?** (You can also link to an open issue here)
Makes it easy for the users to get their OpenAI API key to be used to start conversation with the DocsGPT
- **Other information**:

Before the update (Screenshot):
![before-update](https://github.com/arc53/DocsGPT/assets/58381512/e232ddcf-89be-4a0d-95fb-4f34087df295)

After the update (Screenshot):
![after-update](https://github.com/arc53/DocsGPT/assets/58381512/91ba35e8-81e2-4844-84d2-bcbbfcb20bba)

Page Linked (Screenshot):
![openai-api-key-page](https://github.com/arc53/DocsGPT/assets/58381512/567b8587-075c-469e-aac1-a97384943d4e)
