### PR TITLE
Fix alignment of the help button in the navigation bar

### DIFF
--- a/frontend/src/Navigation.tsx
+++ b/frontend/src/Navigation.tsx
@@ -389,10 +389,10 @@ export default function Navigation({ navOpen, setNavOpen }: NavigationProps) {
             </NavLink>
           </div>
           <div className="flex flex-col justify-end text-eerie-black dark:text-white">
-            <div className="flex justify-between items-center px-1 py-1">
+            <div className="flex justify-between items-center py-1">
               <Help />
 
-              <div className="flex items-center gap-1">
+              <div className="flex items-center gap-1 pr-4">
                 <NavLink
                   target="_blank"
                   to={'https://discord.gg/WHJdfbQDR4'}


### PR DESCRIPTION
### Description
This PR fixes the alignment of the help button with the settings button in the navigation bar.

**Before:** 
![image](https://github.com/user-attachments/assets/04c8a676-4c4a-4c34-95a6-765ea5908d4e)

**After:** 
![Captura de tela de 2024-10-23 22-07-29](https://github.com/user-attachments/assets/0cc29bd3-f006-4d36-9f0b-961e9b918411)


Closes #1374
