### PR TITLE
Better Error handling on /stream endpoint

### DIFF
--- a/application/api/answer/routes.py
+++ b/application/api/answer/routes.py
@@ -76,7 +76,7 @@ def get_data_from_api_key(api_key):
     
     # # Raise custom exception if the API key is not found
     if data is None:
-        raise Exception("API key is invalid", 401)
+        raise Exception("Invalid API Key, please generate new key", 401)
     return data
 
 
@@ -200,6 +200,7 @@ def complete_stream(question, retriever, conversation_id, user_api_key):
     except Exception:
         data = json.dumps({"type": "error","error":"Please try again later. We apologize for any inconvenience."})
         yield f"data: {data}\n\n"
+        return 
 
 @answer.route("/stream", methods=["POST"])
 def stream():

--- a/application/api/answer/routes.py
+++ b/application/api/answer/routes.py
@@ -198,7 +198,8 @@ def complete_stream(question, retriever, conversation_id, user_api_key):
         data = json.dumps({"type": "end"})
         yield f"data: {data}\n\n"
     except Exception as e:
-        data = json.dumps({"type": "error","error": str(e)})
+        data = json.dumps({"type": "error","error":"Please try again later. We apologize for any inconvenience.",
+          "error_exception": str(e)})
         yield f"data: {data}\n\n"
         return 
 

--- a/application/api/answer/routes.py
+++ b/application/api/answer/routes.py
@@ -185,20 +185,20 @@ def complete_stream(question, retriever, conversation_id, user_api_key):
             elif "source" in line:
                 source_log_docs.append(line["source"])
 
-            llm = LLMCreator.create_llm(
-                settings.LLM_NAME, api_key=settings.API_KEY, user_api_key=user_api_key
-               )
-            conversation_id = save_conversation(
-                conversation_id, question, response_full, source_log_docs, llm
+        llm = LLMCreator.create_llm(
+            settings.LLM_NAME, api_key=settings.API_KEY, user_api_key=user_api_key
             )
-           
-            # send data.type = "end" to indicate that the stream has ended as json
-            data = json.dumps({"type": "id", "id": str(conversation_id)})
-            yield f"data: {data}\n\n"
-            data = json.dumps({"type": "end"})
-            yield f"data: {data}\n\n"
-    except Exception:
-        data = json.dumps({"type": "error","error":"Please try again later. We apologize for any inconvenience."})
+        conversation_id = save_conversation(
+            conversation_id, question, response_full, source_log_docs, llm
+        )
+        
+        # send data.type = "end" to indicate that the stream has ended as json
+        data = json.dumps({"type": "id", "id": str(conversation_id)})
+        yield f"data: {data}\n\n"
+        data = json.dumps({"type": "end"})
+        yield f"data: {data}\n\n"
+    except Exception as e:
+        data = json.dumps({"type": "error","error": str(e)})
         yield f"data: {data}\n\n"
         return 
 

--- a/application/api/answer/routes.py
+++ b/application/api/answer/routes.py
@@ -173,30 +173,33 @@ def get_prompt(prompt_id):
 
 def complete_stream(question, retriever, conversation_id, user_api_key):
 
-    response_full = ""
-    source_log_docs = []
-    answer = retriever.gen()
-    for line in answer:
-        if "answer" in line:
-            response_full += str(line["answer"])
-            data = json.dumps(line)
+    try:
+        response_full = ""
+        source_log_docs = []
+        answer = retriever.gen()
+        for line in answer:
+            if "answer" in line:
+                response_full += str(line["answer"])
+                data = json.dumps(line)
+                yield f"data: {data}\n\n"
+            elif "source" in line:
+                source_log_docs.append(line["source"])
+
+            llm = LLMCreator.create_llm(
+                settings.LLM_NAME, api_key=settings.API_KEY, user_api_key=user_api_key
+               )
+            conversation_id = save_conversation(
+                conversation_id, question, response_full, source_log_docs, llm
+            )
+           
+            # send data.type = "end" to indicate that the stream has ended as json
+            data = json.dumps({"type": "id", "id": str(conversation_id)})
             yield f"data: {data}\n\n"
-        elif "source" in line:
-            source_log_docs.append(line["source"])
-
-    llm = LLMCreator.create_llm(
-        settings.LLM_NAME, api_key=settings.API_KEY, user_api_key=user_api_key
-    )
-    conversation_id = save_conversation(
-        conversation_id, question, response_full, source_log_docs, llm
-    )
-
-    # send data.type = "end" to indicate that the stream has ended as json
-    data = json.dumps({"type": "id", "id": str(conversation_id)})
-    yield f"data: {data}\n\n"
-    data = json.dumps({"type": "end"})
-    yield f"data: {data}\n\n"
-
+            data = json.dumps({"type": "end"})
+            yield f"data: {data}\n\n"
+    except Exception:
+        data = json.dumps({"type": "error","error":"Please try again later. We apologize for any inconvenience."})
+        yield f"data: {data}\n\n"
 
 @answer.route("/stream", methods=["POST"])
 def stream():
@@ -274,23 +277,29 @@ def stream():
         ),
         mimetype="text/event-stream",
     )
+    
+   except ValueError:
+       message = "Malformed request body"
+       return Response(
+        error_stream_generate(message),
+        status=400,
+        mimetype="text/event-stream",
+    )
    except Exception as e:
+        print("err",str(e))
         message = e.args[0]
         status_code = 400
         # # Custom exceptions with two arguments, index 1 as status code
         if(len(e.args) >= 2):
             status_code = e.args[1]
-
-        def error_stream_generate():
-            data = json.dumps({"type": "error", "error":message})
-            yield f"data: {data}\n\n"
-
         return Response(
-        error_stream_generate(),
+        error_stream_generate(message),
         status=status_code,
         mimetype="text/event-stream",
     )
-
+def error_stream_generate(err_response):
+            data = json.dumps({"type": "error", "error":err_response})
+            yield f"data: {data}\n\n"
 
 @answer.route("/api/answer", methods=["POST"])
 def api_answer():

--- a/application/api/user/routes.py
+++ b/application/api/user/routes.py
@@ -257,8 +257,8 @@ def combined_json():
         }
     ]
     # structure: name, language, version, description, fullName, date, docLink
-    # append data from vectors_collection
-    for index in vectors_collection.find({"user": user}):
+    # append data from vectors_collection in sorted order in descending order of date
+    for index in vectors_collection.find({"user": user}).sort("date", -1):
         data.append(
             {
                 "name": index["name"],

--- a/frontend/src/conversation/conversationSlice.ts
+++ b/frontend/src/conversation/conversationSlice.ts
@@ -220,7 +220,7 @@ export const conversationSlice = createSlice({
         }
         state.status = 'failed';
         state.queries[state.queries.length - 1].error =
-          'Something went wrong. Please try again later.';
+          'Something went wrong. Please check your internet connection.';
       });
   },
 });

--- a/frontend/src/conversation/conversationSlice.ts
+++ b/frontend/src/conversation/conversationSlice.ts
@@ -68,6 +68,15 @@ export const fetchAnswer = createAsyncThunk<Answer, { question: string }>(
                   query: { conversationId: data.id },
                 }),
               );
+            } else if (data.type === 'error') {
+              // set status to 'failed'
+              dispatch(conversationSlice.actions.setStatus('failed'));
+              dispatch(
+                conversationSlice.actions.raiseError({
+                  index: state.conversation.queries.length - 1,
+                  message: data.error,
+                }),
+              );
             } else {
               const result = data.answer;
               dispatch(
@@ -190,6 +199,13 @@ export const conversationSlice = createSlice({
     },
     setStatus(state, action: PayloadAction<Status>) {
       state.status = action.payload;
+    },
+    raiseError(
+      state,
+      action: PayloadAction<{ index: number; message: string }>,
+    ) {
+      const { index, message } = action.payload;
+      state.queries[index].error = message;
     },
   },
   extraReducers(builder) {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  * Handles exceptions in stream route; Closes #910 
  * Considering following cases:
    1. If API key is invalid, or not found return status code 401, raise  ` Exception("Invalid API Key, please generate new key", 401)`
    2. In case invalid parameters are passed through request body from Frontend, except for ValueError and stream `Malformed request body`
    3. If the upstream LLM server fails to generate response, or the request fails from the server side, stream `Please try again later. We apologize for any inconvenience.`
    4. If the frontend fails to send the request possibly because of Connection or Network issues, the extraReducer message is updated to `Something went wrong. Please check your internet connection.`

* Sorted the local vectors in the /combine endpoint, in the order of latest first [Descending order of date]
    
All the Exceptions are streamed in the following format
``{"type": "error","error":"Please try again later. We apologize for any inconvenience."}``  
Added a reducer `raiseError` in the conversationSlice to append the streamed error responses.
- **Why was this change needed?** (You can also link to an open issue here)
More transparency on /stream route, clear messages on streaming endpoint.