### PR TITLE
hotfix: Added missing file extension `.xlsx` for file processing and recognition

### DIFF
--- a/application/api/user/routes.py
+++ b/application/api/user/routes.py
@@ -340,6 +340,7 @@ class UploadFile(Resource):
                         ".epub",
                         ".html",
                         ".mdx",
+                        ".xlsx",
                     ],
                     job_name,
                     final_filename,

--- a/frontend/src/locale/en.json
+++ b/frontend/src/locale/en.json
@@ -86,7 +86,7 @@
       "start": "Start Chatting",
       "name": "Name",
       "choose": "Choose Files",
-      "info": "Please upload .pdf, .txt, .rst, .csv, .xlsx, .docx, .md, .zip limited to 25mb",
+      "info": "Please upload .pdf, .txt, .rst, .csv, .xlsx, .docx, .md, .html, .epub, .zip limited to 25mb",
       "uploadedFiles": "Uploaded Files",
       "cancel": "Cancel",
       "train": "Train",

--- a/frontend/src/locale/es.json
+++ b/frontend/src/locale/es.json
@@ -86,7 +86,7 @@
       "start": "Empezar a chatear",
       "name": "Nombre",
       "choose": "Seleccionar Archivos",
-      "info": "Por favor, suba archivos .pdf, .txt, .rst, .docx, .md, .zip limitados a 25 MB",
+      "info": "Por favor, suba archivos .pdf, .txt, .rst, .csv, .xlsx, .docx, .md, .html, .epub, .zip limitados a 25 MB",
       "uploadedFiles": "Archivos Subidos",
       "cancel": "Cancelar",
       "train": "Entrenar",

--- a/frontend/src/locale/zh.json
+++ b/frontend/src/locale/zh.json
@@ -86,7 +86,7 @@
       "start": "开始聊天",
       "name": "名称",
       "choose": "选择文件",
-      "info": "请上传 .pdf, .txt, .rst, .docx, .md, .zip 文件，限 25MB",
+      "info": "请上传 .pdf, .txt, .rst, .csv, .xlsx, .docx, .md, .html, .epub, .zip 文件，限 25MB",
       "uploadedFiles": "已上传文件",
       "cancel": "取消",
       "train": "训练",

--- a/frontend/src/upload/Upload.tsx
+++ b/frontend/src/upload/Upload.tsx
@@ -315,6 +315,8 @@ function Upload({
       'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
         ['.docx'],
       'text/csv': ['.csv'],
+      'text/html': ['.html'],
+      'application/epub+zip': ['.epub'],
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': [
         '.xlsx',
       ],


### PR DESCRIPTION
**Observation:**
In cloud version am able to upload the file but unable to interact with it. However in Open source version am not even able to upload the `.xlsx` files successfully as the backend fails with type error due to the missing extension. Additionally am not able to test in cloud version after some extent due to limit that is recently imposed. Any checks on this is appreciated.

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **Why was this change needed?** (You can also link to an open issue here)
   Added the missing extension on the list and able to successfully upload and interact with `.xlsx` file. #1348 
- **Other information**:
Added the `.epub`, `.html` files to upload as the corresponding parsers are already in place and update the all the locale of the same.
![image](https://github.com/user-attachments/assets/62dcf8fe-6bf5-42f3-adc0-ce8c7c7871cd)
![image](https://github.com/user-attachments/assets/6dc64c50-4dcf-4a03-895e-ad24b95fc176)
