### PR TITLE
Removed @vercel/analytics from frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "dependencies": {
         "@reduxjs/toolkit": "^2.2.7",
-        "@vercel/analytics": "^1.3.1",
         "chart.js": "^4.4.4",
         "i18next": "^23.15.1",
         "i18next-browser-languagedetector": "^8.0.0",
@@ -2088,26 +2087,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
-    },
-    "node_modules/@vercel/analytics": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.3.1.tgz",
-      "integrity": "sha512-xhSlYgAuJ6Q4WQGkzYTLmXwhYl39sWjoMA3nHxfkvG+WdBT25c563a7QhwwKivEOZtPJXifYHR1m2ihoisbWyA==",
-      "dependencies": {
-        "server-only": "^0.0.1"
-      },
-      "peerDependencies": {
-        "next": ">= 13",
-        "react": "^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "next": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.3.1",
@@ -8450,11 +8429,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/server-only": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
-      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "^2.2.7",
-    "@vercel/analytics": "^1.3.1",
     "chart.js": "^4.4.4",
     "i18next": "^23.15.1",
     "i18next-browser-languagedetector": "^8.0.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,6 @@ import Navigation from './Navigation';
 import Conversation from './conversation/Conversation';
 import About from './About';
 import PageNotFound from './PageNotFound';
-import { inject } from '@vercel/analytics';
 import { useMediaQuery } from './hooks';
 import { useState } from 'react';
 import Setting from './settings';
@@ -11,7 +10,6 @@ import './locale/i18n';
 import { Outlet } from 'react-router-dom';
 import { SharedConversation } from './conversation/SharedConversation';
 import { useDarkTheme } from './hooks';
-inject();
 
 function MainLayout() {
   const { isMobile } = useMediaQuery();


### PR DESCRIPTION
Removed @vercel/analytics from frontend due to being flagged by AdBlocker, causing rendering issues in the development.
(It is not affecting in Cloud version, neither in build)

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    - Uninstalled @vercel/analytics from the frontend only also removed importing statement of inject and calling it.

- **Why was this change needed?** (You can also link to an open issue here)
    - It was affecting rendering and no error in the console (check the Screenshots) if the AdBlocker extension is enabled, but it starts rendering if you disable it, so if someone is not aware of might be time taking process and check for various setup if it is problem with that. 

- **Other information**:
![norendering](https://github.com/user-attachments/assets/08a02cc8-956d-4343-916b-da6d3cdf5f6c)
![consolemsges](https://github.com/user-attachments/assets/66aa499f-19c1-4f48-9e4e-4e0baa8ad1c8)
