### PR TITLE
fix: hard breaking long string words and intelligent word breaks

### DIFF
--- a/frontend/src/conversation/ConversationBubble.tsx
+++ b/frontend/src/conversation/ConversationBubble.tsx
@@ -61,7 +61,7 @@ const ConversationBubble = forwardRef<
         <Avatar className="mt-2 text-2xl" avatar="🧑‍💻"></Avatar>
         <div
           style={{
-            'word-break': 'break-word',
+            wordBreak: 'break-word',
           }}
           className="ml-10 mr-2 flex items-center rounded-[28px] bg-purple-30 py-[14px] px-[19px] text-white max-w-full whitespace-pre-wrap leading-normal"
         >


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix readability of user contents and overflow of long string characters with no whitespace nor hyphen

- **Why was this change needed?** (You can also link to an open issue here)
Improves reading XP.

- **Other information**:
For a full video review of the fix as it's a bit controversial—considering a legacy approach was used—kindly click on the link below:

https://drive.google.com/file/d/1_XY7y2yaQkX1rp_U3EkcNf8HnQTL_wYa/view?usp=sharing

closes: https://github.com/arc53/DocsGPT/issues/1222