### PR TITLE
Bugfix/docs gpt widget behavior

### DIFF
--- a/extensions/react-widget/src/components/DocsGPTWidget.tsx
+++ b/extensions/react-widget/src/components/DocsGPTWidget.tsx
@@ -719,8 +719,8 @@ export const WidgetCore = ({
   md.renderer.rules.table_close = () => '</table></div>';
   md.renderer.rules.thead_open = () => '<thead class="dgpt-thead">';
   md.renderer.rules.tr_open = () => '<tr class="dgpt-tr">';
-  md.renderer.rules.td_open = () => '<th class="dgpt-th">';
-  md.renderer.rules.th_open = () => '<td class="dgpt-td">';
+  md.renderer.rules.td_open = () => '<td class="dgpt-td">';
+  md.renderer.rules.th_open = () => '<th class="dgpt-th">';
 
 
 
@@ -891,15 +891,11 @@ export const WidgetCore = ({
   // submit handler
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    // Prevent sending empty messages
-    if (promptRef.current && promptRef.current.value.trim() === "") return;
-    //Rest the input to it's original size after submitting
-    if( promptRef.current){
-        promptRef.current.value = "";
-        promptRef.current.style.height = "auto"; 
+    if (!prompt.trim()) return;
+    if (promptRef.current) {
+      promptRef.current.style.height = "auto";
     }
-    await appendQuery(prompt)
-    
+    await appendQuery(prompt);
   }
   const handlePromptKeyDown = async (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR introduces a bug fix to the messaging widget:

Fix message bubble width and text wrapping to prevent overflow.

Correct list spacing and alignment.

Add responsive table support to prevent layout issues.

Replace the single-line input with a textarea to support multi-line input, custom scrollbar styling, and Enter/Shift+Enter behavior for message submission.

- **Why was this change needed?** (You can also link to an open issue here)

Bug fixes were needed to resolve display issues that caused messages, lists, and tables to render improperly or overflow the chat container.

The feature was needed to allow users to input multi-line prompts naturally while maintaining proper submission behavior.

Issue Link: https://github.com/arc53/DocsGPT/issues/2159
- **Other information**:

video showcase:

https://github.com/user-attachments/assets/eac1c327-3ab3-4b11-b467-91cd44fbef11


https://github.com/user-attachments/assets/2941527e-921a-44c5-b1cc-f0bf98710f34

