### PR TITLE
Update requirements.txt HF Transformers

### DIFF
--- a/application/requirements.txt
+++ b/application/requirements.txt
@@ -35,7 +35,7 @@ geojson==2.5.0
 gunicorn==20.1.0
 greenlet==2.0.2
 gpt4all==0.1.7
-huggingface-hub==0.15.1
+huggingface-hub==0.19.4
 humbug==0.3.2
 idna==3.4
 itsdangerous==2.1.2
@@ -98,8 +98,9 @@ sympy==1.11.1
 tenacity==8.2.2
 threadpoolctl==3.1.0
 tiktoken
+tokenizers==0.15.0
 tqdm==4.65.0
-transformers==4.30.0
+transformers==4.36.0
 typer==0.7.0
 typing-inspect==0.8.0
 typing_extensions==4.5.0


### PR DESCRIPTION
Fix 'mistral' models missing

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It fixes Bug mentioned in Issue #800. It upgrades the HF Transformers library.

- **Why was this change needed?** (You can also link to an open issue here)
All models based on Mistral do not work. After this upgrade of the HF Transformers library they get running.

- **Other information**:
Tests are well passed:
=============================== test session starts ===============================
platform linux -- Python 3.10.10, pytest-7.3.1, pluggy-1.3.0
rootdir: /VSCode/DocsGPT
plugins: anyio-3.7.1
collected 20 items                                                                

tests/test_app.py .                                                         [  5%]
tests/test_celery.py .                                                     [ 10%]
tests/test_error.py ....                                                    [ 30%]
tests/test_openapi3parser.py ...                                    [ 45%]
tests/test_vector_store.py .                                           [ 50%]
tests/llm/test_anthropic.py ...                                         [ 65%]
tests/llm/test_openai.py ...                                             [ 80%]
tests/llm/test_sagemaker.py ....                                     [100%]

================================ warnings summary =================================
venv/lib/python3.10/site-packages/kombu/utils/compat.py:82
  /VSCode/DocsGPT/venv/lib/python3.10/site-packages/kombu/utils/compat.py:82: DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
    for ep in importlib_metadata.entry_points().get(namespace, [])

tests/test_openapi3parser.py::test_get_info_from_paths
tests/test_openapi3parser.py::test_parse_file
  /VSCode/DocsGPT/venv/lib/python3.10/site-packages/prance/__init__.py:234: DeprecationWarning: jsonschema.exceptions.RefResolutionError is deprecated as of version 4.18.0. If you wish to catch potential reference resolution errors, directly catch referencing.exceptions.Unresolvable.
    from jsonschema.exceptions import RefResolutionError

tests/test_vector_store.py::test_init_local_faiss_store_huggingface
  /VSCode/DocsGPT/venv/lib/python3.10/site-packages/faiss/loader.py:28: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if LooseVersion(numpy.__version__) >= "1.19":

tests/test_vector_store.py::test_init_local_faiss_store_huggingface
  /VSCode/DocsGPT/venv/lib/python3.10/site-packages/setuptools/_distutils/version.py:346: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    other = LooseVersion(other)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================= 20 passed, 5 warnings in 2.84s ==========================