### PR TITLE
React Widget: Fix for Next.js

### DIFF
--- a/extensions/react-widget/src/main.tsx
+++ b/extensions/react-widget/src/main.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { DocsGPTWidget } from './components/DocsGPTWidget';
 
-
-const renderWidget = (elementId: string, props = {}) => {
-  const root = createRoot(document.getElementById(elementId) as HTMLElement);
-  root.render(<DocsGPTWidget {...props} />);
-};
-
-(window as any).renderDocsGPTWidget = renderWidget;
+if (typeof window !== 'undefined') {
+  const renderWidget = (elementId: string, props = {}) => {
+    const root = createRoot(document.getElementById(elementId) as HTMLElement);
+    root.render(<DocsGPTWidget {...props} />);
+  };
+  (window as any).renderDocsGPTWidget = renderWidget;
+}
 export { DocsGPTWidget };


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  * Fixes, window is not defined error
  * Renders window conditionally only if the typeof window is not undefined, the use of windows may cause conflict in server side.
- **Why was this change needed?** (You can also link to an open issue here)
  * Compatibility with web frameworks