### PR TITLE
docs: Typo in quickstart guide fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ It will install all the dependencies and allow you to download the local model o
 Otherwise, refer to this Guide:
 
 1. Download and open this repository with `git clone https://github.com/arc53/DocsGPT.git`
-2. Create a `.env` file in your root directory and set the env variable `OPENAI_API_KEY` with your [OpenAI API key](https://platform.openai.com/account/api-keys) and `VITE_API_STREAMING` to true or false, depending on whether you want streaming answers or not.
+2. Create a `.env` file in your root directory and set the env variable `API_KEY` with your [OpenAI API key](https://platform.openai.com/account/api-keys) and `VITE_API_STREAMING` to true or false, depending on whether you want streaming answers or not.
    It should look like this inside:
 
    ```


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes a typo in the Quickstart Guide.

- **Why was this change needed?** (You can also link to an open issue here)
OPENAI_API_KEY wouldn't help the application start instead naming the variable API_KEY works.

- **Other information**: