### PR TITLE
correct path for storing embeddings model

### DIFF
--- a/docs/pages/Deploying/Development-Environment.mdx
+++ b/docs/pages/Deploying/Development-Environment.mdx
@@ -67,7 +67,7 @@ To run the DocsGPT backend locally, you'll need to set up a Python environment a
 
 3.  **Download Embedding Model:**
 
-    The backend requires an embedding model. Download the `mpnet-base-v2` model and place it in the `model/` directory within the project root. You can use the following script:
+    The backend requires an embedding model. Download the `mpnet-base-v2` model and place it in the `models/` directory within the project root. You can use the following script:
 
     ```bash
     wget https://d3dg1063dc54p9.cloudfront.net/models/embeddings/mpnet-base-v2.zip
@@ -75,7 +75,7 @@ To run the DocsGPT backend locally, you'll need to set up a Python environment a
     rm mpnet-base-v2.zip
     ```
 
-    Alternatively, you can manually download the zip file from [here](https://d3dg1063dc54p9.cloudfront.net/models/embeddings/mpnet-base-v2.zip), unzip it, and place the extracted folder in `model/`.
+    Alternatively, you can manually download the zip file from [here](https://d3dg1063dc54p9.cloudfront.net/models/embeddings/mpnet-base-v2.zip), unzip it, and place the extracted folder in `models/`.
 
 4.  **Install Backend Dependencies:**
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** 
docs update

- **Why was this change needed?** (You can also link to an open issue here)
To make sure that the embeddings model is placed in the right folder. The project searches for the model in ./models or /app/models

- **Other information**:
<img width="605" height="45" alt="Screenshot 2025-10-07 at 10 45 24 PM" src="https://github.com/user-attachments/assets/6f053512-7602-4d38-9616-4121083f8ed5" />
