### PR TITLE
chore: update twitter.com to x.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <a href="https://github.com/arc53/DocsGPT/blob/main/LICENSE">![link to license file](https://img.shields.io/github/license/arc53/docsgpt)</a>
   <a href="https://www.bestpractices.dev/projects/9907"><img src="https://www.bestpractices.dev/projects/9907/badge"></a>
   <a href="https://discord.gg/n5BX8dh8rU">![link to discord](https://img.shields.io/discord/1070046503302877216)</a>
-  <a href="https://twitter.com/docsgptai">![X (formerly Twitter) URL](https://img.shields.io/twitter/follow/docsgptai)</a>
+  <a href="https://x.com/docsgptai">![X (formerly Twitter) URL](https://img.shields.io/twitter/follow/docsgptai)</a>
 
 <a href="https://docs.docsgpt.cloud/quickstart">⚡️ Quickstart</a> • <a href="https://app.docsgpt.cloud/">☁️ Cloud Version</a> • <a href="https://discord.gg/n5BX8dh8rU">💬 Discord</a>
 <br>

--- a/frontend/src/Navigation.tsx
+++ b/frontend/src/Navigation.tsx
@@ -581,7 +581,7 @@ export default function Navigation({ navOpen, setNavOpen }: NavigationProps) {
                 </NavLink>
                 <NavLink
                   target="_blank"
-                  to={'https://twitter.com/docsgptai'}
+                  to={'https://x.com/docsgptai'}
                   className={
                     'rounded-full hover:bg-gray-100 dark:hover:bg-[#28292E]'
                   }
@@ -590,7 +590,7 @@ export default function Navigation({ navOpen, setNavOpen }: NavigationProps) {
                     src={Twitter}
                     width={20}
                     height={20}
-                    alt="Follow us on Twitter"
+                    alt="Follow us on X"
                     className="m-2 self-center filter dark:invert"
                   />
                 </NavLink>


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Closes #2013 
Minor optimization - Update Twitter links to use x.com directly instead of twitter.com to avoid redirect latency
- **Why was this change needed?** (You can also link to an open issue here)
 Reduces page load time by eliminating unnecessary HTTP redirects from twitter.com to x.com following Twitter's rebranding
- **Other information**:
Updated in Navigation and README.md