### PR TITLE
Add pa11y-ci accessibility check for frontend

### DIFF
--- a/.github/workflows/pa11y-ci.yaml
+++ b/.github/workflows/pa11y-ci.yaml
@@ -1,0 +1,32 @@
+name: pa11y-ci
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  pa11y-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        working-directory: frontend
+        run: |
+          npm ci
+          npm install -g https://github.com/aarongoldenthal/pa11y-ci
+      - name: Build
+        working-directory: frontend
+        run: npm run build
+      - name: Start Preview
+        working-directory: frontend
+        run: |
+          npm run preview & sleep 3
+      - name: Run pa11y-ci
+        working-directory: frontend
+        run: pa11y-ci
+        continue-on-error: true

--- a/frontend/.pa11yci
+++ b/frontend/.pa11yci
@@ -1,0 +1,7 @@
+{
+    "urls": [
+      "http://localhost:4173",
+      "http://localhost:4173/about",
+      "http://localhost:4173/settings"
+    ]
+}


### PR DESCRIPTION
Closes #1304

- I used pa11y-ci fork from https://github.com/aarongoldenthal/pa11y-ci, due to the lack of maintenance on the original project.
