### PR TITLE
Update localhost port to 3000 in readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,6 @@ yarn install
 yarn dev
 ```
 
-- Now, you should be able to view the docs on your local environment by visiting `http://localhost:5000`. You can explore the different markdown files and make changes as you see fit.
+- Now, you should be able to view the docs on your local environment by visiting `http://localhost:3000`. You can explore the different markdown files and make changes as you see fit.
 
 - **Footnotes:** This guide assumes you have Node.js and npm installed. The guide involves running a local server using yarn, and viewing the documentation offline. If you encounter any issues, it may be worth verifying your Node.js and npm installations and whether you have installed yarn correctly.


### PR DESCRIPTION
Yarn dev by default runs the application on port 3000. Changed the port accordingly in readme to maintain consistency.

- **What kind of change does this PR introduce?** (
Docs Update

- **Why was this change needed?**
Docs were inconsistent with actual behaviour.
Fixes #1250

- **Other information**:
None