### PR TITLE
Fix empty response in the conversation

### DIFF
--- a/frontend/src/conversation/conversationSlice.ts
+++ b/frontend/src/conversation/conversationSlice.ts
@@ -148,7 +148,7 @@ export const conversationSlice = createSlice({
       action: PayloadAction<{ index: number; query: Partial<Query> }>,
     ) {
       const { index, query } = action.payload;
-      if (query.response) {
+      if (query.response != undefined) {
         state.queries[index].response =
           (state.queries[index].response || '') + query.response;
       } else {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

When asking a question, the LLM's response streams in as it should, then disappears from the conversation once it is finished. It reappears if the page is refreshed.

The bug seems to occur when the token sent by the LLM is an empty string. In llama-cpp, the last token seems to always be an empty string. This causes the frontend to recognize the string as empty in conversationSlice.ts#L151, which in turn causes the code to enter the else part of the statement, which returns an empty response.

- **Why was this change needed?** (You can also link to an open issue here)

Fixes https://github.com/arc53/DocsGPT/issues/944

- **Other information**: