### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ We as members, contributors, and leaders, pledge to make participation in our co
 
 ## Many Thanks To Our Contributors
 
-<a href="[https://github.com/arc53/DocsGPT/graphs/contributors](https://docsgpt.arc53.com/)" alt="View Contributors">
+<a href="https://github.com/arc53/DocsGPT/graphs/contributors" alt="View Contributors">
   <img src="https://contrib.rocks/image?repo=arc53/DocsGPT" alt="Contributors" />
 </a>
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- - This PR introduces a fix for the incorrect redirection of the contributors' link in the README.md file.

- **Why was this change needed?** (You can also link to an open issue here)
- - The current link redirects to a static image instead of directly pointing to the GitHub contributors list. This change is needed to ensure a proper redirection to the contributors list.

- **Other information**: 
- - No environment variables were used for this issue.