### PR TITLE
Refining the scrolling functionality while streaming

### DIFF
--- a/extensions/react-widget/package-lock.json
+++ b/extensions/react-widget/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docsgpt",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docsgpt",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/plugin-transform-flow-strip-types": "^7.23.3",

--- a/extensions/react-widget/package.json
+++ b/extensions/react-widget/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "docsgpt",
-  "version": "0.4.1",
+  "name": "docsgpt-react",
+  "version": "0.4.2",
   "private": false,
   "description": "DocsGPT 🦖 is an innovative open-source tool designed to simplify the retrieval of information from project documentation using advanced GPT models 🤖.",
   "source": "./src/index.html",
@@ -11,18 +11,6 @@
     "dist",
     "package.json"
   ],
-  "targets": {
-    "modern": {
-      "engines": {
-        "browsers": "Chrome 80"
-      }
-    },
-    "legacy": {
-      "engines": {
-        "browsers": "> 0.5%, last 2 versions, not dead"
-      }
-    }
-  },
   "@parcel/resolver-default": {
     "packageExports": true
   },

--- a/extensions/react-widget/publish.sh
+++ b/extensions/react-widget/publish.sh
@@ -2,6 +2,7 @@
 ## chmod +x publish.sh - to upgrade ownership
 set -e
 cat package.json >> package_copy.json
+cat package-lock.json >> package-lock_copy.json
 publish_package() {
   PACKAGE_NAME=$1
   BUILD_COMMAND=$2
@@ -24,6 +25,9 @@ publish_package() {
 
   # Publish to npm
   npm publish
+  # Clean up
+  mv package_copy.json package.json
+  mv package-lock_copy.json package-lock.json
   echo "Published ${PACKAGE_NAME}"
 }
 
@@ -33,7 +37,7 @@ publish_package "docsgpt" "build"
 # Publish docsgpt-react package
 publish_package "docsgpt-react" "build:react"
 
-# Clean up
-mv package_copy.json package.json
+
 rm -rf package_copy.json
+rm -rf package-lock_copy.json
 echo "---Process completed---"

--- a/frontend/src/conversation/Conversation.tsx
+++ b/frontend/src/conversation/Conversation.tsx
@@ -68,7 +68,7 @@ export default function Conversation() {
   const scrollIntoView = () => {
     if (!conversationRef?.current || eventInterrupt) return;
 
-    if (status === 'idle') {
+    if (status === 'idle' || !queries[queries.length - 1].response) {
       conversationRef.current.scrollTo({
         behavior: 'smooth',
         top: conversationRef.current.scrollHeight,

--- a/frontend/src/conversation/ConversationBubble.tsx
+++ b/frontend/src/conversation/ConversationBubble.tsx
@@ -250,7 +250,10 @@ const ConversationBubble = forwardRef<
                       </div>
                     </div>
                   ) : (
-                    <code className={className ? className : ''} {...props}>
+                    <code
+                      className={className ? className : 'whitespace-pre-line'}
+                      {...props}
+                    >
                       {children}
                     </code>
                   );


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
     * As per the current logic, the `endMessageRef` was referred while scrolling
     * In this PR, referring to the `conversationRef` alone to control scrolling
     * The `scrollIntoView` method should handle the following cases:
         - When the status is `idle` or a new  prompt is just added: Smoothly scroll to the bottom of `conversationRef`
         - While streaming: when the response is getting generated, the scroll should stick to the bottom of the conversation container, to make the streaming more consistent.
- **Why was this change needed?** (You can also link to an open issue here)
    * Frictionless streaming.
- **Other information**:
  Fixed the overflow of code, without any language match.
  Minor change in react-widget/publish.sh : Refresh the package json and package-lock after each publish