### PR TITLE
Update run-with-docker-compose.sh

### DIFF
--- a/run-with-docker-compose.sh
+++ b/run-with-docker-compose.sh
@@ -4,8 +4,8 @@ source .env
 
 if [[ -n "$OPENAI_API_BASE" ]] && [[ -n "$OPENAI_API_VERSION" ]] && [[ -n "$AZURE_DEPLOYMENT_NAME" ]] && [[ -n "$AZURE_EMBEDDINGS_DEPLOYMENT_NAME" ]]; then
   echo "Running Azure Configuration"
-  docker compose -f docker-compose-azure.yaml build && docker compose -f docker-compose-azure.yaml up
+  docker compose -f docker-compose-azure.yaml up --build
 else
   echo "Running Plain Configuration"
-  docker compose build && docker compose up
+  docker compose up --build
 fi


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Feature
- **Why was this change needed?** (You can also link to an open issue here)
- This change adds a conditional setup in the Docker Compose configuration to support both Azure-based and default deployments. It allows seamless switching between configurations based on environment variables, improving deployment flexibility and compatibility with Azure services.
- **Other information**:
- The script checks for Azure-specific environment variables to decide which Docker Compose file to use (docker-compose-azure.yaml or docker-compose.yaml). This enhancement streamlines setup by automating configuration selection based on the environment.