### PR TITLE
Change `model` parameter to `deployment` with OpenAIEmbeddings for Azure

### DIFF
--- a/application/vectorstore/base.py
+++ b/application/vectorstore/base.py
@@ -34,7 +34,7 @@ class BaseVectorStore(ABC):
             if self.is_azure_configured():
                 os.environ["OPENAI_API_TYPE"] = "azure"
                 embedding_instance = embeddings_factory[embeddings_name](
-                    model=settings.AZURE_EMBEDDINGS_DEPLOYMENT_NAME
+                    deployment=settings.AZURE_EMBEDDINGS_DEPLOYMENT_NAME
                 )
             else:
                 embedding_instance = embeddings_factory[embeddings_name](


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This fixes a bug I encountered when using DocsGPT with Azure endpoints and their embeddings.

- **Why was this change needed?** (You can also link to an open issue here)
As DocsGPT is still using an older version of langchain (0.0.312), which does not have the AzureOpenAIEmbeddings class, we need to change the parameter name from `model` to `deployment` to consume the right Azure endpoint.

- **Other information**: