### PR TITLE
Fix: Remove redundant conditional expression in file selection logic

### DIFF
--- a/frontend/src/components/FileUpload.tsx
+++ b/frontend/src/components/FileUpload.tsx
@@ -101,7 +101,7 @@ export const FileUpload = ({
       const filesToUpload = multiple ? acceptedFiles : [acceptedFiles[0]];
       onUpload(filesToUpload);
 
-      const file = multiple ? acceptedFiles[0] : acceptedFiles[0];
+      const file = acceptedFiles[0];
       setCurrentFile(file);
 
       if (showPreview && file.type.startsWith('image/')) {


### PR DESCRIPTION
### Summary
Removed a redundant conditional operator in the upload logic that caused
a SonarQube TypeScript:S3923 issue.

### Changes
- Simplified file selection:
  `const file = multiple ? acceptedFiles[0] : acceptedFiles[0];`
  → `const file = acceptedFiles[0];`

### Motivation
- Improve readability and maintain clean, maintainable code.
- Ensure compliance with SonarQube rule TypeScript:S3923.

### Impact
- No functional change.
- Code quality improvement only.
