### PR TITLE
feat: made color accessible

### DIFF
--- a/frontend/src/conversation/Conversation.tsx
+++ b/frontend/src/conversation/Conversation.tsx
@@ -192,7 +192,7 @@ export default function Conversation() {
             </div>
           )}
         </div>
-        <p className="w-[100vw] self-center bg-white p-5 text-center text-xs text-gray-727272 md:w-full">
+        <p className="w-[100vw] self-center bg-white p-5 text-center text-xs text-gray-595959 md:w-full">
           This is a chatbot that uses the GPT-3, Faiss and LangChain to answer
           questions.
         </p>

--- a/frontend/src/conversation/Conversation.tsx
+++ b/frontend/src/conversation/Conversation.tsx
@@ -192,7 +192,7 @@ export default function Conversation() {
             </div>
           )}
         </div>
-        <p className="w-[100vw] self-center bg-white p-5 text-center text-xs text-gray-2000 md:w-full">
+        <p className="w-[100vw] self-center bg-white p-5 text-center text-xs text-gray-727272 md:w-full">
           This is a chatbot that uses the GPT-3, Faiss and LangChain to answer
           questions.
         </p>


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
In this PR, I make the the background color accessible based on the following advice from the Accessible Insights website:
Fix the following:

- Element has insufficient color contrast of 3.94 (foreground color: #808080, background color: #ffffff, font size: 9.0pt (12px), font weight: normal). Expected contrast ratio of 4.5:1Element has insufficient color contrast of 3.94 (foreground color: #808080, background color: #ffffff, font size: 9.0pt (12px), font weight: normal). Expected contrast ratio of 4.5:1
- Use foreground color: #727272 and the original background color: #ffffff to meet a contrast ratio of 4.81:1.

- **Why was this change needed?** (You can also link to an open issue here)
This change would make it easier for users with low-vision to view the site.
Closes #701 
- **Other information**:
I would like to count this PR towards Hacktoberfest