### PR TITLE
Fix: Make Search Bar Responsive for Small Screens #2113

### DIFF
--- a/frontend/src/settings/Sources.tsx
+++ b/frontend/src/settings/Sources.tsx
@@ -301,12 +301,12 @@ export default function Sources({
             {t('settings.sources.title')}
           </h2>
         </div>
-        <div className="mb-6 flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-center">
-          <div className="w-full sm:w-auto">
+        <div className="mb-6 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="w-full max-w-full sm:w-auto sm:min-w-[280px]">
             <label htmlFor="document-search-input" className="sr-only">
               {t('settings.sources.searchPlaceholder')}
             </label>
-            <div className="relative w-[280px]">
+            <div className="relative w-full min-w-0">
               <input
                 maxLength={256}
                 placeholder={t('settings.sources.searchPlaceholder')}
@@ -318,12 +318,12 @@ export default function Sources({
                   setSearchTerm(e.target.value);
                   setCurrentPage(1);
                 }}
-                className="border-silver dark:border-silver/40 text-jet dark:text-bright-gray focus:border-silver dark:focus:border-silver/60 h-[32px] w-full rounded-full border bg-transparent px-3 text-sm outline-none placeholder:text-gray-400 dark:placeholder:text-gray-500"
+                className="border-silver dark:border-silver/40 text-jet dark:text-bright-gray focus:border-silver dark:focus:border-silver/60 h-[32px] w-full min-w-0 min-w-[120px] rounded-full border bg-transparent px-3 text-sm outline-none placeholder:text-gray-400 dark:placeholder:text-gray-500"
               />
             </div>
           </div>
           <button
-            className="bg-purple-30 hover:bg-violets-are-blue flex h-[38px] min-w-[108px] items-center justify-center rounded-full px-4 text-[14px] whitespace-normal text-white"
+            className="bg-purple-30 hover:bg-violets-are-blue flex h-[38px] w-full min-w-[108px] items-center justify-center rounded-full px-4 text-[14px] whitespace-normal text-white sm:w-auto"
             title={t('settings.sources.addSource')}
             onClick={() => {
               setIsOnboarding(false);

--- a/frontend/src/settings/Tools.tsx
+++ b/frontend/src/settings/Tools.tsx
@@ -157,8 +157,8 @@ export default function Tools() {
       ) : (
         <div className="mt-8">
           <div className="relative flex flex-col">
-            <div className="my-3 flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <div className="w-full sm:w-auto">
+            <div className="my-3 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="w-full max-w-full sm:w-auto sm:min-w-[280px]">
                 <Input
                   maxLength={256}
                   placeholder={t('settings.tools.searchPlaceholder')}
@@ -168,10 +168,11 @@ export default function Tools() {
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
                   borderVariant="thin"
+                  className="w-full min-w-0 min-w-[120px]"
                 />
               </div>
               <button
-                className="bg-purple-30 hover:bg-violets-are-blue flex h-[32px] min-w-[108px] items-center justify-center rounded-full px-4 text-sm whitespace-normal text-white"
+                className="bg-purple-30 hover:bg-violets-are-blue flex h-[32px] w-full min-w-[108px] items-center justify-center rounded-full px-4 text-sm whitespace-normal text-white sm:w-auto"
                 onClick={() => {
                   setAddToolModalState('ACTIVE');
                 }}


### PR DESCRIPTION
### Description

- Makes the search bar on the **Tools** and **Sources** screens fully responsive for all screen sizes (desktop, tablet, mobile).
- Ensures a minimum width on small screens, preventing overlap or the search field from disappearing.
- Adjusts alignment and spacing for better usability on mobile devices.

### How to test

1. Access the Tools and Sources screens at different screen widths (desktop, tablet, mobile).
2. Verify that the search bar remains visible, properly aligned, and functional on all devices.