### PR TITLE
docs(extensions, chrome): Improve Grammar and Clarity in Localization JSON File

### DIFF
--- a/extensions/chrome/_locales/en/messages.json
+++ b/extensions/chrome/_locales/en/messages.json
@@ -8,11 +8,11 @@
     ,"description":"Header text for the localization section"
   }
   ,"l10nIntro": {
-    "message":"'L10n' refers to 'Localization' - 'L' an 'n' are obvious, and 10 comes from the number of letters between those two.  It is the process/whatever of displaying something in the language of choice.  It uses 'I18n', 'Internationalization', which refers to the tools / framework supporting L10n.  I.e., something is internationalized if it has I18n support, and can be localized.  Something is localized for you if it is in your language / dialect."
+    "message":"'L10n' refers to 'Localization' - 'L' and 'n' are obvious, and 10 comes from the number of letters between those two.  It is the process/whatever of displaying something in the language of choice.  It uses 'I18n', 'Internationalization', which refers to the tools / framework supporting L10n.  I.e., something is internationalized if it has I18n support, and can be localized.  Something is localized for you if it is in your language / dialect."
     ,"description":"introduce the basic idea."
   }
   ,"l10nProd": {
-    "message":"You <strong>are</strong> planning to allow localization, right?  You have <em>no idea</em> who will be using your extension!  You have no idea who will be translating it!  At least support the basics, it's not hard, and having the framework in place will let you transition much more easily later on."
+    "message":"You <strong>are</strong> planning to allow localization, right?  You have <em>no idea</em> who will be using your extension or who will be translating it! At least support the basics; it's not hard, and having the framework in place will let you transition much more easily later on."
     ,"description":"drive the point home.  It's good for you."
   }
   ,"l10nFirstParagraph": {
@@ -20,7 +20,7 @@
     ,"description":"inform that <el data-l10n='' /> elements will be localized on load"
   }
   ,"l10nSecondParagraph": {
-    "message":"If you need more complex localization, you can also define <strong>data-l10n-args</strong>.  This should contain <span class='code'>$containerType$</span> filled with <span class='code'>$dataType$</span>, which will be passed into Chrome's i18n API as <span class='code'>$functionArgs$</span>.  In fact, this paragraph does just that, and wraps the args in mono-space font.  Easy!"
+    "message":"If you need more complex localization, you can also define <strong>data-l10n-args</strong>. It should contain a <span class='code'>$containerType$</span> filled with <span class='code'>$dataType$</span>, which will be passed into Chrome's i18n API as <span class='code'>$functionArgs$</span>.  In fact, this paragraph does just that, and wraps the args in mono-space font.  Easy!"
     ,"description":"introduce the data-l10n-args attribute.  End on a lame note."
     ,"placeholders": {
       "containerType": {
@@ -45,7 +45,7 @@
     ,"description":"inform that we handle placeholders, buttons, and direct HTML input"
   }
   ,"l10nButtonsBefore": {
-    "message":"Different types of buttons are handled as well.  &lt;button&gt; elements have their html set:"
+    "message":"Different types of buttons are handled as well.  &lt;button&gt; elements have their HTML set:"
   }
   ,"l10nButton": {
     "message":"in a <strong>button</strong>"
@@ -57,7 +57,7 @@
     "message":"a <strong>submit</strong> value"
   }
   ,"l10nButtonsAfter": {
-    "message":"Awesome, no?"
+    "message":"Pretty awesome, right?"
   }
   ,"l10nExtras": {
     "message":"You can even set <span class='code'>data-l10n</span> on things like the &lt;title&gt; tag, which lets you have translatable page titles, or fieldset &lt;legend&gt; tags, or anywhere else - the default <span class='code'>Boil.localize()</span> behavior will check every tag in the document, not just the body."


### PR DESCRIPTION
### What kind of change does this PR introduce?
- **Type of Change**: Documentation update

### Why was this change needed?
While I was exploring and trying to understand the codebase, I noticed some localization messages in `messages.json` that could benefit from clearer grammar and punctuation. These small updates will enhance readability and ensure the content is more accessible for everyone.

### Other information
- This PR focuses solely on improving the documentation, with no functional changes, so no additional testing is required. I believe these enhancements will positively impact user experience and aid future contributors.
