### PR TITLE
fix: Removed incorrect www from URL in DocsGPT Docs frontend (#1854)

### DIFF
--- a/docs/theme.config.jsx
+++ b/docs/theme.config.jsx
@@ -60,7 +60,7 @@ const config = {
           GitHub
         </a>
         {' | '}
-        <a href="https://www.blog.docsgpt.cloud/" target="_blank">
+        <a href="https://blog.docsgpt.cloud/" target="_blank">
           Blog
         </a>
       </div>

--- a/frontend/src/agents/NewAgent.tsx
+++ b/frontend/src/agents/NewAgent.tsx
@@ -232,7 +232,7 @@ export default function NewAgent({ mode }: { mode: 'new' | 'edit' | 'draft' }) {
       const data = await response.json();
       const tools: OptionType[] = data.tools.map((tool: UserToolType) => ({
         id: tool.id,
-        label: tool.customName,
+        label: tool.displayName,
         icon: `/toolIcons/tool_${tool.name}.svg`,
       }));
       setUserTools(tools);

--- a/frontend/src/agents/NewAgent.tsx
+++ b/frontend/src/agents/NewAgent.tsx
@@ -232,7 +232,7 @@ export default function NewAgent({ mode }: { mode: 'new' | 'edit' | 'draft' }) {
       const data = await response.json();
       const tools: OptionType[] = data.tools.map((tool: UserToolType) => ({
         id: tool.id,
-        label: tool.displayName,
+        label: tool.customName,
         icon: `/toolIcons/tool_${tool.name}.svg`,
       }));
       setUserTools(tools);


### PR DESCRIPTION
### 📜 Description

This PR fixes the blog URL in `DocsGPT/docs/theme.config.jsx` by removing the incorrect `www` subdomain (`https://www.blog.docsgpt.cloud/`) and updating it to the correct link: `https://blog.docsgpt.cloud/`.

### 🛠️ Changes Made

- Updated the `href` in the blog anchor tag to use the correct URL without the `www` prefix.

### ✅ Fixes

Closes #1854

### 💻 Environment

- OS: Windows
- Browser: Chrome 

---

Let me know if any updates are needed. 👍
