### PR TITLE
fix distortion on different browsers

### DIFF
--- a/frontend/src/Hero.tsx
+++ b/frontend/src/Hero.tsx
@@ -39,7 +39,7 @@ export default function Hero({ className = '' }: { className?: string }) {
         } flex flex-wrap items-center justify-center gap-2 sm:gap-1 md:gap-0`}
       >
         {/* first */}
-        <div className=" rounded-[50px] bg-gradient-to-l from-[#6EE7B7]/70 via-[#3B82F6] to-[#9333EA]/50 p-1  md:rounded-tr-none md:rounded-br-none">
+        <div className="h-auto md:h-60 rounded-[50px] bg-gradient-to-l from-[#6EE7B7]/70 via-[#3B82F6] to-[#9333EA]/50 p-1  md:rounded-tr-none md:rounded-br-none">
           <div
             className={`h-full rounded-[45px] bg-white p-${
               isMobile ? '3.5' : '6 py-8'
@@ -84,9 +84,9 @@ export default function Hero({ className = '' }: { className?: string }) {
           </div>
         </div>
         {/* second */}
-        <div className=" rounded-[50px] bg-gradient-to-r from-[#6EE7B7]/70 via-[#3B82F6] to-[#9333EA]/50 p-1  md:rounded-none  md:py-1 md:px-0">
+        <div className="h-auto md:h-60 rounded-[50px] bg-gradient-to-r from-[#6EE7B7]/70 via-[#3B82F6] to-[#9333EA]/50 p-1  md:rounded-none  md:py-1 md:px-0">
           <div
-            className={`rounded-[45px] bg-white p-${
+            className={`h-full rounded-[45px] bg-white p-${
               isMobile ? '3.5' : '6 py-6'
             }  md:rounded-none`}
           >
@@ -121,9 +121,9 @@ export default function Hero({ className = '' }: { className?: string }) {
           </div>
         </div>
         {/* third */}
-        <div className=" rounded-[50px] bg-gradient-to-l from-[#6EE7B7]/80 via-[#3B82F6] to-[#9333EA]/50 p-1 md:rounded-tl-none md:rounded-bl-none ">
+        <div className="h-auto md:h-60 rounded-[50px] bg-gradient-to-l from-[#6EE7B7]/80 via-[#3B82F6] to-[#9333EA]/50 p-1 md:rounded-tl-none md:rounded-bl-none ">
           <div
-            className={`firefox rounded-[45px] bg-white p-${
+            className={`h-full firefox rounded-[45px] bg-white p-${
               isMobile ? '3.5' : '6 px-6 '
             } lg:rounded-tl-none lg:rounded-bl-none`}
           >


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
 Fixes unwanted dimensional variation in different browsers(**Chrome, Firefox** web page looks a bit different)

- **Why was this change needed?** (You can also link to an open issue here)
The Hero component varies in dimensions in different browsers 
### **Firefox demo** 
![image](https://github.com/arc53/DocsGPT/assets/96079232/ba72bec3-915b-461c-a365-9fe60f8eb0bc)
