### PR TITLE
Bugfix/859 large zip breaking stream endpoint

### DIFF
--- a/application/parser/file/rst_parser.py
+++ b/application/parser/file/rst_parser.py
@@ -93,37 +93,14 @@ class RstParser(BaseParser):
 
     def chunk_by_token_count(self, text: str, max_tokens: int = 100) -> List[str]:
         """Chunk text by token count."""
-        # words = text.split()
-        # chunks = []
-        # current_chunk = []
-        # current_token_count = 0
-
-        # for word in words:
-        #     word_token_len = len(word.split())  # Token count
-        #     if current_token_count + word_token_len > max_tokens:
-        #         chunks.append(" ".join(current_chunk))
-        #         current_chunk = []
-        #         current_token_count = 0
-        #     current_chunk.append(word)
-        #     current_token_count += word_token_len
-
-        # if current_chunk:
-        #     chunks.append(" ".join(current_chunk))
-
-        # return chunks
     
-
         avg_token_length = 5
     
-        # Calculate approximate chunk size in characters
         chunk_size = max_tokens * avg_token_length
-        
-        # Split text into chunks
+
         chunks = []
         for i in range(0, len(text), chunk_size):
             chunk = text[i:i+chunk_size]
-            
-            # Adjust chunk to end at a word boundary
             if i + chunk_size < len(text):
                 last_space = chunk.rfind(' ')
                 if last_space != -1:


### PR DESCRIPTION
- **What kind of change does this PR introduce?** 
-> Bug Fix

- **Why was this change needed?** 
-> This change addresses the issue where the stream endpoint fails to provide an answer when the embedded file in a zip archive is too long (see issue #859). The problem arises from the RstParser class not properly handling files without headers, leading to stream endpoint breaks. The implementation needs to be updated to chunk files based on token size rather than solely relying on headers.
