### PR TITLE
fix: update Node.js version to 22 for Vite compatibility

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.6.1-bullseye-slim
+FROM node:22-bullseye-slim
 
 
 WORKDIR /app


### PR DESCRIPTION
Updates the frontend Dockerfile from Node 20.6.1 to Node 22 to resolve compatibility issues with Vite dependencies.

Closes #2157
