### PR TITLE
Optimize limit_chat_history function to remove gpt_model dependencies

### DIFF
--- a/application/api/answer/routes.py
+++ b/application/api/answer/routes.py
@@ -437,8 +437,9 @@ class Stream(Resource):
 
         try:
             question = data["question"]
+            token_limit = data.get("token_limit", settings.DEFAULT_MAX_HISTORY)
             history = limit_chat_history(
-                json.loads(data.get("history", "[]")), gpt_model=gpt_model
+                json.loads(data.get("history", "[]")), token_limit
             )
             conversation_id = data.get("conversation_id")
             prompt_id = data.get("prompt_id", "default")
@@ -446,7 +447,6 @@ class Stream(Resource):
 
             index = data.get("index", None)
             chunks = int(data.get("chunks", 2))
-            token_limit = data.get("token_limit", settings.DEFAULT_MAX_HISTORY)
             retriever_name = data.get("retriever", "classic")
             agent_id = data.get("agent_id", None)
             agent_type = settings.AGENT_NAME
@@ -613,13 +613,13 @@ class Answer(Resource):
 
         try:
             question = data["question"]
+            token_limit = data.get("token_limit", settings.DEFAULT_MAX_HISTORY)
             history = limit_chat_history(
-                json.loads(data.get("history", "[]")), gpt_model=gpt_model
+                json.loads(data.get("history", "[]")), token_limit
             )
             conversation_id = data.get("conversation_id")
             prompt_id = data.get("prompt_id", "default")
             chunks = int(data.get("chunks", 2))
-            token_limit = data.get("token_limit", settings.DEFAULT_MAX_HISTORY)
             retriever_name = data.get("retriever", "classic")
             agent_type = settings.AGENT_NAME
 

--- a/application/utils.py
+++ b/application/utils.py
@@ -92,21 +92,11 @@ def get_hash(data):
     return hashlib.md5(data.encode(), usedforsecurity=False).hexdigest()
 
 
-def limit_chat_history(history, max_token_limit=None, gpt_model="docsgpt"):
+def limit_chat_history(history, max_token_limit):
     """
     Limits chat history based on token count.
     Returns a list of messages that fit within the token limit.
     """
-    from application.core.settings import settings
-
-    max_token_limit = (
-        max_token_limit
-        if max_token_limit
-        and max_token_limit
-        < settings.LLM_TOKEN_LIMITS.get(gpt_model, settings.DEFAULT_MAX_HISTORY)
-        else settings.LLM_TOKEN_LIMITS.get(gpt_model, settings.DEFAULT_MAX_HISTORY)
-    )
-
     if not history:
         return []
 


### PR DESCRIPTION
## Summary
Simplified the `limit_chat_history` function in `application/utils.py` by removing the `gpt_model` parameter and all related internal dependencies, making the function only depend on the provided `max_token_limit` parameter.

## Changes Made

### Function Signature Updated
- **Before**: `def limit_chat_history(history, max_token_limit=None, gpt_model="docsgpt"):`
- **After**: `def limit_chat_history(history, max_token_limit):`

### Removed Dependencies
- ✅ Removed `gpt_model` parameter completely
- ✅ Removed internal `from application.core.settings import settings` dependency
- ✅ Removed complex logic that determined `max_token_limit` based on `gpt_model` and settings:
  ```python
  # Removed this entire block:
  max_token_limit = (
      max_token_limit
      if max_token_limit
      and max_token_limit
      < settings.LLM_TOKEN_LIMITS.get(gpt_model, settings.DEFAULT_MAX_HISTORY)
      else settings.LLM_TOKEN_LIMITS.get(gpt_model, settings.DEFAULT_MAX_HISTORY)
  )
  ```

### Core Functionality Preserved
- ✅ All original logic for processing chat history remains intact
- ✅ Tool calls processing functionality unchanged
- ✅ Token counting and trimming logic preserved
- ✅ Function returns the same data structure as before