### PR TITLE
Configure Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
     directory: "/frontend" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

CI update

- **Why was this change needed?** (You can also link to an open issue here)

Many of the actions used in our workflows are outdated because they use Node 16. As announced on 25 September 2024, GitHub has officially deprecated support for Node 16 actions, see https://github.blog/changelog/2024-09-25-end-of-life-for-actions-node16/).

![image](https://github.com/user-attachments/assets/90683ced-a7a6-4f81-b9a4-b3408ab2d6e8)

- **Other information**:

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot