### PR TITLE
fix: updated docker execution script from `docker-compose` to `docker…

### DIFF
--- a/run-with-docker-compose.sh
+++ b/run-with-docker-compose.sh
@@ -4,8 +4,8 @@ source .env
 
 if [[ -n "$OPENAI_API_BASE" ]] && [[ -n "$OPENAI_API_VERSION" ]] && [[ -n "$AZURE_DEPLOYMENT_NAME" ]] && [[ -n "$AZURE_EMBEDDINGS_DEPLOYMENT_NAME" ]]; then
   echo "Running Azure Configuration"
-  docker-compose -f docker-compose-azure.yaml build && docker-compose -f docker-compose-azure.yaml up
+  docker compose -f docker-compose-azure.yaml build && docker compose -f docker-compose-azure.yaml up
 else
   echo "Running Plain Configuration"
-  docker-compose build && docker-compose up
+  docker compose build && docker compose up
 fi


### PR DESCRIPTION
… compose` so it works on latest versions of docker used across contributors machine

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **Why was this change needed?** (You can also link to an open issue here)
It's very likely the majority has migrated to Docker V2. The update is required for running docker files in latest version.

- **Other information**: