### PR TITLE
React-widget: Adding "large" option for widget size

### DIFF
--- a/extensions/react-widget/package.json
+++ b/extensions/react-widget/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "build": "parcel build src/main.tsx --public-url ./",
-    "build:react": "parcel build index.ts",
+    "build:react": "parcel build src/index.ts",
     "dev": "parcel src/index.html -p 3000",
     "test": "jest",
     "lint": "eslint",

--- a/extensions/react-widget/package.json
+++ b/extensions/react-widget/package.json
@@ -31,6 +31,7 @@
   },
   "scripts": {
     "build": "parcel build src/main.tsx --public-url ./",
+    "build:react": "parcel build index.ts",
     "dev": "parcel src/index.html -p 3000",
     "test": "jest",
     "lint": "eslint",

--- a/extensions/react-widget/publish.sh
+++ b/extensions/react-widget/publish.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
-## chmod +x publish.sh   - to upgrade ownership
-# Exit immediately if a command exits with a non-zero status.
+## chmod +x publish.sh - to upgrade ownership
 set -e
-
-# Define the function to update package.json and publish the package
 cat package.json >> package_copy.json
 publish_package() {
   PACKAGE_NAME=$1
@@ -11,29 +8,29 @@ publish_package() {
   # Update package name in package.json
   jq --arg name "$PACKAGE_NAME" '.name=$name' package.json > temp.json && mv temp.json package.json
 
-  # Remove 'target' key if the package name is 'widget-react'
+  # Remove 'target' key if the package name is 'docsgpt-react'
   if [ "$PACKAGE_NAME" = "docsgpt-react" ]; then
     jq 'del(.targets)' package.json > temp.json && mv temp.json package.json
   fi
+
   if [ -d "dist" ]; then
     echo "Deleting existing dist directory..."
     rm -rf dist
   fi
-  # Increment version (patch by default)
-  #npm version patch
 
-  # Run the build command
+  npm version patch
+
   npm run "$BUILD_COMMAND"
 
   # Publish to npm
-  npm pack
+  npm publish
   echo "Published ${PACKAGE_NAME}"
 }
 
-# Publish widget package
+# Publish docsgpt package
 publish_package "docsgpt" "build"
 
-# Publish widget-react package
+# Publish docsgpt-react package
 publish_package "docsgpt-react" "build:react"
 
 # Clean up

--- a/extensions/react-widget/publish.sh
+++ b/extensions/react-widget/publish.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+## chmod +x publish.sh   - to upgrade ownership
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Define the function to update package.json and publish the package
+cat package.json >> package_copy.json
+publish_package() {
+  PACKAGE_NAME=$1
+  BUILD_COMMAND=$2
+  # Update package name in package.json
+  jq --arg name "$PACKAGE_NAME" '.name=$name' package.json > temp.json && mv temp.json package.json
+
+  # Remove 'target' key if the package name is 'widget-react'
+  if [ "$PACKAGE_NAME" = "docsgpt-react" ]; then
+    jq 'del(.targets)' package.json > temp.json && mv temp.json package.json
+  fi
+  if [ -d "dist" ]; then
+    echo "Deleting existing dist directory..."
+    rm -rf dist
+  fi
+  # Increment version (patch by default)
+  #npm version patch
+
+  # Run the build command
+  npm run "$BUILD_COMMAND"
+
+  # Publish to npm
+  npm pack
+  echo "Published ${PACKAGE_NAME}"
+}
+
+# Publish widget package
+publish_package "docsgpt" "build"
+
+# Publish widget-react package
+publish_package "docsgpt-react" "build:react"
+
+# Clean up
+mv package_copy.json package.json
+rm -rf package_copy.json
+echo "---Process completed---"

--- a/extensions/react-widget/src/components/DocsGPTWidget.tsx
+++ b/extensions/react-widget/src/components/DocsGPTWidget.tsx
@@ -100,7 +100,7 @@ const StyledContainer = styled.div`
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05), 0 2px 4px rgba(0, 0, 0, 0.1);
     transition: visibility 0.3s, opacity 0.3s;
 `;
-const FloatingButton = styled.div<{ bgColor: string }>`
+const FloatingButton = styled.div<{ bgcolor: string }>`
     position: fixed;
     display: flex;
     z-index: 500;
@@ -111,7 +111,7 @@ const FloatingButton = styled.div<{ bgColor: string }>`
     width: 5rem;
     height: 5rem;
     border-radius: 9999px;
-    background: ${props => props.bgColor};
+    background: ${props => props.bgcolor};
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
     cursor: pointer;
     &:hover {
@@ -431,10 +431,10 @@ export const DocsGPTWidget = ({
           setOpen(false)
         }} />
       }
-      <FloatingButton bgColor={buttonBg} onClick={() => setOpen(!open)} hidden={open}>
+      <FloatingButton bgcolor={buttonBg} onClick={() => setOpen(!open)} hidden={open}>
         <img style={{ maxHeight: '4rem', maxWidth: '4rem' }} src={buttonIcon} />
       </FloatingButton>
-      <WidgetContainer modal={size === 'large'}>
+      <WidgetContainer modal={size == 'large'}>
         <GlobalStyles />
         {open && <StyledContainer>
           <div>

--- a/extensions/react-widget/src/types/index.ts
+++ b/extensions/react-widget/src/types/index.ts
@@ -19,7 +19,7 @@ export interface WidgetProps {
   description?: string;
   heroTitle?: string;
   heroDescription?: string;
-  size?: 'small' | 'medium';
+  size?: 'small' | 'medium' | 'large';
   theme?:THEME,
   buttonIcon?:string;
   buttonBg?:string;


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
   * adding "large" option for widget size prop.
   * adding publish.sh to automate the process for publishing docsgpt-react and docsgpt npm packages simultaneously.
   
![image](https://github.com/user-attachments/assets/57be5810-95d4-436e-8d4e-a11b7df1aa85)

- **Why was this change needed?** (You can also link to an open issue here)
   * More flexible sizes for integrating widgets to client web apps.
- **Other information**:
   To test publish.sh
    * Run `./publish.sh`
    * Run `chmod +x publish.sh` if the ownership conflicts on system.