### PR TITLE
Feat(1169): Handle state of empty tables

### DIFF
--- a/frontend/src/locale/en.json
+++ b/frontend/src/locale/en.json
@@ -62,7 +62,8 @@
       "name": "Name",
       "key": "API Key",
       "sourceDoc": "Source Document",
-      "createNew": "Create New"
+      "createNew": "Create New",
+      "noData": "No existing Chatbots"
     },
     "analytics": {
       "label": "Analytics"

--- a/frontend/src/locale/en.json
+++ b/frontend/src/locale/en.json
@@ -54,7 +54,8 @@
       "name": "Document Name",
       "date": "Vector Date",
       "type": "Type",
-      "tokenUsage": "Token Usage"
+      "tokenUsage": "Token Usage",
+      "noData": "No existing Documents"
     },
     "apiKeys": {
       "label": "Chatbots",

--- a/frontend/src/locale/es.json
+++ b/frontend/src/locale/es.json
@@ -54,7 +54,8 @@
       "name": "Nombre del Documento",
       "date": "Fecha Vector",
       "type": "Tipo",
-      "tokenUsage": "Uso de Tokens"
+      "tokenUsage": "Uso de Tokens",
+      "noData": "No hay documentos existentes"
     },
     "apiKeys": {
       "label": "Chatbots",

--- a/frontend/src/locale/es.json
+++ b/frontend/src/locale/es.json
@@ -62,7 +62,8 @@
       "name": "Nombre",
       "key": "Clave de API",
       "sourceDoc": "Documento Fuente",
-      "createNew": "Crear Nuevo"
+      "createNew": "Crear Nuevo",
+      "noData": "No hay chatbots existentes"
     },
     "analytics": {
       "label": "Analítica"

--- a/frontend/src/locale/jp.json
+++ b/frontend/src/locale/jp.json
@@ -54,7 +54,8 @@
       "name": "ドキュメント名",
       "date": "ベクトル日付",
       "type": "タイプ",
-      "tokenUsage": "トークン使用量"
+      "tokenUsage": "トークン使用量",
+      "noData": "既存のドキュメントはありません"
     },
     "apiKeys": {
       "label": "チャットボット",

--- a/frontend/src/locale/jp.json
+++ b/frontend/src/locale/jp.json
@@ -62,7 +62,8 @@
       "name": "名前",
       "key": "APIキー",
       "sourceDoc": "ソースドキュメント",
-      "createNew": "新規作成"
+      "createNew": "新規作成",
+      "noData": "既存のチャットボットはありません"
     },
     "analytics": {
       "label": "分析"

--- a/frontend/src/locale/zh.json
+++ b/frontend/src/locale/zh.json
@@ -62,7 +62,8 @@
       "name": "名称",
       "key": "API 密钥",
       "sourceDoc": "源文档",
-      "createNew": "创建新的"
+      "createNew": "创建新的",
+      "noData": "没有现有的聊天机器人"
     },
     "analytics": {
       "label": "分析"

--- a/frontend/src/locale/zh.json
+++ b/frontend/src/locale/zh.json
@@ -54,7 +54,8 @@
       "name": "文件名称",
       "date": "向量日期",
       "type": "类型",
-      "tokenUsage": "令牌使用"
+      "tokenUsage": "令牌使用",
+      "noData": "没有现有的文档"
     },
     "apiKeys": {
       "label": "聊天机器人",

--- a/frontend/src/settings/APIKeys.tsx
+++ b/frontend/src/settings/APIKeys.tsx
@@ -118,7 +118,7 @@ export default function APIKeys() {
               <tbody>
                 {!apiKeys?.length && (
                   <tr>
-                    <td colSpan={4} className="border-r border-t p-4">
+                    <td colSpan={4} className="border-t p-4">
                       {t('settings.apiKeys.noData')}
                     </td>
                   </tr>

--- a/frontend/src/settings/APIKeys.tsx
+++ b/frontend/src/settings/APIKeys.tsx
@@ -116,6 +116,13 @@ export default function APIKeys() {
                 </tr>
               </thead>
               <tbody>
+                {!apiKeys?.length && (
+                  <tr>
+                    <td colSpan={4} className="border-r border-t p-4">
+                      {t('settings.apiKeys.noData')}
+                    </td>
+                  </tr>
+                )}
                 {apiKeys?.map((element, index) => (
                   <tr key={index}>
                     <td className="border-r border-t p-4">{element.name}</td>

--- a/frontend/src/settings/Documents.tsx
+++ b/frontend/src/settings/Documents.tsx
@@ -76,7 +76,7 @@ const Documents: React.FC<DocumentsProps> = ({
             <tbody>
               {!documents?.length && (
                 <tr>
-                  <td colSpan={5} className="border-r border-t p-4">
+                  <td colSpan={5} className="border-t p-4">
                     {t('settings.documents.noData')}
                   </td>
                 </tr>

--- a/frontend/src/settings/Documents.tsx
+++ b/frontend/src/settings/Documents.tsx
@@ -74,6 +74,13 @@ const Documents: React.FC<DocumentsProps> = ({
               </tr>
             </thead>
             <tbody>
+              {!documents?.length && (
+                <tr>
+                  <td colSpan={5} className="border-r border-t p-4">
+                    {t('settings.documents.noData')}
+                  </td>
+                </tr>
+              )}
               {documents &&
                 documents.map((document, index) => (
                   <tr key={index}>


### PR DESCRIPTION
- **What kind of change does this PR introduce?**  
  Feature update: Added a "No existing ..." messages in multiple locales (English, Spanish, Japanese, and Chinese), and updated both the `APIKeys.tsx` and `Documents.tsx` components to display a message when there are no API keys or documents available.

- **Why was this change needed?**  
  related to #1169. This change was needed to improve user experience by providing feedback when there are no existing chatbots or documents in their respective sections, ensuring users are clearly informed when no data is available across multiple languages.

- **Other information**:  
![image](https://github.com/user-attachments/assets/9cdc6e1a-fcd3-4a71-ab69-f234cf115e5e)
