### PR TITLE
fix(ui): enhance accessibility and styling for new chat buttons

### DIFF
--- a/frontend/src/Navigation.tsx
+++ b/frontend/src/Navigation.tsx
@@ -319,7 +319,8 @@ export default function Navigation({ navOpen, setNavOpen }: NavigationProps) {
                 onClick={() => {
                   newChat();
                 }}
-                className="transition-transform duration-200 hover:scale-110"
+                aria-label="Start new chat"
+                className="text-eerie-black dark:text-bright-gray hidden items-center gap-2 rounded-full bg-white px-3 py-1 shadow-sm transition-transform duration-150 hover:-translate-y-0.5 md:flex dark:bg-[#0b0b0c]"
               >
                 <img
                   src={openNewChat}
@@ -378,19 +379,17 @@ export default function Navigation({ navOpen, setNavOpen }: NavigationProps) {
             resetConversation();
           }}
           className={({ isActive }) =>
-            `${
-              isActive ? 'bg-transparent' : ''
-            } group border-silver hover:border-rainy-gray dark:border-purple-taupe sticky mx-4 mt-4 flex cursor-pointer gap-2.5 rounded-3xl border p-3 hover:bg-transparent dark:text-white`
+            `sticky mx-4 mt-4 flex cursor-pointer items-center gap-3 rounded-full p-3 transition-all duration-200 ${
+              isActive
+                ? 'bg-gradient-to-r from-[#6EE7B7] to-[#3B82F6] text-white shadow-md'
+                : 'text-eerie-black dark:text-bright-gray bg-white hover:scale-[1.02] hover:shadow dark:bg-[#0b0b0c]'
+            }`
           }
         >
-          <img
-            src={Add}
-            alt="Create new chat"
-            className="opacity-80 group-hover:opacity-100"
-          />
-          <p className="text-dove-gray dark:text-chinese-silver dark:group-hover:text-bright-gray text-sm group-hover:text-neutral-600">
-            {t('newChat')}
-          </p>
+          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gradient-to-tr from-white/60 to-white/30 shadow-sm">
+            <img src={Add} alt="Create new chat" className="h-5 w-5" />
+          </div>
+          <p className="text-sm font-medium">{t('newChat')}</p>
         </NavLink>
         <div
           id="conversationsMainDiv"

--- a/frontend/src/components/ActionButtons.tsx
+++ b/frontend/src/components/ActionButtons.tsx
@@ -46,14 +46,15 @@ export default function ActionButtons({
         {showNewChat && (
           <button
             title="Open New Chat"
+            aria-label="Open New Chat"
             onClick={newChat}
-            className="hover:bg-bright-gray flex items-center gap-1 rounded-full p-2 lg:hidden dark:hover:bg-[#28292E]"
+            className="text-eerie-black dark:text-bright-gray flex items-center gap-2 rounded-full bg-white px-3 py-2 shadow-sm transition-transform duration-150 hover:-translate-y-0.5 hover:shadow-md lg:hidden dark:bg-[#0b0b0c]"
           >
             <img
-              className="filter dark:invert"
+              className="h-5 w-5 filter dark:invert"
               alt="NewChat"
-              width={21}
-              height={21}
+              width={20}
+              height={20}
               src={newChatIcon}
             />
           </button>


### PR DESCRIPTION
**Description** This PR refreshes the "New Chat" button UI to be visually consistent and more attractive across the entire app. The update replaces the older icon-only/unstyled variants with a unified pill-style button that includes improved spacing, shadow, hover/active states, and better dark-mode contrast.

**What changed**
Reworked visual styling to use a rounded pill, subtle shadow, and smooth hover/active transforms.
Added an eye-catching active gradient state for the selected view and subtle elevation for inactive/hover states.
Improved icon sizing and alignment to ensure consistent spacing next to the label.
Added/ensured accessible labels for icon-only controls so the button is screen-reader friendly.

Previous
![WhatsApp Image 2025-10-12 at 09 33 16_70d3b6f2](https://github.com/user-attachments/assets/48cd3d94-8349-48d1-96ab-835ac3588ca9)

New/Updated
<img width="342" height="216" alt="image" src="https://github.com/user-attachments/assets/0b120710-c016-47cc-a814-d8b18539c316" />
