### PR TITLE
fix: relax ESLint strict type rules to warnings

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -21,6 +21,8 @@ module.exports = {
     'react/prop-types': 'off',
     'unused-imports/no-unused-imports': 'error',
     'react/react-in-jsx-scope': 'off',
+    '@typescript-eslint/no-explicit-any': 'warn',
+    '@typescript-eslint/no-unused-vars': 'warn',
     'prettier/prettier': [
       'error',
       {


### PR DESCRIPTION
Adjust @typescript-eslint/no-explicit-any and @typescript-eslint/no-unused-vars from error to warning to allow gradual code refactoring.