### PR TITLE
bug fix: spinner to match theme (dark/light) in navigation

### DIFF
--- a/frontend/src/Navigation.tsx
+++ b/frontend/src/Navigation.tsx
@@ -399,7 +399,7 @@ export default function Navigation({ navOpen, setNavOpen }: NavigationProps) {
           {conversations?.loading && !isDeletingConversation && (
             <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 transform">
               <img
-                src={isDarkTheme ? SpinnerDark : Spinner}
+                src={isDarkTheme ? Spinner : SpinnerDark}
                 className="animate-spin cursor-pointer bg-transparent"
                 alt="Loading conversations"
               />


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes #2043 The spinner in the conversation list (navigation section) was reverted. Previously, the loader color matched the theme, making it invisible or hard to notice.
- **Why was this change needed?** (You can also link to an open issue here)
The spinner was not clearly visible due to its color blending with the theme, affecting user experience.
- **Other information**:
This fix ensures better visibility of the loader, improving UI clarity during loading states.