### PR TITLE
docs: Ensure --env-file .env is included for environment variable loa…

### DIFF
--- a/docs/pages/Deploying/Docker-Deploying.mdx
+++ b/docs/pages/Deploying/Docker-Deploying.mdx
@@ -84,11 +84,11 @@ There are two Ollama optional files:
 
     **CPU:**
     ```bash
-    docker compose -f deployment/docker-compose.yaml -f deployment/optional/docker-compose.optional.ollama-cpu.yaml up -d
+    docker compose --env-file .env -f deployment/docker-compose.yaml -f deployment/optional/docker-compose.optional.ollama-cpu.yaml up -d
     ```
     **GPU:**
     ```bash
-    docker compose -f deployment/docker-compose.yaml -f deployment/optional/docker-compose.optional.ollama-gpu.yaml up -d
+    docker compose --env-file .env -f deployment/docker-compose.yaml -f deployment/optional/docker-compose.optional.ollama-gpu.yaml up -d
     ```
 
 3.  **Pull the Ollama Model:**


### PR DESCRIPTION

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
 Docs update 
- **Why was this change needed?** (You can also link to an open issue here)
Found an issue in the documentation where environment variables from .env were not consistently loaded when launching with Ollama locally.
The command:
`docker compose -f deployment/docker-compose.yaml -f deployment/optional/docker-compose.optional.ollama-cpu.yaml up -d
`
did not always load the .env variables as expected in Docker Compose.
Updating the docs to explicitly include --env-file .env for reliable environment variable loading.

- **Other information**:
None