### PR TITLE
fix: correct agent tools name when creating new agent (#1877)

### DIFF
--- a/frontend/src/agents/NewAgent.tsx
+++ b/frontend/src/agents/NewAgent.tsx
@@ -232,7 +232,7 @@ export default function NewAgent({ mode }: { mode: 'new' | 'edit' | 'draft' }) {
       const data = await response.json();
       const tools: OptionType[] = data.tools.map((tool: UserToolType) => ({
         id: tool.id,
-        label: tool.displayName,
+        label: tool.customName,
         icon: `/toolIcons/tool_${tool.name}.svg`,
       }));
       setUserTools(tools);


### PR DESCRIPTION
### 📜 Description

This PR fixes a bug where the custom (renamed) tool names were not displayed in the dropdown during agent creation and editing. Instead, the standard tool names were shown. This behavior was inconsistent with the message input section, where renamed tool names were correctly displayed.

### 🛠️ Changes Made

- Updated the agent creation and editing logic to use the renamed (custom) tool names from the tool metadata, matching the behavior in the message input section.

### ✅ Fixes

Closes #1877

## 📷 Proof

<img width="1561" height="863" alt="Screenshot 2025-07-14 203723" src="https://github.com/user-attachments/assets/592e8717-4515-4024-8a3a-62ddffe417d8" />

<img width="1462" height="869" alt="Screenshot 2025-07-14 203812" src="https://github.com/user-attachments/assets/608745d4-448e-4507-bc4b-93008f583a92" />


### 💻 Environment

- OS: Windows
- Browser: Chrome
- Dev Environment: Docker

---

Let me know if any changes are needed. Thanks! 🙌