### PR TITLE
fix signature for AzureOpenAILLM

### DIFF
--- a/application/llm/openai.py
+++ b/application/llm/openai.py
@@ -137,17 +137,17 @@ class OpenAILLM(BaseLLM):
 class AzureOpenAILLM(OpenAILLM):
 
     def __init__(
-        self, openai_api_key, openai_api_base, openai_api_version, deployment_name
+        self, api_key, user_api_key, *args, **kwargs 
     ):
-        super().__init__(openai_api_key)
+
+        super().__init__(api_key)
         self.api_base = (settings.OPENAI_API_BASE,)
         self.api_version = (settings.OPENAI_API_VERSION,)
         self.deployment_name = (settings.AZURE_DEPLOYMENT_NAME,)
         from openai import AzureOpenAI
 
         self.client = AzureOpenAI(
-            api_key=openai_api_key,
+            api_key=api_key,
             api_version=settings.OPENAI_API_VERSION,
-            api_base=settings.OPENAI_API_BASE,
-            deployment_name=settings.AZURE_DEPLOYMENT_NAME,
+            azure_endpoint=settings.OPENAI_API_BASE
         )


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix for the AzureOpenAILLM signature 

The create_llm(cls, type, api_key, user_api_key, *args, **kwargs). in **llm_creator.py** has different signature 

AzureOpenAILLM accepts 

def __init__(
        self, openai_api_key, openai_api_base, openai_api_version, deployment_name
    ):

- **Why was this change needed?** (You can also link to an open issue here)

https://github.com/arc53/DocsGPT/issues/1699

- **Other information**:

Also Class AzureOpenAI from openai package also does not have param "deployment_name"

Causing 

[2025-03-14 03:22:19,182] ERROR in routes: /api/answer - error: AzureOpenAILLM.init() missing 2 required positional arguments: 'openai_api_version' and 'deployment_name' - traceback: Traceback (most recent call last):
File "/app/application/api/answer/routes.py", line 541, in post
agent = AgentCreator.create_agent(
^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/application/agents/agent_creator.py", line 14, in create_agent
return agent_class(*args, **kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/application/agents/classic_agent.py", line 21, in init
super().init(endpoint, llm_name, gpt_model, api_key, user_api_key)
File "/app/application/agents/base.py", line 14, in init
self.llm = LLMCreator.create_llm(
^^^^^^^^^^^^^^^^^^^^^^
File "/app/application/llm/llm_creator.py", line 32, in create_llm
return llm_class(api_key, user_api_key, *args, **kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: AzureOpenAILLM.init() missing 2 required positional arguments: 'openai_api_version' and 'deployment_name'