### PR TITLE
fix: add missing env variable to docker compose for frontend

### DIFF
--- a/deployment/docker-compose.yaml
+++ b/deployment/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     environment:
       - VITE_API_HOST=http://localhost:7091
       - VITE_API_STREAMING=$VITE_API_STREAMING
+      - VITE_EMBEDDINGS_NAME=$EMBEDDINGS_NAME
     ports:
       - "5173:5173"
     depends_on:


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
 bug fix
- **Why was this change needed?** (You can also link to an open issue here)
Fix Sources File Not Loading in Front End When EMBEDDINGS_NAME Environment Variable is Changed
[frontend/src/components/SourceDropdown.tsx](https://github.com/arc53/DocsGPT/blob/main/frontend/src/components/SourceDropdown.tsx)

- **Other information**:
None