### PR TITLE
fix: replace secure_filename with safe_filename for attachment handling

### DIFF
--- a/application/api/user/routes.py
+++ b/application/api/user/routes.py
@@ -3557,7 +3557,7 @@ class StoreAttachment(Resource):
 
         try:
             attachment_id = ObjectId()
-            original_filename = secure_filename(os.path.basename(file.filename))
+            original_filename = safe_filename(os.path.basename(file.filename))
             relative_path = f"{settings.UPLOAD_FOLDER}/{user}/attachments/{str(attachment_id)}/{original_filename}"
 
             metadata = storage.save_file(file, relative_path)


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- **Why was this change needed?** (You can also link to an open issue here)

- **Other information**: