### PR TITLE
OAuth fix for connector 

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,11 @@
 - [x] Agent optimisations (May 2025)
 - [x] Filesystem sources update (July 2025)
 - [x] Json Responses (August 2025)
-- [ ] Sharepoint integration (August 2025)
-- [ ] MCP support (August 2025)
-- [ ] Add OAuth 2.0 authentication for tools and sources (August 2025)
+- [x] MCP support (August 2025)
+- [x] Google Drive integration (September 2025)
+- [ ] Add OAuth 2.0 authentication for MCP (September 2025)
+- [ ] Sharepoint integration (October 2025)
+- [ ] Deep Agents (October 2025)
 - [ ] Agent scheduling
 
 You can find our full roadmap [here](https://github.com/orgs/arc53/projects/2). Please don't hesitate to contribute or create issues, it helps us improve DocsGPT!

--- a/application/api/connector/routes.py
+++ b/application/api/connector/routes.py
@@ -334,7 +334,7 @@ class ConnectorsCallback(Resource):
 
         except Exception as e:
             current_app.logger.error(f"Error handling connector callback: {e}")
-            return redirect(f"/api/connectors/callback-status?status=error&message=Authentication+failed.+Please+try+again+and+make+sure+to+grant+all+requested+permissions.")
+            return redirect("/api/connectors/callback-status?status=error&message=Authentication+failed.+Please+try+again+and+make+sure+to+grant+all+requested+permissions.")
 
 
 @connectors_ns.route("/api/connectors/refresh")

--- a/application/api/connector/routes.py
+++ b/application/api/connector/routes.py
@@ -234,8 +234,20 @@ class ConnectorAuth(Resource):
             if not ConnectorCreator.is_supported(provider):
                 return make_response(jsonify({"success": False, "error": f"Unsupported provider: {provider}"}), 400)
 
-            import uuid
-            state = str(uuid.uuid4())
+            decoded_token = request.decoded_token
+            if not decoded_token:
+                return make_response(jsonify({"success": False, "error": "Unauthorized"}), 401)
+            user_id = decoded_token.get('sub')
+
+            now = datetime.datetime.now(datetime.timezone.utc)
+            result = sessions_collection.insert_one({
+                "provider": provider,
+                "user": user_id,
+                "status": "pending",
+                "created_at": now
+            })
+            state = str(result.inserted_id)
+
             auth = ConnectorCreator.create_auth(provider)
             authorization_url = auth.get_authorization_url(state=state)
             return make_response(jsonify({
@@ -260,21 +272,22 @@ class ConnectorsCallback(Resource):
 
             provider = request.args.get('provider', 'google_drive')
             authorization_code = request.args.get('code')
-            _ = request.args.get('state')
+            state = request.args.get('state')
             error = request.args.get('error')
 
             if error:
-                return redirect(f"/api/connectors/callback-status?status=error&message=OAuth+error:+{error}.+Please+try+again+and+make+sure+to+grant+all+requested+permissions,+including+offline+access.&provider={provider}")
+                return redirect(f"/api/connectors/callback-status?status=error&message=Authentication+failed.+Please+try+again+and+make+sure+to+grant+all+requested+permissions.&provider={provider}")
 
             if not authorization_code:
-                return redirect(f"/api/connectors/callback-status?status=error&message=Authorization+code+not+provided.+Please+complete+the+authorization+process+and+make+sure+to+grant+offline+access.&provider={provider}")
+                return redirect(f"/api/connectors/callback-status?status=error&message=Authentication+failed.+Please+try+again+and+make+sure+to+grant+all+requested+permissions.&provider={provider}")
+
+            state_object_id = ObjectId(state)
 
             try:
                 auth = ConnectorCreator.create_auth(provider)
                 token_info = auth.exchange_code_for_tokens(authorization_code)
 
                 session_token = str(uuid.uuid4())
-                
 
                 try:
                     credentials = auth.create_credentials_from_token_info(token_info)
@@ -292,26 +305,28 @@ class ConnectorsCallback(Resource):
                     "expiry": token_info.get("expiry")
                 }
 
-                user_id = request.decoded_token.get("sub") if getattr(request, "decoded_token", None) else None
-                sessions_collection.insert_one({
-                    "session_token": session_token,
-                    "user": user_id,
-                    "token_info": sanitized_token_info,
-                    "created_at": datetime.datetime.now(datetime.timezone.utc),
-                    "user_email": user_email,
-                    "provider": provider
-                })
+                sessions_collection.find_one_and_update(
+                    {"_id": state_object_id, "provider": provider},
+                    {
+                        "$set": {
+                            "session_token": session_token,
+                            "token_info": sanitized_token_info,
+                            "user_email": user_email,
+                            "status": "authorized"
+                        }
+                    }
+                )
 
                 # Redirect to success page with session token and user email
                 return redirect(f"/api/connectors/callback-status?status=success&message=Authentication+successful&provider={provider}&session_token={session_token}&user_email={user_email}")
 
             except Exception as e:
                 current_app.logger.error(f"Error exchanging code for tokens: {str(e)}", exc_info=True)
-                return redirect(f"/api/connectors/callback-status?status=error&message=Failed+to+exchange+authorization+code+for+tokens:+{str(e)}&provider={provider}")
+                return redirect(f"/api/connectors/callback-status?status=error&message=Authentication+failed.+Please+try+again+and+make+sure+to+grant+all+requested+permissions.&provider={provider}")
 
         except Exception as e:
             current_app.logger.error(f"Error handling connector callback: {e}")
-            return redirect(f"/api/connectors/callback-status?status=error&message=Failed+to+complete+connector+authentication:+{str(e)}.+Please+try+again+and+make+sure+to+grant+all+requested+permissions,+including+offline+access.")
+            return redirect(f"/api/connectors/callback-status?status=error&message=Authentication+failed.+Please+try+again+and+make+sure+to+grant+all+requested+permissions.")
 
 
 @connectors_ns.route("/api/connectors/refresh")

--- a/application/core/settings.py
+++ b/application/core/settings.py
@@ -43,8 +43,7 @@ class Settings(BaseSettings):
     # Google Drive integration
     GOOGLE_CLIENT_ID: Optional[str] = None # Replace with your actual Google OAuth client ID
     GOOGLE_CLIENT_SECRET: Optional[str] = None# Replace with your actual Google OAuth client secret
-    CONNECTOR_REDIRECT_BASE_URI: Optional[str] = "http://127.0.0.1:7091/api/connectors/callback" 
-    ##append ?provider={provider_name} in your Provider console like http://127.0.0.1:7091/api/connectors/callback?provider=google_drive
+    CONNECTOR_REDIRECT_BASE_URI: Optional[str] = "http://127.0.0.1:7091/api/connectors/callback" ##add redirect url as it is to your provider's console(gcp)
 
 
     # LLM Cache

--- a/application/parser/connectors/google_drive/auth.py
+++ b/application/parser/connectors/google_drive/auth.py
@@ -23,7 +23,7 @@ class GoogleDriveAuth(BaseConnectorAuth):
     def __init__(self):
         self.client_id = settings.GOOGLE_CLIENT_ID
         self.client_secret = settings.GOOGLE_CLIENT_SECRET
-        self.redirect_uri = f"{settings.CONNECTOR_REDIRECT_BASE_URI}?provider=google_drive"
+        self.redirect_uri = f"{settings.CONNECTOR_REDIRECT_BASE_URI}"
         
         if not self.client_id or not self.client_secret:
             raise ValueError("Google OAuth credentials not configured. Please set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET in settings.")


### PR DESCRIPTION
**Update the redirect URL in the GCP with `http://127.0.0.1:7091/api/connectors/callback` for testing locally**

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
     - OAuth state-handling to the existing connector_sessions collection so we can reliably associate the authenticated Google account with the initiating
     - The route `/api/connectors/callback` refers to the same mongodb document for the user and provider
     - simplified a minor thing so that we use the exact redirect url as in the settings in the GCP; URL is now passed as state not args
- **Why was this change needed?** (You can also link to an open issue here)
  fixes the error while authenticating with google drive 

- **Other information**:

mongodb states
* pending user
```
{
"_id": {
"$oid": "68d45fed6a313bd0d4df3ee9"
},
"state": "184fad0d-3608-4c3c-950c-838f95653fd3",
"provider": "google_drive",
"user": "user_XXXX",
"status": "pending",
"created_at": {
"$date": "2025-09-24T21:17:33.386Z"
}
}
```

authorised user

```
{
  "_id": {
    "$oid": "68d4730c3f8840ce5c37dd2d"
  },
  "provider": "google_drive",
  "user": "user_XXXXXXXXXXX",
  "status": "authorized",
  "created_at": {
    "$date": "2025-09-24T22:39:08.174Z"
  },
  "session_token": "f1834a21-7df5-4a8c-9101-42b28acaa404",
  "token_info": {
    "access_token": "XXXXX",
    "refresh_token": "XXXXX",
    "token_uri": "https://oauth2.googleapis.com/token",
    "expiry": "2025-09-24T23:39:12.716985"
  },
  "user_email": "XXXXX@arc53.com"
}
```
```