### PR TITLE
refactor(user/routes): simplify parsing of isPromptable

### DIFF
--- a/application/api/user/routes.py
+++ b/application/api/user/routes.py
@@ -7,7 +7,7 @@ from bson.binary import Binary, UuidRepresentation
 from bson.dbref import DBRef
 from bson.objectid import ObjectId
 from flask import Blueprint, jsonify, make_response, request
-from flask_restx import fields, Namespace, Resource
+from flask_restx import inputs, fields, Namespace, Resource
 from pymongo import MongoClient
 from werkzeug.utils import secure_filename
 
@@ -802,7 +802,7 @@ class ShareConversation(Resource):
         if missing_fields:
             return missing_fields
 
-        is_promptable = request.args.get("isPromptable")
+        is_promptable = request.args.get("isPromptable", type=inputs.boolean)
         if is_promptable is None:
             return make_response(
                 jsonify({"success": False, "message": "isPromptable is required"}), 400
@@ -831,7 +831,7 @@ class ShareConversation(Resource):
                 uuid.uuid4(), UuidRepresentation.STANDARD
             )
 
-            if is_promptable.lower() == "true":
+            if is_promptable:
                 prompt_id = data.get("prompt_id", "default")
                 chunks = data.get("chunks", "2")
 
@@ -859,7 +859,7 @@ class ShareConversation(Resource):
                             "conversation_id": DBRef(
                                 "conversations", ObjectId(conversation_id)
                             ),
-                            "isPromptable": is_promptable.lower() == "true",
+                            "isPromptable": is_promptable,
                             "first_n_queries": current_n_queries,
                             "user": user,
                             "api_key": api_uuid,
@@ -883,7 +883,7 @@ class ShareConversation(Resource):
                                     "$ref": "conversations",
                                     "$id": ObjectId(conversation_id),
                                 },
-                                "isPromptable": is_promptable.lower() == "true",
+                                "isPromptable": is_promptable,
                                 "first_n_queries": current_n_queries,
                                 "user": user,
                                 "api_key": api_uuid,
@@ -918,7 +918,7 @@ class ShareConversation(Resource):
                                 "$ref": "conversations",
                                 "$id": ObjectId(conversation_id),
                             },
-                            "isPromptable": is_promptable.lower() == "true",
+                            "isPromptable": is_promptable,
                             "first_n_queries": current_n_queries,
                             "user": user,
                             "api_key": api_uuid,
@@ -939,7 +939,7 @@ class ShareConversation(Resource):
                     "conversation_id": DBRef(
                         "conversations", ObjectId(conversation_id)
                     ),
-                    "isPromptable": is_promptable.lower() == "false",
+                    "isPromptable": not is_promptable,
                     "first_n_queries": current_n_queries,
                     "user": user,
                 }
@@ -962,7 +962,7 @@ class ShareConversation(Resource):
                             "$ref": "conversations",
                             "$id": ObjectId(conversation_id),
                         },
-                        "isPromptable": is_promptable.lower() == "false",
+                        "isPromptable": not is_promptable,
                         "first_n_queries": current_n_queries,
                         "user": user,
                     }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Refactoring

- **Why was this change needed?** (You can also link to an open issue here)

We can use the `inputs.boolean` from flask-restx [^1] to parse boolean for us. This way `is_promptable` is a `bool` variable and not a `str` variable so we don't need to do `.lower() == "true"` everywhere.

[^1]: https://flask-restx.readthedocs.io/en/latest/api.html?highlight=boolean#flask_restx.inputs.boolean

- **Other information**: