### PR TITLE
error handling for /stream endpoint

### DIFF
--- a/application/api/answer/routes.py
+++ b/application/api/answer/routes.py
@@ -9,6 +9,7 @@ import traceback
 from pymongo import MongoClient
 from bson.objectid import ObjectId
 from transformers import GPT2TokenizerFast
+from flask import stream_with_context, jsonify
 
 
 
@@ -191,47 +192,53 @@ def complete_stream(question, docsearch, chat_history, prompt_id, conversation_i
 
 @answer.route("/stream", methods=["POST"])
 def stream():
-    data = request.get_json()
-    # get parameter from url question
-    question = data["question"]
-    if "history" not in data:
-        history = []
-    else:
-        history = data["history"]
-        history = json.loads(history)
-    if "conversation_id" not in data:
-        conversation_id = None
-    else:
-        conversation_id = data["conversation_id"]
-    if 'prompt_id' in data:
-        prompt_id = data["prompt_id"]
-    else:
-        prompt_id = 'default'
-    if 'selectedDocs' in data and data['selectedDocs'] is None:
-        chunks = 0
-    elif 'chunks' in data:
-        chunks = int(data["chunks"])
-    else:
-        chunks = 2
+    try:
+        data = request.get_json()
+        # get parameter from url question
+        question = data["question"]
+        if "history" not in data:
+            history = []
+        else:
+            history = data["history"]
+            history = json.loads(history)
+        if "conversation_id" not in data:
+            conversation_id = None
+        else:
+            conversation_id = data["conversation_id"]
+        if 'prompt_id' in data:
+            prompt_id = data["prompt_id"]
+        else:
+            prompt_id = 'default'
+        if 'selectedDocs' in data and data['selectedDocs'] is None:
+            chunks = 0
+        elif 'chunks' in data:
+            chunks = int(data["chunks"])
+        else:
+            chunks = 2
 
-    # check if active_docs is set
+        # check if active_docs is set
 
-    if "api_key" in data:
-        data_key = get_data_from_api_key(data["api_key"])
-        vectorstore = get_vectorstore({"active_docs": data_key["source"]})
-    elif "active_docs" in data:
-        vectorstore = get_vectorstore({"active_docs": data["active_docs"]})
-    else:
-        vectorstore = ""
-    docsearch = VectorCreator.create_vectorstore(settings.VECTOR_STORE, vectorstore, settings.EMBEDDINGS_KEY)
+        if "api_key" in data:
+            data_key = get_data_from_api_key(data["api_key"])
+            vectorstore = get_vectorstore({"active_docs": data_key["source"]})
+        elif "active_docs" in data:
+            vectorstore = get_vectorstore({"active_docs": data["active_docs"]})
+        else:
+            vectorstore = ""
+        docsearch = VectorCreator.create_vectorstore(settings.VECTOR_STORE, vectorstore, settings.EMBEDDINGS_KEY)
 
-    return Response(
-        complete_stream(question, docsearch,
-                        chat_history=history,
-                        prompt_id=prompt_id,
-                        conversation_id=conversation_id,
-                        chunks=chunks), mimetype="text/event-stream"
-    )
+        return Response(
+            stream_with_context(complete_stream(question, docsearch,
+                            chat_history=history,
+                            prompt_id=prompt_id,
+                            conversation_id=conversation_id,
+                            chunks=chunks)), mimetype="text/event-stream"
+        )
+    except Exception as e:
+        error_message = "An error occurred: " + str(e)
+        return Response(stream_with_context(generate_error_stream(error_message)), mimetype="text/event-stream")
+def generate_error_stream(error_message):
+    yield f"data: {{\"type\": \"error\", \"message\": \"{error_message}\"}}\n\n"    
 
 
 @answer.route("/api/answer", methods=["POST"])

--- a/application/error.py
+++ b/application/error.py
@@ -3,7 +3,7 @@ from werkzeug.http import HTTP_STATUS_CODES
 
 
 def response_error(code_status, message=None):
-    payload = {'error': HTTP_STATUS_CODES.get(code_status, "something went wrong")}
+    payload = {'error': HTTP_STATUS_CODES.get(code_status, "something went wrong"), 'message': message if message else "An error occurred"}
     if message:
         payload['message'] = message
     response = jsonify(payload)

--- a/application/llm/docsgpt_provider.py
+++ b/application/llm/docsgpt_provider.py
@@ -24,12 +24,13 @@ class DocsGPTAPILLM(BaseLLM):
 
         return response_clean
 
-    def gen_stream(self, model, engine, messages, stream=True, **kwargs):
-        context = messages[0]['content']
-        user_question = messages[-1]['content']
-        prompt = f"### Instruction \n {user_question} \n ### Context \n {context} \n ### Answer \n"
+def gen_stream(self, model, engine, messages, stream=True, **kwargs):
+    context = messages[0]['content']
+    user_question = messages[-1]['content']
+    prompt = f"### Instruction \n {user_question} \n ### Context \n {context} \n ### Answer \n"
 
-        # send prompt to endpoint /stream
+    # send prompt to endpoint /stream
+    try:
         response = requests.post(
             f"{self.endpoint}/stream",
             json={
@@ -38,12 +39,14 @@ class DocsGPTAPILLM(BaseLLM):
             },
             stream=True
         )
-    
+
         for line in response.iter_lines():
             if line:
-                #data = json.loads(line)
                 data_str = line.decode('utf-8')
                 if data_str.startswith("data: "):
                     data = json.loads(data_str[6:])
                     yield data['a']
+    except Exception as e:
+        error_message = "An error occurred: " + str(e)
+        yield f"data: {{\"type\": \"error\", \"message\": \"{error_message}\"}}\n\n"
                     

--- a/frontend/src/conversation/Conversation.tsx
+++ b/frontend/src/conversation/Conversation.tsx
@@ -94,15 +94,26 @@ export default function Conversation() {
 
   const prepResponseView = (query: Query, index: number) => {
     let responseView;
+
     if (query.error) {
+      let errorMessage = 'An Error occoured, please try again later.';
+      try {
+        const errorObject = JSON.parse(query.error);
+        if (errorObject && errorObject.message) {
+          errorMessage = errorObject.message;
+        }
+      } catch (e) {
+        console.error(e);
+      }
+
       responseView = (
         <ConversationBubble
           ref={endMessageRef}
           className={`${index === queries.length - 1 ? 'mb-32' : 'mb-7'}`}
           key={`${index}ERROR`}
-          message={query.error}
+          message={errorMessage}
           type="ERROR"
-        ></ConversationBubble>
+        />
       );
     } else if (query.response) {
       responseView = (
@@ -111,15 +122,16 @@ export default function Conversation() {
           className={`${index === queries.length - 1 ? 'mb-32' : 'mb-7'}`}
           key={`${index}ANSWER`}
           message={query.response}
-          type={'ANSWER'}
+          type="ANSWER"
           sources={query.sources}
           feedback={query.feedback}
           handleFeedback={(feedback: FEEDBACK) =>
             handleFeedback(query, feedback, index)
           }
-        ></ConversationBubble>
+        />
       );
     }
+
     return responseView;
   };
 

--- a/frontend/src/conversation/conversationApi.ts
+++ b/frontend/src/conversation/conversationApi.ts
@@ -97,6 +97,7 @@ export function fetchAnswerSteaming(
   promptId: string | null,
   chunks: string,
   onEvent: (event: MessageEvent) => void,
+  onError: (error: string) => void,
 ): Promise<Answer> {
   let docPath = 'default';
 
@@ -184,6 +185,7 @@ export function fetchAnswerSteaming(
       })
       .catch((error) => {
         console.error('Connection failed:', error);
+        onError(error);
         reject(error);
       });
   });

--- a/frontend/src/conversation/conversationSlice.ts
+++ b/frontend/src/conversation/conversationSlice.ts
@@ -28,9 +28,11 @@ export const fetchAnswer = createAsyncThunk<Answer, { question: string }>(
           state.conversation.conversationId,
           state.preference.prompt.id,
           state.preference.chunks,
-
+          (error) => {
+            console.error(error);
+          },
           (event) => {
-            const data = JSON.parse(event.data);
+            const data = JSON.parse(event);
 
             // check if the 'end' event has been received
             if (data.type === 'end') {
@@ -64,6 +66,13 @@ export const fetchAnswer = createAsyncThunk<Answer, { question: string }>(
               dispatch(
                 updateConversationId({
                   query: { conversationId: data.id },
+                }),
+              );
+            } else if (data.type === 'error') {
+              dispatch(
+                conversationSlice.actions.setError({
+                  index: state.conversation.queries.length - 1,
+                  error: data.message,
                 }),
               );
             } else {
@@ -142,6 +151,10 @@ export const conversationSlice = createSlice({
     },
     setConversation(state, action: PayloadAction<Query[]>) {
       state.queries = action.payload;
+    },
+    setError(state, action: PayloadAction<{ index: number; error: string }>) {
+      const { index, error } = action.payload;
+      state.queries[index].error = error;
     },
     updateStreamingQuery(
       state,


### PR DESCRIPTION
This PR (issue #910) introduces both a backend and frontend feature for improved error handling during streaming operations.

I have updated code in backend (`application`) and `frontend` folders.

If an error occurs during the stream, the user will see a specific error message like "error reason" instead of a generic "An Error occurred, please try again later." message.