### PR TITLE
Fixed wrong closing parenthesis in `codecov.yml`

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,2 @@
 ignore:
-  - "*/tests/*”
+  - "*/tests/*"


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, …)
Fixed wrong closing parenthesis in `codecov.yml`

- **Why was this change needed?** (You can also link to an open issue here)
The `codecov.yml` file will not work as intended because the closing parenthesis are wrong.

- **Other information**: