### PR TITLE
Feedback Buttons Appear Before Message is Fully Rendered

### DIFF
--- a/frontend/src/conversation/ConversationBubble.tsx
+++ b/frontend/src/conversation/ConversationBubble.tsx
@@ -556,63 +556,67 @@ const ConversationBubble = forwardRef<
               </div>
             ) : (
               <>
-                <div className="relative mr-2 block items-center justify-center">
-                  <CopyButton textToCopy={message} />
-                </div>
-                <div className="relative mr-2 block items-center justify-center">
-                  <SpeakButton text={message} />
-                </div>
-                {handleFeedback && (
+                {!isStreaming && (
                   <>
-                    <div className="relative mr-2 flex items-center justify-center">
-                      <div>
-                        <div
-                          className={`flex items-center justify-center rounded-full p-2 ${
-                            isLikeHovered
-                              ? 'dark:bg-purple-taupe bg-[#EEEEEE]'
-                              : 'bg-white-3000 dark:bg-transparent'
-                          }`}
-                        >
-                          <Like
-                            className={`${feedback === 'LIKE' ? 'fill-white-3000 stroke-purple-30 dark:fill-transparent' : 'stroke-gray-4000 fill-none'} cursor-pointer`}
-                            onClick={() => {
-                              if (feedback === 'LIKE') {
-                                handleFeedback?.(null);
-                              } else {
-                                handleFeedback?.('LIKE');
-                              }
-                            }}
-                            onMouseEnter={() => setIsLikeHovered(true)}
-                            onMouseLeave={() => setIsLikeHovered(false)}
-                          ></Like>
-                        </div>
-                      </div>
+                    <div className="relative mr-2 block items-center justify-center">
+                      <CopyButton textToCopy={message} />
                     </div>
+                    <div className="relative mr-2 block items-center justify-center">
+                      <SpeakButton text={message} />
+                    </div>
+                    {handleFeedback && (
+                      <>
+                        <div className="relative mr-2 flex items-center justify-center">
+                          <div>
+                            <div
+                              className={`flex items-center justify-center rounded-full p-2 ${
+                                isLikeHovered
+                                  ? 'dark:bg-purple-taupe bg-[#EEEEEE]'
+                                  : 'bg-white-3000 dark:bg-transparent'
+                              }`}
+                            >
+                              <Like
+                                className={`${feedback === 'LIKE' ? 'fill-white-3000 stroke-purple-30 dark:fill-transparent' : 'stroke-gray-4000 fill-none'} cursor-pointer`}
+                                onClick={() => {
+                                  if (feedback === 'LIKE') {
+                                    handleFeedback?.(null);
+                                  } else {
+                                    handleFeedback?.('LIKE');
+                                  }
+                                }}
+                                onMouseEnter={() => setIsLikeHovered(true)}
+                                onMouseLeave={() => setIsLikeHovered(false)}
+                              ></Like>
+                            </div>
+                          </div>
+                        </div>
 
-                    <div className="relative mr-2 flex items-center justify-center">
-                      <div>
-                        <div
-                          className={`flex items-center justify-center rounded-full p-2 ${
-                            isDislikeHovered
-                              ? 'dark:bg-purple-taupe bg-[#EEEEEE]'
-                              : 'bg-white-3000 dark:bg-transparent'
-                          }`}
-                        >
-                          <Dislike
-                            className={`${feedback === 'DISLIKE' ? 'fill-white-3000 stroke-red-2000 dark:fill-transparent' : 'stroke-gray-4000 fill-none'} cursor-pointer`}
-                            onClick={() => {
-                              if (feedback === 'DISLIKE') {
-                                handleFeedback?.(null);
-                              } else {
-                                handleFeedback?.('DISLIKE');
-                              }
-                            }}
-                            onMouseEnter={() => setIsDislikeHovered(true)}
-                            onMouseLeave={() => setIsDislikeHovered(false)}
-                          ></Dislike>
+                        <div className="relative mr-2 flex items-center justify-center">
+                          <div>
+                            <div
+                              className={`flex items-center justify-center rounded-full p-2 ${
+                                isDislikeHovered
+                                  ? 'dark:bg-purple-taupe bg-[#EEEEEE]'
+                                  : 'bg-white-3000 dark:bg-transparent'
+                              }`}
+                            >
+                              <Dislike
+                                className={`${feedback === 'DISLIKE' ? 'fill-white-3000 stroke-red-2000 dark:fill-transparent' : 'stroke-gray-4000 fill-none'} cursor-pointer`}
+                                onClick={() => {
+                                  if (feedback === 'DISLIKE') {
+                                    handleFeedback?.(null);
+                                  } else {
+                                    handleFeedback?.('DISLIKE');
+                                  }
+                                }}
+                                onMouseEnter={() => setIsDislikeHovered(true)}
+                                onMouseLeave={() => setIsDislikeHovered(false)}
+                              ></Dislike>
+                            </div>
+                          </div>
                         </div>
-                      </div>
-                    </div>
+                      </>
+                    )}
                   </>
                 )}
               </>


### PR DESCRIPTION
Fix #2038

# Description
Earlier the feedback buttons were showing up as soon as the AI started replying. It didn’t look good because the message was still typing and the buttons already came.

Now I fixed it, so the feedback buttons will only show after the AI fully completes the message. This looks much better and feels more natural while using the chat.

# Before
[Screencast From 2025-10-14 14-58-24.webm](https://github.com/user-attachments/assets/f0a15119-9f1d-4e9e-bf6f-84730a38103f)

# After
[Screencast From 2025-10-14 14-43-16.webm](https://github.com/user-attachments/assets/4a1a954f-3452-40d8-abbe-60910550327c)
