### PR TITLE
adjusted edit button padding and response box padding & roundness

### DIFF
--- a/frontend/src/conversation/ConversationBubble.tsx
+++ b/frontend/src/conversation/ConversationBubble.tsx
@@ -188,7 +188,7 @@ const ConversationBubble = forwardRef<
                     setIsEditClicked(true);
                     setEditInputBox(message ?? '');
                   }}
-                  className={`hover:bg-light-silver mt-3 flex h-fit shrink-0 cursor-pointer items-center rounded-full p-2 dark:hover:bg-[#35363B] ${isQuestionHovered || isEditClicked ? 'visible' : 'invisible'}`}
+                  className={`hover:bg-light-silver mt-3 flex h-fit shrink-0 cursor-pointer items-center rounded-full p-2 pt-1.5 pl-1.5 dark:hover:bg-[#35363B] ${isQuestionHovered || isEditClicked ? 'visible' : 'invisible'}`}
                 >
                   <img src={Edit} alt="Edit" className="cursor-pointer" />
                 </button>
@@ -407,7 +407,7 @@ const ConversationBubble = forwardRef<
               </p>
             </div>
             <div
-              className={`fade-in-bubble bg-gray-1000 dark:bg-gun-metal mr-5 flex max-w-full rounded-[28px] px-7 py-[18px] ${
+              className={`fade-in-bubble bg-gray-1000 dark:bg-gun-metal mr-5 flex max-w-full rounded-[18px] px-6 py-4.5 ${
                 type === 'ERROR'
                   ? 'text-red-3000 dark:border-red-2000 relative flex-row items-center rounded-full border border-transparent bg-[#FFE7E7] p-2 py-5 text-sm font-normal dark:text-white'
                   : 'flex-col rounded-3xl'


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This change introduces some slight UI enhancements on Edit Button and Response box.

1. I- added a `pt-1.5` and `pl-1.5` to the Edit button to better center-align the svg.
2. I also modified the conversation box's roundness from 28px to 18px; modified horizontal padding from `px-7` to `px-6`; removed a hard-coded vertical padding and changed it from 18px to `py-4.5`.

- **Why was this change needed?** (You can also link to an open issue here)
Opened Issue: https://github.com/arc53/DocsGPT/issues/2010
This change is supposed to make the Response box appears more elegantly, and make Edit button aligns better.
This changes effectively ensures the consistency in the DocsGPT's UI/UX design and thus providing a better end-user experience.