### PR TITLE
fix: adjust share modal size and spacing

### DIFF
--- a/frontend/src/modals/ShareConversationModal.tsx
+++ b/frontend/src/modals/ShareConversationModal.tsx
@@ -111,7 +111,7 @@ export const ShareConversationModal = ({
         <p className="text-eerie-black dark:text-silver/60 text-sm leading-relaxed">
           {t('modals.shareConv.note')}
         </p>
-        <div className="border-silver/30 flex items-center justify-between border-b pb-2">
+        <div className="flex items-center justify-between">
           <span className="text-eerie-black text-lg dark:text-white">
             {t('modals.shareConv.option')}
           </span>


### PR DESCRIPTION
Issue: #2016 
- **What kind of change does this PR introduce?** 
Bug Fix
- **Why was this change needed?** 
- The change fixes the overflowing of share button pop-up.
- The changes were needed to make the ShareConversationModal properly sized and readable without touching other modals that rely on the shared WrapperModal.
- 
- **Other information**:
Before:
<img width="374" height="809" alt="image" src="https://github.com/user-attachments/assets/18183b14-875e-4ebe-9eaa-b08dc261940c" />

After:
<img width="373" height="818" alt="image" src="https://github.com/user-attachments/assets/451718b5-48c3-489e-b552-c76ca4826309" />

