### PR TITLE
FEAT: Auto Language Detection using User's Browser Default

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "@reduxjs/toolkit": "^1.9.2",
     "@vercel/analytics": "^0.1.10",
     "i18next": "^23.11.5",
+    "i18next-browser-languagedetector": "^8.0.0",
     "react": "^18.2.0",
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.2.0",

--- a/frontend/src/locale/i18n.ts
+++ b/frontend/src/locale/i18n.ts
@@ -1,29 +1,39 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
 
 import en from './en.json'; //English
 import es from './es.json'; //Spanish
 import jp from './jp.json'; //Japanese
 import zh from './zh.json'; //Mandarin
 
-i18n.use(initReactI18next).init({
-  resources: {
-    en: {
-      translation: en,
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: {
+        translation: en,
+      },
+      es: {
+        translation: es,
+      },
+      jp: {
+        translation: jp,
+      },
+      zh: {
+        translation: zh,
+      },
     },
-    es: {
-      translation: es,
+    fallbackLng: 'en',
+    detection: {
+      order: ['localStorage', 'navigator'], // checks localStorage for existing lang before browser's
+      caches: ['localStorage'], //stores detected lang to localStorage with i18nextLng key
+      lookupLocalStorage: 'docsgpt-locale', //using docsgpt-locale as the custom key for storing and retrieving the lang rather than the default `i18nextLng`
     },
-    jp: {
-      translation: jp,
-    },
-    zh: {
-      translation: zh,
-    },
-  },
-});
+  });
 
-const locale = localStorage.getItem('docsgpt-locale') ?? 'en';
-i18n.changeLanguage(locale);
+const savedLocale = localStorage.getItem('docsgpt-locale') ?? i18n.language;
+i18n.changeLanguage(savedLocale);
 
 export default i18n;

--- a/frontend/src/locale/i18n.ts
+++ b/frontend/src/locale/i18n.ts
@@ -27,13 +27,12 @@ i18n
     },
     fallbackLng: 'en',
     detection: {
-      order: ['localStorage', 'navigator'], // checks localStorage for existing lang before browser's
-      caches: ['localStorage'], //stores detected lang to localStorage with i18nextLng key
-      lookupLocalStorage: 'docsgpt-locale', //using docsgpt-locale as the custom key for storing and retrieving the lang rather than the default `i18nextLng`
+      order: ['localStorage', 'navigator'],
+      caches: ['localStorage'],
+      lookupLocalStorage: 'docsgpt-locale',
     },
   });
 
-const savedLocale = localStorage.getItem('docsgpt-locale') ?? i18n.language;
-i18n.changeLanguage(savedLocale);
+i18n.changeLanguage(i18n.language);
 
 export default i18n;


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature: on first visit, user's browser language is detected and used if supported. Otherwise, English is used.

- **Why was this change needed?** (You can also link to an open issue here)
Users no longer have to set their primary language manually in the app.

- **Other information**:
closes: https://github.com/arc53/DocsGPT/issues/1016