### PR TITLE
fix: handle missing kwargs in local save_file (Fixes #2009)

### DIFF
--- a/application/storage/local.py
+++ b/application/storage/local.py
@@ -26,7 +26,7 @@ class LocalStorage(BaseStorage):
             return path
         return os.path.join(self.base_dir, path)
 
-    def save_file(self, file_data: BinaryIO, path: str) -> dict:
+    def save_file(self, file_data: BinaryIO, path: str, **kwargs) -> dict:
         """Save a file to local storage."""
         full_path = self._get_full_path(path)
 


### PR DESCRIPTION
Fixes #2009

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Bug Fix.  Previously, the local save_file function didn’t accept kwargs, causing a crash when passed extra params (by api/user/agents/routes.py). Added support to maintain consistency with AWS version.

- **Why was this change needed?** (You can also link to an open issue here)
- To be able to create agents locally, without configuring aws storage
