### PR TITLE
Add "Scroll to Top" in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<div id="top"></div>
 <h1 align="center">
   DocsGPT  🦖
 </h1>
@@ -185,3 +186,5 @@ We as members, contributors, and leaders, pledge to make participation in our co
 The source code license is [MIT](https://opensource.org/license/mit/), as described in the [LICENSE](LICENSE) file.
 
 Built with [🦜️🔗 LangChain](https://github.com/hwchase17/langchain)
+
+<p align="right">(<a href="#top">🔼 Back to top</a>)</p>


### PR DESCRIPTION
Added "Back to Top" button in the Readme.md file.

***Description***
As the readme.md is very huge and log this button will help the users to scroll to top in just one click .

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

- **Why was this change needed?** (You can also link to an open issue here)
As the Readme was huge and after reading the entire file ,we need to scroll the screen manually to reach the top.So this button will help to do the same in just one click
