### PR TITLE
Feature/api key create

### DIFF
--- a/frontend/src/Setting.tsx
+++ b/frontend/src/Setting.tsx
@@ -760,7 +760,7 @@ const SaveAPIKeyModal: React.FC<SaveAPIKeyModalProps> = ({ apiKey, close }) => {
   };
   return (
     <div className="fixed top-0 left-0 flex h-screen w-screen items-center justify-center bg-gray-900 bg-opacity-50">
-      <div className="z-10 w-11/12 rounded-3xl bg-white p-4 sm:w-[600px]">
+      <div className="z-10 w-11/12 rounded-3xl bg-white p-4 dark:bg-outer-space dark:text-bright-gray sm:w-[600px]">
         <button className="float-right m-2 w-4" onClick={close}>
           <img src={Exit} />
         </button>
@@ -771,10 +771,10 @@ const SaveAPIKeyModal: React.FC<SaveAPIKeyModalProps> = ({ apiKey, close }) => {
         <div className="flex justify-between py-2">
           <div>
             <h2 className="text-base font-semibold">API Key</h2>
-            <span className="text-xs font-normal leading-7">{apiKey}</span>
+            <span className="text-sm font-normal leading-7 ">{apiKey}</span>
           </div>
           <button
-            className="my-1 h-10 w-20 rounded-full border border-purple-30 p-2 text-sm text-purple-30"
+            className="my-1 h-10 w-20 rounded-full border border-purple-30 p-2 text-sm text-purple-30 dark:border-purple-500 dark:text-purple-500"
             onClick={handleCopyKey}
           >
             {isCopied ? 'Copied' : 'Copy'}
@@ -782,9 +782,8 @@ const SaveAPIKeyModal: React.FC<SaveAPIKeyModalProps> = ({ apiKey, close }) => {
         </div>
         <button
           onClick={close}
-          className="rounded-full bg-[#FFC700] px-4 py-3 font-medium text-black dark:bg-purple-taupe dark:text-white"
+          className="rounded-full bg-philippine-yellow px-4 py-3 font-medium text-black"
         >
-          {' '}
           I saved the Key
         </button>
       </div>
@@ -806,8 +805,6 @@ const CreateAPIKeyModal: React.FC<CreateAPIKeyModalProps> = ({
     value: string;
   } | null>(null);
   const docs = useSelector(selectSourceDocs);
-  console.log(docs);
-
   const extractDocPaths = () =>
     docs
       ? docs
@@ -840,11 +837,13 @@ const CreateAPIKeyModal: React.FC<CreateAPIKeyModalProps> = ({
 
   return (
     <div className="fixed top-0 left-0 flex h-screen w-screen items-center justify-center bg-gray-900 bg-opacity-50">
-      <div className="z-10 w-11/12 rounded-3xl bg-white p-4 sm:w-[600px]">
+      <div className="z-10 w-11/12 rounded-3xl bg-white p-4 dark:bg-outer-space sm:w-[600px]">
         <button className="float-right m-2 w-4" onClick={close}>
           <img src={Exit} />
         </button>
-        <h1 className="m-4 text-2xl font-bold text-jet">Create New API Key</h1>
+        <h1 className="m-4 text-2xl font-bold text-jet dark:text-bright-gray">
+          Create New API Key
+        </h1>
         <div className="relative m-4">
           <span className="absolute left-2 -top-2 bg-white px-2 text-xs text-gray-4000 dark:bg-outer-space dark:text-silver">
             API Key Name

--- a/frontend/src/Setting.tsx
+++ b/frontend/src/Setting.tsx
@@ -759,12 +759,12 @@ const SaveAPIKeyModal: React.FC<SaveAPIKeyModalProps> = ({ apiKey, close }) => {
     setIsCopied(true);
   };
   return (
-    <div className="fixed top-0 left-0 flex h-screen w-screen items-center justify-center bg-gray-900 bg-opacity-50">
-      <div className="z-10 w-11/12 rounded-3xl bg-white p-4 dark:bg-outer-space dark:text-bright-gray sm:w-[600px]">
-        <button className="float-right m-2 w-4" onClick={close}>
-          <img src={Exit} />
+    <div className="fixed top-0 left-0 z-30 flex h-screen w-screen items-center justify-center bg-gray-alpha bg-opacity-50">
+      <div className="relative w-11/12 rounded-md bg-white p-5 dark:bg-outer-space dark:text-bright-gray sm:w-[512px]">
+        <button className="absolute top-4 right-4 w-4" onClick={close}>
+          <img className="filter dark:invert" src={Exit} />
         </button>
-        <h1 className="mb-0 text-xl font-medium">Please save your Key</h1>
+        <h1 className="my-0 text-xl font-medium">Please save your Key</h1>
         <h3 className="text-sm font-normal text-outer-space">
           This is the only time your key will be shown.
         </h3>
@@ -782,7 +782,7 @@ const SaveAPIKeyModal: React.FC<SaveAPIKeyModalProps> = ({ apiKey, close }) => {
         </div>
         <button
           onClick={close}
-          className="rounded-full bg-philippine-yellow px-4 py-3 font-medium text-black"
+          className="rounded-full bg-philippine-yellow px-4 py-3 font-medium text-black hover:bg-[#E6B91A]"
         >
           I saved the Key
         </button>
@@ -836,15 +836,15 @@ const CreateAPIKeyModal: React.FC<CreateAPIKeyModalProps> = ({
       : [];
 
   return (
-    <div className="fixed top-0 left-0 flex h-screen w-screen items-center justify-center bg-gray-900 bg-opacity-50">
-      <div className="z-10 w-11/12 rounded-3xl bg-white p-4 dark:bg-outer-space sm:w-[600px]">
-        <button className="float-right m-2 w-4" onClick={close}>
-          <img src={Exit} />
+    <div className="fixed top-0 left-0 z-30 flex h-screen w-screen items-center justify-center bg-gray-alpha bg-opacity-50">
+      <div className="relative w-11/12 rounded-lg bg-white p-5 dark:bg-outer-space sm:w-[512px]">
+        <button className="absolute top-2 right-2 m-2 w-4" onClick={close}>
+          <img className="filter dark:invert" src={Exit} />
         </button>
-        <h1 className="m-4 text-2xl font-bold text-jet dark:text-bright-gray">
+        <span className="mb-4 text-xl font-bold text-jet dark:text-bright-gray">
           Create New API Key
-        </h1>
-        <div className="relative m-4">
+        </span>
+        <div className="relative my-4">
           <span className="absolute left-2 -top-2 bg-white px-2 text-xs text-gray-4000 dark:bg-outer-space dark:text-silver">
             API Key Name
           </span>
@@ -855,7 +855,7 @@ const CreateAPIKeyModal: React.FC<CreateAPIKeyModalProps> = ({
             onChange={(e) => setAPIKeyName(e.target.value)}
           />
         </div>
-        <div className="m-4">
+        <div className="my-4">
           <Dropdown
             className="mt-2 w-full"
             placeholder="Select the source doc"
@@ -872,7 +872,7 @@ const CreateAPIKeyModal: React.FC<CreateAPIKeyModalProps> = ({
             sourcePath &&
             createAPIKey({ name: APIKeyName, source: sourcePath.value })
           }
-          className="float-right m-4 rounded-full bg-purple-30 px-4 py-3 text-white disabled:opacity-50"
+          className="float-right my-4 rounded-full bg-purple-30 px-4 py-3 text-white disabled:opacity-50"
         >
           Create
         </button>

--- a/frontend/src/components/Dropdown.tsx
+++ b/frontend/src/components/Dropdown.tsx
@@ -7,18 +7,20 @@ function Dropdown({
   onSelect,
   showDelete,
   onDelete,
+  placeholder,
 }: {
   options:
     | string[]
     | { name: string; id: string; type: string }[]
     | { label: string; value: string }[];
-  selectedValue: string | { label: string; value: string };
+  selectedValue: string | { label: string; value: string } | null;
   onSelect:
     | ((value: string) => void)
     | ((value: { name: string; id: string; type: string }) => void)
     | ((value: { label: string; value: string }) => void);
   showDelete?: boolean;
   onDelete?: (value: string) => void;
+  placeholder?: string;
 }) {
   const [isOpen, setIsOpen] = useState(false);
   return (
@@ -51,7 +53,11 @@ function Dropdown({
               !selectedValue && 'text-silver'
             }`}
           >
-            {selectedValue ? selectedValue.label : 'From URL'}
+            {selectedValue
+              ? selectedValue.label
+              : placeholder
+              ? placeholder
+              : 'From URL'}
           </span>
         )}
         <img

--- a/frontend/src/components/Dropdown.tsx
+++ b/frontend/src/components/Dropdown.tsx
@@ -8,7 +8,6 @@ function Dropdown({
   showDelete,
   onDelete,
   placeholder,
-  className,
 }: {
   options:
     | string[]
@@ -28,14 +27,11 @@ function Dropdown({
   const [isOpen, setIsOpen] = useState(false);
   return (
     <div
-      className={`relative ${
-        className
-          ? className
-          : typeof selectedValue === 'string'
-          ? ' mt-2 w-32'
-          : ' w-full align-middle'
-      } 
-        }`}
+      className={
+        typeof selectedValue === 'string'
+          ? 'relative mt-2 w-32'
+          : 'relative w-full align-middle'
+      }
     >
       <button
         onClick={() => setIsOpen(!isOpen)}
@@ -56,7 +52,7 @@ function Dropdown({
         ) : (
           <span
             className={`overflow-hidden text-ellipsis dark:text-bright-gray ${
-              !selectedValue && 'text-silver'
+              !selectedValue && 'text-silver dark:text-gray-400'
             }`}
           >
             {selectedValue

--- a/frontend/src/components/Dropdown.tsx
+++ b/frontend/src/components/Dropdown.tsx
@@ -8,6 +8,7 @@ function Dropdown({
   showDelete,
   onDelete,
   placeholder,
+  className,
 }: {
   options:
     | string[]
@@ -21,15 +22,20 @@ function Dropdown({
   showDelete?: boolean;
   onDelete?: (value: string) => void;
   placeholder?: string;
+  className?: string;
+  width?: string;
 }) {
   const [isOpen, setIsOpen] = useState(false);
   return (
     <div
-      className={
-        typeof selectedValue === 'string'
-          ? 'relative mt-2 w-32'
-          : 'relative w-full align-middle'
-      }
+      className={`relative ${
+        className
+          ? className
+          : typeof selectedValue === 'string'
+          ? ' mt-2 w-32'
+          : ' w-full align-middle'
+      } 
+        }`}
     >
       <button
         onClick={() => setIsOpen(!isOpen)}
@@ -69,7 +75,7 @@ function Dropdown({
         />
       </button>
       {isOpen && (
-        <div className="absolute left-0 right-0 z-50 -mt-1 overflow-y-auto rounded-b-xl border-2 bg-white shadow-lg dark:border-chinese-silver dark:bg-dark-charcoal">
+        <div className="absolute left-0 right-0 z-50 -mt-1 max-h-40 overflow-y-auto rounded-b-xl border-2 bg-white shadow-lg dark:border-chinese-silver dark:bg-dark-charcoal">
           {options.map((option: any, index) => (
             <div
               key={index}

--- a/frontend/src/components/Dropdown.tsx
+++ b/frontend/src/components/Dropdown.tsx
@@ -35,7 +35,7 @@ function Dropdown({
     >
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className={`flex w-full cursor-pointer items-center justify-between border-2 bg-white p-3 dark:border-chinese-silver dark:bg-transparent ${
+        className={`flex w-full cursor-pointer items-center justify-between border-2 border-silver bg-white p-3 dark:border-chinese-silver dark:bg-transparent ${
           isOpen
             ? typeof selectedValue === 'string'
               ? 'rounded-t-xl'

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 ::-webkit-scrollbar {
-  width: 10px;
+  width: 8px;
 }
 ::-webkit-scrollbar-track {
   background: #f1f1f1;

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -46,7 +46,8 @@ module.exports = {
         'gun-metal':'#2E303E',
         'sonic-silver':'#747474',
         'soap':'#D8CCF1',
-        'independence':'#54546D'
+        'independence':'#54546D',
+        'philippine-yellow':'#FFC700',
       },
     },
   },


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  * Adding a new tab for API Keys in Settings, also compatible with Dark theme.
  * The Create button opens up the `CreateAPIKeyModal` which allows to select the source and API Key name.
  * On Submitting the preferences, New modal `SaveAPIKeyModal` appears which allows users to copy the API key for further reference.
- **Why was this change needed?** (You can also link to an open issue here)
   * New Feature addition (Frontend)
- **Other information**:
  * Demo
![Screenshot from 2024-03-29 03-38-50](https://github.com/arc53/DocsGPT/assets/96079232/726254c2-275e-4669-adda-6486538a5802)
![Screenshot from 2024-03-29 03-38-41](https://github.com/arc53/DocsGPT/assets/96079232/954c5179-fd63-45a1-adc5-38de9e38a71a)
![Screenshot from 2024-03-29 03-38-29](https://github.com/arc53/DocsGPT/assets/96079232/9f350b23-9847-4a2e-9a40-2ba304fd527a)

