### PR TITLE
fix the command for installing on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ A more detailed [Quickstart](https://docs.docsgpt.cloud/quickstart) is available
 2. **Run the PowerShell setup script:**
 
    ```powershell
-   PowerShell -ExecutionPolicy Bypass -File .\setup.ps1
+   PowerShell -ExecutionPolicy Bypass -File setup.ps1
    ```
 
 Either script will guide you through setting up DocsGPT. Four options available: using the public API, running locally, connecting to a local inference engine, or using a cloud API provider. Scripts will automatically configure your `.env` file and handle necessary downloads and installations based on your chosen option.


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Docs update

---
- **Why was this change needed?** (You can also link to an open issue here)

The command for installing on Windows in the README.md file was incorrect for some environments. The `.` in `./setup.ps1` could cause path resolution issues in certain PowerShell or command-prompt configurations. 

This change corrects the command from `PowerShell -ExecutionPolicy Bypass -File ./setup.ps1` to `PowerShell -ExecutionPolicy Bypass -File setup.ps1` to ensure it runs reliably for all Windows users.

---
- **Other information**:

This is a minor documentation fix to improve the setup experience on Windows. No functional code has been changed.