### PR TITLE
Fix_hero

### DIFF
--- a/frontend/src/Hero.tsx
+++ b/frontend/src/Hero.tsx
@@ -36,14 +36,14 @@ export default function Hero({ className = '' }: { className?: string }) {
       <div
         className={`sections ${
           isMobile ? '' : 'mt-1'
-        } flex flex-wrap items-center justify-center gap-2 sm:gap-1 md:gap-0`}
+        } flex flex-wrap items-center justify-center gap-2 lg:gap-1 xl:gap-0`}
       >
         {/* first */}
-        <div className=" rounded-[50px] bg-gradient-to-l from-[#6EE7B7]/70 via-[#3B82F6] to-[#9333EA]/50 p-1  md:rounded-tr-none md:rounded-br-none">
+        <div className=" rounded-[50px] bg-gradient-to-l from-[#6EE7B7]/70 via-[#3B82F6] to-[#9333EA]/50 p-1  xl:rounded-tr-none xl:rounded-br-none">
           <div
             className={`h-full rounded-[45px] bg-white p-${
-              isMobile ? '3.5' : '6 py-8'
-            }  md:rounded-tr-none md:rounded-br-none`}
+              isMobile ? '3.5' : '6 py-6'
+            }  xl:rounded-tr-none xl:rounded-br-none`}
           >
             {/* Add Mobile check here */}
             {isMobile ? (
@@ -84,11 +84,11 @@ export default function Hero({ className = '' }: { className?: string }) {
           </div>
         </div>
         {/* second */}
-        <div className=" rounded-[50px] bg-gradient-to-r from-[#6EE7B7]/70 via-[#3B82F6] to-[#9333EA]/50 p-1  md:rounded-none  md:py-1 md:px-0">
+        <div className=" rounded-[50px] bg-gradient-to-r from-[#6EE7B7]/70 via-[#3B82F6] to-[#9333EA]/50 p-1  xl:rounded-none  xl:py-1 xl:px-0">
           <div
             className={`rounded-[45px] bg-white p-${
               isMobile ? '3.5' : '6 py-6'
-            }  md:rounded-none`}
+            }  xl:rounded-none`}
           >
             {/* Add Mobile check here */}
             {isMobile ? (
@@ -121,11 +121,11 @@ export default function Hero({ className = '' }: { className?: string }) {
           </div>
         </div>
         {/* third */}
-        <div className=" rounded-[50px] bg-gradient-to-l from-[#6EE7B7]/80 via-[#3B82F6] to-[#9333EA]/50 p-1 md:rounded-tl-none md:rounded-bl-none ">
+        <div className=" rounded-[50px] bg-gradient-to-l from-[#6EE7B7]/80 via-[#3B82F6] to-[#9333EA]/50 p-1 xl:rounded-tl-none xl:rounded-bl-none ">
           <div
-            className={`firefox rounded-[45px] bg-white p-${
+            className={`rounded-[45px] bg-white p-${
               isMobile ? '3.5' : '6 px-6 '
-            } lg:rounded-tl-none lg:rounded-bl-none`}
+            } xl:rounded-tl-none xl:rounded-bl-none`}
           >
             {/* Add Mobile check here */}
             {isMobile ? (

--- a/frontend/src/Navigation.tsx
+++ b/frontend/src/Navigation.tsx
@@ -242,7 +242,7 @@ export default function Navigation({ navOpen, setNavOpen }: NavigationProps) {
             </p>
           </NavLink>
           {conversations && (
-            <div className="conversations-container max-h-[25rem] overflow-y-auto">
+            <div className="conversations-container max-h-[19rem] overflow-y-auto">
               <p className="ml-6 mt-3 text-sm font-semibold">Chats</p>
               {conversations?.map((conversation) => (
                 <ConversationTile


### PR DESCRIPTION
Fix of hero section for chrome and firefox. 
Current chrome and firefox behaviour:
<img width="946" alt="image" src="https://github.com/arc53/DocsGPT/assets/32868631/4d58f992-b6ce-4d11-bd24-159f539e5da9">
<img width="742" alt="image" src="https://github.com/arc53/DocsGPT/assets/32868631/f32b1d38-41f4-4a4d-b8f0-7bbd484ef7be">

Fix of conversations-container pushing containers below.
Now visible with full conversation history
<img width="280" alt="image" src="https://github.com/arc53/DocsGPT/assets/32868631/166b74fe-90ac-4f13-abb4-84f0f7f44d94">

- **What kind of change does this PR introduce?**  Bug fix 

- **Why was this change needed?** 
Previous chrome behaviour:
<img width="985" alt="image" src="https://github.com/arc53/DocsGPT/assets/32868631/bc679ae1-b85e-4119-bee5-5ab78046356e">
<img width="771" alt="image" src="https://github.com/arc53/DocsGPT/assets/32868631/87dabe7f-511d-4f05-9b59-4e01f8472e0e">
Previous firefox behaviour:
<img width="963" alt="image" src="https://github.com/arc53/DocsGPT/assets/32868631/8c76aaa4-70a2-4b24-9f45-90170e6da353">
<img width="699" alt="image" src="https://github.com/arc53/DocsGPT/assets/32868631/59379172-6760-479e-86f8-be2aa7cfbc17">
- **Other information**:
Safari exception is required
<img width="955" alt="image" src="https://github.com/arc53/DocsGPT/assets/32868631/f8fae677-af24-45c6-a802-a2e89b0867cc">
