### PR TITLE
Changed the file attachment system to support multiple files upload by the user

### DIFF
--- a/results.txt
+++ b/results.txt
@@ -1,0 +1,12 @@
+Base URL:http://petstore.swagger.io,https://api.example.com
+Path1: /pets
+description: None
+parameters: []
+methods: 
+get=A paged array of pets
+post=Null response
+Path2: /pets/{petId}
+description: None
+parameters: []
+methods: 
+get=Expected response to a valid request


### PR DESCRIPTION
I have made edits to the following files:
1) `/application/api/user/attachments/routes.py`
2) `/frontend/src/components/MessageInput.tsx`

In `routes.py`, earlier it accepted only one file as input, now I have edited it to allow multiple file uploads, and it processes each one separately and saves it in the storage.

In `MessageInput.tsx`, I have edited the xhr object to allow the user to select multiple files on the frontend to be uploaded through the attachment button.