### PR TITLE
Optimize Dockerfile to reduce image size and improve build efficiency

### DIFF
--- a/application/Dockerfile
+++ b/application/Dockerfile
@@ -4,14 +4,11 @@ FROM ubuntu:24.04 as builder
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install -y software-properties-common
-
-RUN add-apt-repository ppa:deadsnakes/ppa
-
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa && \
 # Install necessary packages and Python
-RUN apt-get update && \
+    apt-get update && \
     apt-get install -y --no-install-recommends gcc wget unzip libc6-dev python3.11 python3.11-distutils python3.11-venv && \
-    apt-get clean && \
     rm -rf /var/lib/apt/lists/* 
 
 # Verify Python installation and setup symlink
@@ -50,12 +47,10 @@ RUN pip install --no-cache-dir --upgrade pip && \
 FROM ubuntu:24.04 as final
 
 RUN apt-get update && \
-    apt-get install -y software-properties-common
-
-RUN add-apt-repository ppa:deadsnakes/ppa
-
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa && \
 # Install Python
-RUN apt-get update && apt-get install -y --no-install-recommends python3.11 && \
+    apt-get update && apt-get install -y --no-install-recommends python3.11 && \
     ln -s /usr/bin/python3.11 /usr/bin/python && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION


- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

	Optimization of Dockerfile to reduce image size and improve build efficiency.

- **Why was this change needed?** (You can also link to an open issue here)

	This change aims to reduce Docker image size and enhance build efficiency. By merging apt-related RUN commands, we consolidate cleanup operations within the same layer, effectively reducing image size. Additionally, we removed the redundant apt-get clean command, as this operation is automatically handled in the Ubuntu base image.

- **Other information**:

	The reason why to remove `apt-get clean` is based on Docker's official best practices guide. More details can be found at:
	- https://docs.docker.com/build/building/best-practices/#apt-get

	These changes not only reduce image size but also improve the efficiency of the build process, positively impacting continuous integration and deployment workflows.