### PR TITLE
Fix: replace map with for...of loop to avoid ignoring return value (S2201)

### DIFF
--- a/frontend/src/upload/Upload.tsx
+++ b/frontend/src/upload/Upload.tsx
@@ -358,13 +358,11 @@ function Upload({
                         [],
                     );
                     if (data && Array.isArray(data)) {
-                      data.map((updatedDoc: Doc) => {
+                      for (const updatedDoc of data) {
                         if (updatedDoc.id && !docIds.has(updatedDoc.id)) {
-                          // Select the doc not present in the intersection of current Docs and fetched data
                           dispatch(setSelectedDocs(updatedDoc));
-                          return;
                         }
-                      });
+                      }
                     }
                   });
                   setProgress(


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix – replaced map with for...of loop to avoid ignoring return values and to comply with Sonar rule typescript:S2201.

### Why was this change needed? (You can also link to an open issue here)
- The previous implementation used Array.map() only for side-effects (dispatch(setSelectedDocs)), but ignored the returned array. This violates Sonar’s typescript:S2201 rule (“Return values of functions should not be ignored”) and could cause confusion in code reviews.
- By replacing map with for...of loop, the code now clearly communicates intent, avoids unnecessary return values, and improves readability.

### Other information:
- This change does not affect application logic.
- The dispatch behavior remains the same, only iteration method is updated.
- Ensures cleaner code quality and passes Sonar checks.