### PR TITLE
Fixed Empty Document Name Upload

### DIFF
--- a/frontend/src/upload/Upload.tsx
+++ b/frontend/src/upload/Upload.tsx
@@ -207,9 +207,11 @@ export default function Upload({
           <button
             onClick={uploadFile}
             className={`ml-6 rounded-3xl bg-purple-30 text-white ${
-              files.length > 0 ? '' : 'bg-opacity-75 text-opacity-80'
+              files.length > 0 && docName.trim().length > 0
+                ? ''
+                : 'bg-opacity-75 text-opacity-80'
             } py-2 px-6`}
-            disabled={files.length === 0} // Disable the button if no file is selected
+            disabled={files.length === 0 || docName.trim().length === 0} // Disable the button if no file is selected or docName is empty
           >
             Train
           </button>


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug Fix)

- **Why was this change needed?** (#809)

- **Other information**:
- The Train button will be disabled if the Document File Name is Empty. The Discussion is done in the Discord