### PR TITLE
Bug fix: /api/share route 

### DIFF
--- a/application/api/user/routes.py
+++ b/application/api/user/routes.py
@@ -939,7 +939,7 @@ class ShareConversation(Resource):
                     "conversation_id": DBRef(
                         "conversations", ObjectId(conversation_id)
                     ),
-                    "isPromptable": not is_promptable,
+                    "isPromptable": is_promptable,
                     "first_n_queries": current_n_queries,
                     "user": user,
                 }
@@ -962,7 +962,7 @@ class ShareConversation(Resource):
                             "$ref": "conversations",
                             "$id": ObjectId(conversation_id),
                         },
-                        "isPromptable": not is_promptable,
+                        "isPromptable": is_promptable,
                         "first_n_queries": current_n_queries,
                         "user": user,
                     }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  * Steps to reproduce this bug:
         1. Create a conversation
         2. Create a shared link for the conversation, with enable allow users to prompt further
         3. Create another shared link for the conversation, this time disable the option to prompt further
     
  * Current behaviour: The same uuid is assigned to both the shared conversations 
  * Expected behaviour: A shared conversation which is promptable with a particular doc should be unique avoiding redundant entries; while a non-promptable shared conversation should also be unique but distinct from a promptable one

- **Why was this change needed?** (You can also link to an open issue here)
     Avoids ambiguity in the behaviour of shared conversations.