### PR TITLE
Fixes missing attributes on shared agents

### DIFF
--- a/application/api/user/routes.py
+++ b/application/api/user/routes.py
@@ -1789,6 +1789,10 @@ class SharedAgent(Resource):
                     else ""
                 ),
                 "description": shared_agent.get("description", ""),
+                "source": shared_agent.get("source", ""),
+                "chunks": shared_agent.get("chunks", "0"),
+                "retriever": shared_agent.get("retriever", "classic"),
+                "prompt_id": shared_agent.get("prompt_id", "default"),
                 "tools": shared_agent.get("tools", []),
                 "tool_details": resolve_tool_details(shared_agent.get("tools", [])),
                 "agent_type": shared_agent.get("agent_type", ""),


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
     Fixes unintended behaviour with shared agents:
        * user A creates an agent with specific prompt, shares it publicly
        * user B queries, and the response is noticed form the default prompt
- **Why was this change needed?** (You can also link to an open issue here)
        * functionality
- **Other information**:
Logging queries generated with a shared agent generated with a custom prompt and custom source
before
```
[2025-08-08 18:00:27,160] INFO in google_ai: GoogleLLM: Message 0: role=system, content_preview=[Part(video_metadata=None, thought=None, code_execution_result=None, executable_code=None, file_data=None, function_call=None, function_response=None, inline_data=None, text="You are a helpful AI assi...
```
after:

```
[2025-08-08 18:09:41,533] INFO in base: BaseAgent: Building messages with system prompt (39 chars): reply with the meaning of the word only...
```