### PR TITLE
Bug Fix: Crash, abnormal update while switching conversation Ids

### DIFF
--- a/frontend/src/conversation/Conversation.tsx
+++ b/frontend/src/conversation/Conversation.tsx
@@ -55,10 +55,6 @@ export default function Conversation() {
   }, []);
 
   useEffect(() => {
-    fetchStream.current && fetchStream.current.abort();
-  }, [conversationId]);
-
-  useEffect(() => {
     if (queries.length) {
       queries[queries.length - 1].error && setLastQueryReturnedErr(true);
       queries[queries.length - 1].response && setLastQueryReturnedErr(false); //considering a query that initially returned error can later include a response property on retry

--- a/frontend/src/conversation/conversationSlice.ts
+++ b/frontend/src/conversation/conversationSlice.ts
@@ -151,6 +151,7 @@ export const conversationSlice = createSlice({
       state,
       action: PayloadAction<{ index: number; query: Partial<Query> }>,
     ) {
+      if (state.status === 'idle') return;
       const { index, query } = action.payload;
       if (query.response != undefined) {
         state.queries[index].response =
@@ -167,6 +168,7 @@ export const conversationSlice = createSlice({
       action: PayloadAction<{ query: Partial<Query> }>,
     ) {
       state.conversationId = action.payload.query.conversationId ?? null;
+      state.status = 'idle';
     },
     updateStreamingSource(
       state,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

    Basically conversationId is updated in two situations:
       1. switching the conversation
       2. streaming when data.type = 'id'

     As per the current flow, there are following bugs:

- While streaming, switching to New Chat, crashes the application
- In case of New Chat, the conversations are not updating in the sidebar

     Fix:
- Pause the update of streaming query without pausing the fetchAnswer middleware explicitly.
             * Set the status as idle for every update to conversationId
             * Append the streaming answer to the response only when the status is not idle.
- **Why was this change needed?** (You can also link to an open issue here)
        - Fixes the root cause of the problem.