### PR TITLE
fix: Making alt text less redundant

### DIFF
--- a/frontend/src/Navigation.tsx
+++ b/frontend/src/Navigation.tsx
@@ -368,7 +368,7 @@ export default function Navigation({ navOpen, setNavOpen }: NavigationProps) {
             rel="noreferrer"
             className="my-auto mx-4 flex h-9 cursor-pointer gap-4 rounded-3xl hover:bg-gray-100"
           >
-            <img src={Discord} alt="link" className="ml-2 w-5" />
+            <img src={Discord} alt="discord-link" className="ml-2 w-5" />
             <p className="my-auto text-sm text-eerie-black">
               Visit our Discord
             </p>
@@ -380,7 +380,7 @@ export default function Navigation({ navOpen, setNavOpen }: NavigationProps) {
             rel="noreferrer"
             className="my-auto mx-4 flex h-9 cursor-pointer gap-4 rounded-3xl hover:bg-gray-100"
           >
-            <img src={Github} alt="link" className="ml-2 w-5" />
+            <img src={Github} alt="github-link" className="ml-2 w-5" />
             <p className="my-auto text-sm text-eerie-black">Visit our Github</p>
           </a>
         </div>

--- a/frontend/src/Navigation.tsx
+++ b/frontend/src/Navigation.tsx
@@ -335,7 +335,7 @@ export default function Navigation({ navOpen, setNavOpen }: NavigationProps) {
               }`
             }
           >
-            <img src={SettingGear} alt="info" className="ml-2 w-5 opacity-60" />
+            <img src={SettingGear} alt="settings" className="ml-2 w-5 opacity-60" />
             <p className="my-auto text-sm text-eerie-black">Settings</p>
           </NavLink>
         </div>


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
There was repetitive alt text for the icons/links on the website. So I gave them more descriptive names.
- **Why was this change needed?** (You can also link to an open issue here)
According to [Deque University](https://dequeuniversity.com/rules/axe/4.7/image-redundant-alt), repetitive alt text can confuse screen readers, thus, making it difficult for users with disabilities to navigate this project's website.
- **Other information**:
Closes #808 