### PR TITLE
Added Chat Dropdown Escape Key Functionality

### DIFF
--- a/frontend/src/conversation/ConversationTile.tsx
+++ b/frontend/src/conversation/ConversationTile.tsx
@@ -111,6 +111,20 @@ export default function ConversationTile({
     }
   }, [isOpen]);
 
+  const handleEscape = (event: KeyboardEvent) => {
+    if (event.key == 'Escape') {
+      setOpen(false);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleEscape);
+
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, []);
+
   function onClear() {
     setConversationsName(conversation.name);
     setIsEdit(false);


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Allows users to use Escape to exit out of the chat dropdown menu for Share/Rename/Delete without needing to manually click out of it.

- **Why was this change needed?** (You can also link to an open issue here)
Enables consistency across UI via Enter/Escape key functionality

- **Other information**:
Relates to issues presented in #1620 