### PR TITLE
Fixed broken link to settings.py configuration

### DIFF
--- a/docs/pages/Deploying/Development-Environment.mdx
+++ b/docs/pages/Deploying/Development-Environment.mdx
@@ -42,7 +42,7 @@ To run the DocsGPT backend locally, you'll need to set up a Python environment a
 
     *   **Option 1: Using a `.env` file (Recommended):**
         *   If you haven't already, create a file named `.env` in the **root directory** of your DocsGPT project.
-        *   Modify the `.env` file to adjust settings as needed. You can find a comprehensive list of configurable options in [`application/core/settings.py`](application/core/settings.py).
+        *   Modify the `.env` file to adjust settings as needed. You can find a comprehensive list of configurable options in [`application/core/settings.py`](https://github.com/arc53/DocsGPT/blob/main/application/core/settings.py).
 
     *   **Option 2: Exporting Environment Variables:**
         *   Alternatively, you can export environment variables directly in your terminal. However, using a `.env` file is generally more organized for development.


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
docs update
- **Why was this change needed?** (You can also link to an open issue here)
Mentioning the settings.py location on as ```[application/core/settings.py](application/core/settings.py)``` created a link to
https://docs.docsgpt.cloud/Deploying/application/core/settings.py which can misguide the users to a wrong page. That's why I have updated the link to the original location of this file to this repo https://github.com/arc53/DocsGPT/blob/main/application/core/settings.py
