### PR TITLE
style: use underscore for an unused loop variable

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -31,7 +31,7 @@ check_and_start_docker() {
         # Wait for Docker to be fully operational with animated dots
         echo -n "Waiting for Docker to start"
         while ! docker system info > /dev/null 2>&1; do
-            for i in {1..3}; do
+            for _ in {1..3}; do
                 echo -n "."
                 sleep 1
             done


### PR DESCRIPTION
This addresses the SC2034 warning.

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Uses the underscore `_` instead of `i` in the _waiting for docker loop_ in `setup.sh`.

- **Why was this change needed?** (You can also link to an open issue here)
Because of _pure esthetics_. But it also resolved the [`SC2034`](https://www.shellcheck.net/wiki/SC2034) ShellCheck warning.

- **Other information**:
N/A