### PR TITLE
chore(dependabot): add react-widget npm dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
     directory: "/frontend" # Location of package manifests
     schedule:
       interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/extensions/react-widget"
+    schedule:
+      interval: "daily"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
     Expands the `dependabot.yml` file to include the React widget's npm dependencies. This change ensures that Dependabot automatically monitors and creates pull requests for updates to these dependencies.
- **Why was this change needed?** (You can also link to an open issue here)
     maintenance