### PR TITLE
Refactor: Ingestor types for remote resources in Upload Component

### DIFF
--- a/frontend/src/components/Input.tsx
+++ b/frontend/src/components/Input.tsx
@@ -7,6 +7,7 @@ const Input = ({
   value,
   isAutoFocused = false,
   placeholder,
+  label,
   maxLength,
   className,
   colorVariant = 'silver',
@@ -26,21 +27,30 @@ const Input = ({
     thick: 'border-2',
   };
   return (
-    <input
-      className={`h-[42px] w-full rounded-full px-3 py-1 outline-none dark:bg-transparent dark:text-white ${className} ${colorStyles[colorVariant]} ${borderStyles[borderVariant]}`}
-      type={type}
-      id={id}
-      name={name}
-      autoFocus={isAutoFocused}
-      placeholder={placeholder}
-      maxLength={maxLength}
-      value={value}
-      onChange={onChange}
-      onPaste={onPaste}
-      onKeyDown={onKeyDown}
-    >
-      {children}
-    </input>
+    <div className="relative">
+      <input
+        className={`h-[42px] w-full rounded-full px-3 py-1 outline-none dark:bg-transparent dark:text-white ${className} ${colorStyles[colorVariant]} ${borderStyles[borderVariant]}`}
+        type={type}
+        id={id}
+        name={name}
+        autoFocus={isAutoFocused}
+        placeholder={placeholder}
+        maxLength={maxLength}
+        value={value}
+        onChange={onChange}
+        onPaste={onPaste}
+        onKeyDown={onKeyDown}
+      >
+        {children}
+      </input>
+      {label && (
+        <div className="absolute -top-2 left-2">
+          <span className="bg-white px-2 text-xs text-gray-4000 dark:bg-outer-space dark:text-silver">
+            {label}
+          </span>
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/frontend/src/components/ToggleSwitch.tsx
+++ b/frontend/src/components/ToggleSwitch.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+type ToggleSwitchProps = {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  className?: string;
+  label?: string;
+  disabled?: boolean;
+  activeColor?: string;
+  inactiveColor?: string;
+  id?: string;
+};
+
+const ToggleSwitch: React.FC<ToggleSwitchProps> = ({
+  checked,
+  onChange,
+  className = '',
+  label,
+  disabled = false,
+  activeColor = 'bg-purple-30',
+  inactiveColor = 'bg-transparent',
+  id,
+}) => {
+  return (
+    <label
+      className={`cursor-pointer select-none items-center ${disabled ? 'opacity-50 cursor-not-allowed' : ''} ${className}`}
+      htmlFor={id}
+    >
+      <div className="relative">
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={(e) => onChange(e.target.checked)}
+          className="sr-only"
+          disabled={disabled}
+          id={id}
+        />
+        <div
+          className={`box block h-8 w-14 rounded-full border border-purple-30 ${
+            checked
+              ? `${activeColor} dark:${activeColor}`
+              : `${inactiveColor} dark:${inactiveColor}`
+          }`}
+        ></div>
+        <div
+          className={`absolute left-1 top-1 flex h-6 w-6 items-center justify-center rounded-full transition ${
+            checked ? 'translate-x-full bg-silver' : 'bg-purple-30'
+          }`}
+        ></div>
+      </div>
+      {label && (
+        <span className="ml-2 text-eerie-black dark:text-white">{label}</span>
+      )}
+    </label>
+  );
+};
+
+export default ToggleSwitch;

--- a/frontend/src/components/ToggleSwitch.tsx
+++ b/frontend/src/components/ToggleSwitch.tsx
@@ -23,9 +23,12 @@ const ToggleSwitch: React.FC<ToggleSwitchProps> = ({
 }) => {
   return (
     <label
-      className={`cursor-pointer select-none items-center ${disabled ? 'opacity-50 cursor-not-allowed' : ''} ${className}`}
+      className={`cursor-pointer select-none justify-between flex flex-row items-center ${disabled ? 'opacity-50 cursor-not-allowed' : ''} ${className}`}
       htmlFor={id}
     >
+      {label && (
+        <span className="mr-2 text-eerie-black dark:text-white">{label}</span>
+      )}
       <div className="relative">
         <input
           type="checkbox"
@@ -48,9 +51,6 @@ const ToggleSwitch: React.FC<ToggleSwitchProps> = ({
           }`}
         ></div>
       </div>
-      {label && (
-        <span className="ml-2 text-eerie-black dark:text-white">{label}</span>
-      )}
     </label>
   );
 };

--- a/frontend/src/components/types/index.ts
+++ b/frontend/src/components/types/index.ts
@@ -8,6 +8,7 @@ export type InputProps = {
   maxLength?: number;
   name?: string;
   placeholder?: string;
+  label?: string;
   className?: string;
   children?: React.ReactElement;
   onChange: (

--- a/frontend/src/upload/Upload.tsx
+++ b/frontend/src/upload/Upload.tsx
@@ -495,49 +495,6 @@ function Upload({
         },
       };
     });
-    console.log(ingestor);
-  };
-
-  const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-  ) => {
-    const { name, value } = e.target;
-
-    if (ingestor.type === 'reddit') {
-      const redditConfig = ingestor.config as RedditIngestorConfig;
-      setIngestor({
-        ...ingestor,
-        config: {
-          ...redditConfig,
-          [name]:
-            name === 'search_queries'
-              ? value.split(',').map((item) => item.trim())
-              : name === 'number_posts'
-                ? parseInt(value)
-                : value,
-        },
-      });
-    } else if (ingestor.type === 'github') {
-      const githubConfig = ingestor.config as GithubIngestorConfig;
-      setIngestor({
-        ...ingestor,
-        config: {
-          ...githubConfig,
-          [name]: value,
-        },
-      });
-    } else {
-      const urlConfig = ingestor.config as
-        | CrawlerIngestorConfig
-        | UrlIngestorConfig;
-      setIngestor({
-        ...ingestor,
-        config: {
-          ...urlConfig,
-          [name]: value,
-        },
-      });
-    }
   };
 
   const handleIngestorTypeChange = (type: IngestorType) => {

--- a/frontend/src/upload/types/ingestor.ts
+++ b/frontend/src/upload/types/ingestor.ts
@@ -41,3 +41,121 @@ export type IngestorFormData = {
   source: IngestorType;
   data: string;
 };
+
+export type FieldType = 'string' | 'number' | 'enum' | 'boolean';
+
+export interface FormField {
+  name: keyof BaseIngestorConfig | string;
+  label: string;
+  type: FieldType;
+  options?: { label: string; value: string }[];
+}
+
+export const IngestorFormSchemas: Record<IngestorType, FormField[]> = {
+  crawler: [
+    {
+      name: 'name',
+      label: 'Name',
+      type: 'string',
+    },
+    {
+      name: 'url',
+      label: 'URL',
+      type: 'string',
+    },
+  ],
+  url: [
+    {
+      name: 'name',
+      label: 'Name',
+      type: 'string',
+    },
+    {
+      name: 'url',
+      label: 'URL',
+      type: 'string',
+    },
+  ],
+  reddit: [
+    {
+      name: 'name',
+      label: 'Name',
+      type: 'string',
+    },
+    {
+      name: 'client_id',
+      label: 'Client ID',
+      type: 'string',
+    },
+    {
+      name: 'client_secret',
+      label: 'Client Secret',
+      type: 'string',
+    },
+    {
+      name: 'user_agent',
+      label: 'User Agent',
+      type: 'string',
+    },
+    {
+      name: 'search_queries',
+      label: 'Search Queries',
+      type: 'string',
+    },
+    {
+      name: 'number_posts',
+      label: 'Number of Posts',
+      type: 'number',
+    },
+  ],
+  github: [
+    {
+      name: 'name',
+      label: 'Name',
+      type: 'string',
+    },
+    {
+      name: 'repo_url',
+      label: 'Repository URL',
+      type: 'string',
+    },
+  ],
+};
+
+export const IngestorDefaultConfigs: Record<
+  IngestorType,
+  Omit<IngestorConfig, 'type'>
+> = {
+  crawler: {
+    name: '',
+    config: {
+      name: '',
+      url: '',
+    } as CrawlerIngestorConfig,
+  },
+  url: {
+    name: '',
+    config: {
+      name: '',
+      url: '',
+    } as UrlIngestorConfig,
+  },
+  reddit: {
+    name: '',
+    config: {
+      name: '',
+      client_id: '',
+      client_secret: '',
+      user_agent: '',
+      search_queries: [],
+      number_posts: 10,
+    } as RedditIngestorConfig,
+  },
+  github: {
+    name: '',
+    config: {
+      name: '',
+      repo_url: '',
+    } as GithubIngestorConfig,
+  },
+};

--- a/frontend/src/upload/types/ingestor.ts
+++ b/frontend/src/upload/types/ingestor.ts
@@ -6,7 +6,7 @@ export interface RedditIngestorConfig extends BaseIngestorConfig {
   client_id: string;
   client_secret: string;
   user_agent: string;
-  search_queries: string[];
+  search_queries: string;
   number_posts: number;
 }
 
@@ -31,8 +31,7 @@ export interface IngestorConfig {
     | RedditIngestorConfig
     | GithubIngestorConfig
     | CrawlerIngestorConfig
-    | UrlIngestorConfig
-    | string;
+    | UrlIngestorConfig;
 }
 
 export type IngestorFormData = {
@@ -54,11 +53,6 @@ export interface FormField {
 export const IngestorFormSchemas: Record<IngestorType, FormField[]> = {
   crawler: [
     {
-      name: 'name',
-      label: 'Name',
-      type: 'string',
-    },
-    {
       name: 'url',
       label: 'URL',
       type: 'string',
@@ -66,22 +60,12 @@ export const IngestorFormSchemas: Record<IngestorType, FormField[]> = {
   ],
   url: [
     {
-      name: 'name',
-      label: 'Name',
-      type: 'string',
-    },
-    {
       name: 'url',
       label: 'URL',
       type: 'string',
     },
   ],
   reddit: [
-    {
-      name: 'name',
-      label: 'Name',
-      type: 'string',
-    },
     {
       name: 'client_id',
       label: 'Client ID',
@@ -110,11 +94,6 @@ export const IngestorFormSchemas: Record<IngestorType, FormField[]> = {
   ],
   github: [
     {
-      name: 'name',
-      label: 'Name',
-      type: 'string',
-    },
-    {
       name: 'repo_url',
       label: 'Repository URL',
       type: 'string',
@@ -129,32 +108,28 @@ export const IngestorDefaultConfigs: Record<
   crawler: {
     name: '',
     config: {
-      name: '',
       url: '',
     } as CrawlerIngestorConfig,
   },
   url: {
     name: '',
     config: {
-      name: '',
       url: '',
     } as UrlIngestorConfig,
   },
   reddit: {
     name: '',
     config: {
-      name: '',
       client_id: '',
       client_secret: '',
       user_agent: '',
-      search_queries: [],
+      search_queries: '',
       number_posts: 10,
     } as RedditIngestorConfig,
   },
   github: {
     name: '',
     config: {
-      name: '',
       repo_url: '',
     } as GithubIngestorConfig,
   },

--- a/frontend/src/upload/types/ingestor.ts
+++ b/frontend/src/upload/types/ingestor.ts
@@ -1,0 +1,43 @@
+export interface BaseIngestorConfig {
+  name: string;
+}
+
+export interface RedditIngestorConfig extends BaseIngestorConfig {
+  client_id: string;
+  client_secret: string;
+  user_agent: string;
+  search_queries: string[];
+  number_posts: number;
+}
+
+export interface GithubIngestorConfig extends BaseIngestorConfig {
+  repo_url: string;
+}
+
+export interface CrawlerIngestorConfig extends BaseIngestorConfig {
+  url: string;
+}
+
+export interface UrlIngestorConfig extends BaseIngestorConfig {
+  url: string;
+}
+
+export type IngestorType = 'crawler' | 'github' | 'reddit' | 'url';
+
+export interface IngestorConfig {
+  type: IngestorType;
+  name: string;
+  config:
+    | RedditIngestorConfig
+    | GithubIngestorConfig
+    | CrawlerIngestorConfig
+    | UrlIngestorConfig
+    | string;
+}
+
+export type IngestorFormData = {
+  name: string;
+  user: string;
+  source: IngestorType;
+  data: string;
+};


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  -  Separate the configurations for different remote upload options by structuring interfaces.
  -  Adding form schema to generate form elements dynamically based on the `IngestorType`
  - Form fields are rendered as 
      - `string/number` as `Input` component
      -  `boolean` as `ToggleSwitch` component
      - `enums` as `Dropdown` component
 
- **Why was this change needed?** (You can also link to an open issue here)
     Maintenance