### PR TITLE
Fixed branch name from `master` to `main` in the contributing guide.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ Here's a step-by-step guide on how to contribute to DocsGPT:
    - Before you make any changes, make sure that your fork is in sync to avoid merge conflicts using:
      ```shell
      git remote add upstream https://github.com/arc53/DocsGPT.git
-     git pull upstream master
+     git pull upstream main
      ```
 
 4. **Create and Switch to a New Branch:**


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Documentation update/fix.

- **Why was this change needed?** (You can also link to an open issue here)
I see that `DocsGPT` is using `main` as it's primary branch and not `master` but in the `CONTRIBUTING` guide you are mentioning:
```
git pull upstream master
```
So, it should be changed to the following for better clarity.
```
git pull upstream main
```

- **Other information**: