### PR TITLE
GenAI eatting image from DOCX

### DIFF
--- a/application/parser/file/docs_parser.py
+++ b/application/parser/file/docs_parser.py
@@ -3,12 +3,20 @@
 Contains parsers for docx, pdf files.
 
 """
-from pathlib import Path
-from typing import Dict
 
+from pathlib import Path
+from typing import Dict, List, Any, Union
+from base64 import b64encode
 from application.parser.file.base_parser import BaseParser
 from application.core.settings import settings
+from docx import Document
+from docx.enum.shape import WD_INLINE_SHAPE_TYPE
 import requests
+import logging
+import sys
+
+logger = logging.getLogger(__name__)
+
 
 class PDFParser(BaseParser):
     """PDF parser."""
@@ -23,9 +31,9 @@ class PDFParser(BaseParser):
             doc2md_service = "https://llm.arc53.com/doc2md"
             # alternatively you can use local vision capable LLM
             with open(file, "rb") as file_loaded:
-                files = {'file': file_loaded}
-                response = requests.post(doc2md_service, files=files)   
-                data = response.json()["markdown"] 
+                files = {"file": file_loaded}
+                response = requests.post(doc2md_service, files=files)
+                data = response.json()["markdown"]
             return data
 
         try:
@@ -63,7 +71,146 @@ class DocxParser(BaseParser):
             import docx2txt
         except ImportError:
             raise ValueError("docx2txt is required to read Microsoft Word files.")
-
+        document = Document(file)
+        docx_content = []
         text = docx2txt.process(file)
+        for block in self.iter_blocks(document):
+            if isinstance(block, str):  # It's plain text
+                docx_content.append(block)
+            elif isinstance(block, list):  # It's a table
+                table_text = "\n".join([" | ".join(row) for row in block])
+                print(f"Appending table: {block}", file=sys.stderr)
+                docx_content.append(table_text)
+            elif isinstance(block, dict):  # It's an image
+                #print(f"Appending image: {block}", file=sys.stderr)
+                docx_content.extend([block["content"]["filename"], block["content"]["image_base64"]])
 
-        return text
+        final_content = "\n\n".join(docx_content)
+        print("Completed parsing file. Final consolidated content:", file=sys.stderr)
+        print(final_content, file=sys.stderr)
+        return final_content
+
+    def iter_blocks(self, document: Document):
+        print("Iterating over document blocks...", file=sys.stderr)
+        if hasattr(document, "paragraphs"):
+            print(
+                f"Document has paragraphs: {len(document.paragraphs)}", file=sys.stderr
+            )
+            for para in document.paragraphs:
+                if para.text.strip():
+                    print(f"Found paragraph: {para.text.strip()}", file=sys.stderr)
+                    yield para.text.strip()
+
+        # check images
+        if hasattr(document, "inline_shapes"):
+            print(
+                f"Document has inline shapes: {len(document.inline_shapes)}",
+                file=sys.stderr,
+            )
+            for shape in document.inline_shapes:
+                """
+                Found inline shape: <docx.shape.InlineShape object at 0x319554a10>
+                Shape type: WD_INLINE_SHAPE_TYPE.PICTURE
+                """
+                for attr in dir(shape):
+                    print(f"Shape attribute: {attr}", file=sys.stderr)
+                    print(
+                        f"Shape attribute value: {getattr(shape, attr)}",
+                        file=sys.stderr,
+                    )
+                if shape.type == WD_INLINE_SHAPE_TYPE.PICTURE:
+                    print("Extracting image from inline shape...", file=sys.stderr)
+                    image_data = self.extract_image_from_shape(shape, document=document)
+                    if image_data:
+                        print(f"Extracted image filename: {image_data['content']['filename']}", file=sys.stderr)
+                        print(f"Base64 snippet: {image_data['content']['image_base64'][:20]}...", file=sys.stderr)
+                        yield image_data
+                    else:
+                        print("No image data extracted.", file=sys.stderr)
+
+        if hasattr(document, "tables"):
+            print(f"Document has tables: {len(document.tables)}", file=sys.stderr)
+            for table in document.tables:
+                table_data = self.extract_table(table)
+                print(f"Found table: {table_data}", file=sys.stderr)
+                yield table_data
+
+        if hasattr(document, "sections"):
+            print(f"Document has sections: {len(document.sections)}", file=sys.stderr)
+            for section in document.sections:
+                if section.header:
+                    print("Found header.", file=sys.stderr)
+                    for paragraph in section.header.paragraphs:
+                        if paragraph.text.strip():
+                            print(
+                                f"Header paragraph: {paragraph.text.strip()}",
+                                file=sys.stderr,
+                            )
+                            yield paragraph.text.strip()
+                if section.footer:
+                    print("Found footer.", file=sys.stderr)
+                    for paragraph in section.footer.paragraphs:
+                        if paragraph.text.strip():
+                            print(
+                                f"Footer paragraph: {paragraph.text.strip()}",
+                                file=sys.stderr,
+                            )
+                            yield paragraph.text.strip()
+
+    def extract_table(self, table) -> str:
+        """
+        This function will return the table data in HTML format.
+        for easy to read format. to LLM
+        """
+        print("Extracting table data with HTML semantics...", file=sys.stderr)
+        table_html = ["<table>"]
+
+        # Add table rows
+        for row in table.rows:
+            row_html = ["<tr>"]
+            for cell in row.cells:
+                tag = "th" if self.is_header_row(row) else "td"
+                cell_text = cell.text.strip()
+                print(f"Extracted cell: {cell_text}", file=sys.stderr)
+                row_html.append(f"<{tag}>{cell_text}</{tag}>")
+            row_html.append("</tr>")
+            table_html.extend(row_html)
+
+        table_html.append("</table>")
+        return "\n".join(table_html)
+
+    def is_header_row(self, row) -> bool:
+        """Determine if the row is a header row (you can customize this logic)."""
+        return all(cell.text.isupper() for cell in row.cells)
+    
+    def extract_image_from_shape(self, shape, document: Document) -> Dict:
+        """Extract image from an inline shape."""
+        try:
+            if shape.type == WD_INLINE_SHAPE_TYPE.PICTURE:
+                print(f"Processing shape: {shape}", file=sys.stderr)
+
+                # Get the relationship ID for the image
+                rId = shape._inline.graphic.graphicData.pic.blipFill.blip.embed
+                print(f"Found relationship ID: {rId}", file=sys.stderr)
+
+                # Fetch the image data from the part relationships
+                image_part = document.part.related_parts[rId]
+                image_data = image_part.blob
+                image_filename = image_part.filename or f"image_{rId}.png"
+
+                # Convert the image to Base64
+                import base64
+                image_base64 = base64.b64encode(image_data).decode("utf-8")
+                print(f"Successfully extracted image: {image_filename}", file=sys.stderr)
+
+                return {
+                    "type": "image",
+                    "content": {
+                        "filename": image_filename,
+                        "image_base64": image_base64,
+                    },
+                }
+        except Exception as e:
+            print(f"Error extracting image: {e}", file=sys.stderr)
+
+        return None

--- a/application/parser/file/image_parser.py
+++ b/application/parser/file/image_parser.py
@@ -3,10 +3,12 @@
 Contains parser for .png, .jpg, .jpeg files.
 
 """
+
 from pathlib import Path
 import requests
+import base64
 from typing import Dict, Union
-
+from urllib.parse import urlparse
 from application.parser.file.base_parser import BaseParser
 
 
@@ -21,7 +23,7 @@ class ImageParser(BaseParser):
         doc2md_service = "https://llm.arc53.com/doc2md"
         # alternatively you can use local vision capable LLM
         with open(file, "rb") as file_loaded:
-            files = {'file': file_loaded}
-            response = requests.post(doc2md_service, files=files)   
-            data = response.json()["markdown"] 
+            files = {"file": file_loaded}
+            response = requests.post(doc2md_service, files=files)
+            data = response.json()["markdown"]
         return data

--- a/application/requirements.txt
+++ b/application/requirements.txt
@@ -67,6 +67,7 @@ pypdf2==3.0.1
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
 python-pptx==1.0.2
+python-docx==1.1.2
 qdrant-client==1.11.0
 redis==5.0.1
 referencing==0.30.2


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

> Chage from docx2txt.process to extract them manually
> Eatting image as Base64 | Table as HTML tag | Text for paragraph

- **Why was this change needed?** (You can also link to an open issue here)

> To using multiple vector store to retrieve correct image as paragraph order instead of zip them by docx2text.process()

- **Other information**:
- Progress the issue is now when we retrieve need to find the way to convert base64 back for AI to understand image
![Screenshot 2024-11-28 at 12 00 19 PM](https://github.com/user-attachments/assets/6c3e996e-ce80-4086-8858-0a50feb40d9f)

@dartpain  let me know if this correct approach or wrong direction