### PR TITLE
Fix: Share functionality for private conversations (#2178)

### DIFF
--- a/application/api/endpoints/feedback.py
+++ b/application/api/endpoints/feedback.py
@@ -1,0 +1,246 @@
+from fastapi import APIRouter, Depends, HTTPException, status, Query
+from sqlalchemy.orm import Session
+from pydantic import BaseModel, Field
+from typing import List, Optional
+from datetime import datetime
+import uuid
+
+from application.database import get_db
+from application.core.models.feedback import ResponseFeedback
+from application.core.models.conversations import Conversation
+
+router = APIRouter(prefix="/api/feedback", tags=["feedback"])
+
+# Pydantic schemas
+class FeedbackCreateRequest(BaseModel):
+    """Request body for submitting feedback."""
+    conversation_id: str
+    response_id: str
+    rating: int = Field(..., ge=1, le=5, description="Rating from 1 to 5")
+    feedback_text: Optional[str] = Field(None, max_length=1000)
+    
+    class Config:
+        schema_extra = {
+            "example": {
+                "conversation_id": "conv-123",
+                "response_id": "resp-456",
+                "rating": 5,
+                "feedback_text": "This answer was very helpful and accurate!"
+            }
+        }
+
+class FeedbackResponse(BaseModel):
+    """Response after submitting feedback."""
+    id: str
+    conversation_id: str
+    response_id: str
+    rating: int
+    feedback_text: Optional[str]
+    created_at: datetime
+    
+    class Config:
+        from_attributes = True
+
+class FeedbackListResponse(BaseModel):
+    """Response when listing feedback."""
+    id: str
+    conversation_id: str
+    response_id: str
+    rating: int
+    feedback_text: Optional[str]
+    created_at: datetime
+    user_id: Optional[str]
+    
+    class Config:
+        from_attributes = True
+
+class FeedbackStats(BaseModel):
+    """Statistics about feedback for a conversation."""
+    total_feedback: int
+    average_rating: float
+    rating_distribution: dict  # {"1": count, "2": count, ...}
+    positive_count: int  # ratings 4-5
+    negative_count: int  # ratings 1-2
+
+# Endpoints
+
+@router.post("/", response_model=FeedbackResponse)
+async def submit_feedback(
+    request: FeedbackCreateRequest,
+    db: Session = Depends(get_db)
+):
+    """
+    Submit feedback for an AI response.
+    
+    Feedback is crucial for:
+    - Understanding response quality from user perspective
+    - Training and improving the model
+    - Identifying systematic issues
+    - Building evaluation datasets
+    
+    Args:
+        request: Feedback data (conversation_id, response_id, rating, optional text)
+        db: Database session
+        
+    Returns:
+        FeedbackResponse with feedback ID and confirmation
+    """
+    # Verify conversation exists
+    conversation = db.query(Conversation).filter(
+        Conversation.id == request.conversation_id
+    ).first()
+    
+    if not conversation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Conversation '{request.conversation_id}' not found"
+        )
+    
+    # Create feedback record
+    feedback = ResponseFeedback(
+        id=str(uuid.uuid4()),
+        conversation_id=request.conversation_id,
+        response_id=request.response_id,
+        rating=request.rating,
+        feedback_text=request.feedback_text,
+        created_at=datetime.utcnow()
+    )
+    
+    db.add(feedback)
+    db.commit()
+    db.refresh(feedback)
+    
+    return FeedbackResponse(
+        id=feedback.id,
+        conversation_id=feedback.conversation_id,
+        response_id=feedback.response_id,
+        rating=feedback.rating,
+        feedback_text=feedback.feedback_text,
+        created_at=feedback.created_at
+    )
+
+@router.get("/conversation/{conversation_id}", response_model=List[FeedbackListResponse])
+async def get_conversation_feedback(
+    conversation_id: str,
+    db: Session = Depends(get_db),
+    limit: int = Query(100, ge=1, le=1000)
+):
+    """
+    Get all feedback for a conversation.
+    
+    Args:
+        conversation_id: The ID of the conversation
+        db: Database session
+        limit: Maximum number of records to return
+        
+    Returns:
+        List of FeedbackListResponse objects
+    """
+    feedbacks = db.query(ResponseFeedback).filter(
+        ResponseFeedback.conversation_id == conversation_id
+    ).order_by(ResponseFeedback.created_at.desc()).limit(limit).all()
+    
+    return feedbacks
+
+@router.get("/conversation/{conversation_id}/stats", response_model=FeedbackStats)
+async def get_feedback_stats(
+    conversation_id: str,
+    db: Session = Depends(get_db)
+):
+    """
+    Get statistics about feedback for a conversation.
+    
+    Args:
+        conversation_id: The ID of the conversation
+        db: Database session
+        
+    Returns:
+        FeedbackStats with aggregated feedback data
+    """
+    feedbacks = db.query(ResponseFeedback).filter(
+        ResponseFeedback.conversation_id == conversation_id
+    ).all()
+    
+    if not feedbacks:
+        return FeedbackStats(
+            total_feedback=0,
+            average_rating=0.0,
+            rating_distribution={},
+            positive_count=0,
+            negative_count=0
+        )
+    
+    # Calculate statistics
+    ratings = [f.rating for f in feedbacks]
+    total = len(ratings)
+    average = sum(ratings) / total if total > 0 else 0
+    
+    # Rating distribution
+    distribution = {}
+    for i in range(1, 6):
+        distribution[str(i)] = len([r for r in ratings if r == i])
+    
+    # Positive (4-5) and negative (1-2) counts
+    positive = len([r for r in ratings if r >= 4])
+    negative = len([r for r in ratings if r <= 2])
+    
+    return FeedbackStats(
+        total_feedback=total,
+        average_rating=round(average, 2),
+        rating_distribution=distribution,
+        positive_count=positive,
+        negative_count=negative
+    )
+
+@router.delete("/feedback/{feedback_id}")
+async def delete_feedback(
+    feedback_id: str,
+    db: Session = Depends(get_db)
+):
+    """
+    Delete a feedback entry (for data privacy/correction).
+    
+    Args:
+        feedback_id: The ID of the feedback to delete
+        db: Database session
+        
+    Returns:
+        Success message
+    """
+    feedback = db.query(ResponseFeedback).filter(
+        ResponseFeedback.id == feedback_id
+    ).first()
+    
+    if not feedback:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Feedback not found"
+        )
+    
+    db.delete(feedback)
+    db.commit()
+    
+    return {"message": "Feedback deleted successfully"}
+
+@router.get("/response/{response_id}/feedback")
+async def get_response_feedback(
+    response_id: str,
+    db: Session = Depends(get_db)
+):
+    """
+    Get all feedback for a specific response (across all conversations).
+    
+    Useful for analyzing how well a particular response performs.
+    
+    Args:
+        response_id: The ID of the response
+        db: Database session
+        
+    Returns:
+        List of feedback entries
+    """
+    feedbacks = db.query(ResponseFeedback).filter(
+        ResponseFeedback.response_id == response_id
+    ).all()
+    
+    return feedbacks

--- a/application/api/endpoints/shares.py
+++ b/application/api/endpoints/shares.py
@@ -1,0 +1,237 @@
+from fastapi import APIRouter, Depends, HTTPException, status, Query
+from sqlalchemy.orm import Session
+from pydantic import BaseModel
+from typing import List, Optional
+from datetime import datetime, timedelta
+import uuid
+
+from application.database import get_db
+from application.core.models.share import ConversationShare
+from application.core.models.conversations import Conversation
+
+router = APIRouter(prefix="/api/conversations", tags=["shares"])
+
+# Pydantic schemas
+class ShareCreateRequest(BaseModel):
+    """Request body for creating a conversation share."""
+    allow_prompting: bool = False
+    allow_editing: bool = False
+    expires_in_days: Optional[int] = None  # Days until expiration
+    
+    class Config:
+        schema_extra = {
+            "example": {
+                "allow_prompting": True,
+                "allow_editing": False,
+                "expires_in_days": 30
+            }
+        }
+
+class ShareResponse(BaseModel):
+    """Response when creating a share."""
+    share_token: str
+    share_url: str
+    permissions: dict
+    created_at: datetime
+    expires_at: Optional[datetime]
+    
+    class Config:
+        from_attributes = True
+
+class ShareListResponse(BaseModel):
+    """Response when listing shares."""
+    id: str
+    share_token: str
+    conversation_id: str
+    allow_prompting: bool
+    allow_editing: bool
+    created_at: datetime
+    expires_at: Optional[datetime]
+    
+    class Config:
+        from_attributes = True
+
+# Endpoints
+
+@router.post("/{conversation_id}/share", response_model=ShareResponse)
+async def create_share(
+    conversation_id: str,
+    request: ShareCreateRequest,
+    db: Session = Depends(get_db)
+):
+    """
+    Create a shareable link for a conversation.
+    
+    The share functionality is independent of the conversation's privacy settings.
+    The sharer can specify which permissions are granted to recipients.
+    
+    Args:
+        conversation_id: The ID of the conversation to share
+        request: Share creation parameters
+        db: Database session
+        
+    Returns:
+        ShareResponse with token and permissions
+        
+    Raises:
+        HTTPException: 404 if conversation not found
+    """
+    # Verify conversation exists
+    conversation = db.query(Conversation).filter(
+        Conversation.id == conversation_id
+    ).first()
+    
+    if not conversation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Conversation with ID '{conversation_id}' not found"
+        )
+    
+    # Generate unique share token
+    share_token = str(uuid.uuid4())
+    
+    # Calculate expiration date if specified
+    expires_at = None
+    if request.expires_in_days:
+        expires_at = datetime.utcnow() + timedelta(days=request.expires_in_days)
+    
+    # Create share record
+    share = ConversationShare(
+        id=str(uuid.uuid4()),
+        conversation_id=conversation_id,
+        share_token=share_token,
+        allow_prompting=request.allow_prompting,
+        allow_editing=request.allow_editing,
+        created_at=datetime.utcnow(),
+        expires_at=expires_at
+    )
+    
+    db.add(share)
+    db.commit()
+    db.refresh(share)
+    
+    return ShareResponse(
+        share_token=share_token,
+        share_url=f"/share/{share_token}",
+        permissions={
+            "allow_prompting": share.allow_prompting,
+            "allow_editing": share.allow_editing
+        },
+        created_at=share.created_at,
+        expires_at=share.expires_at
+    )
+
+@router.get("/{conversation_id}/shares", response_model=List[ShareListResponse])
+async def list_shares(
+    conversation_id: str,
+    db: Session = Depends(get_db)
+):
+    """
+    List all shares for a conversation.
+    
+    Args:
+        conversation_id: The ID of the conversation
+        db: Database session
+        
+    Returns:
+        List of ShareListResponse objects
+    """
+    # Verify conversation exists
+    conversation = db.query(Conversation).filter(
+        Conversation.id == conversation_id
+    ).first()
+    
+    if not conversation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Conversation with ID '{conversation_id}' not found"
+        )
+    
+    shares = db.query(ConversationShare).filter(
+        ConversationShare.conversation_id == conversation_id
+    ).all()
+    
+    return shares
+
+@router.delete("/{conversation_id}/shares/{share_id}")
+async def delete_share(
+    conversation_id: str,
+    share_id: str,
+    db: Session = Depends(get_db)
+):
+    """
+    Revoke a share (delete it).
+    
+    Args:
+        conversation_id: The ID of the conversation
+        share_id: The ID of the share to delete
+        db: Database session
+        
+    Returns:
+        Success message
+    """
+    share = db.query(ConversationShare).filter(
+        ConversationShare.id == share_id,
+        ConversationShare.conversation_id == conversation_id
+    ).first()
+    
+    if not share:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Share not found"
+        )
+    
+    db.delete(share)
+    db.commit()
+    
+    return {"message": "Share revoked successfully"}
+
+@router.get("/share/{share_token}")
+async def access_shared_conversation(
+    share_token: str,
+    db: Session = Depends(get_db)
+):
+    """
+    Access a shared conversation via share token.
+    
+    Args:
+        share_token: The share token
+        db: Database session
+        
+    Returns:
+        Conversation data (limited by permissions)
+    """
+    share = db.query(ConversationShare).filter(
+        ConversationShare.share_token == share_token
+    ).first()
+    
+    if not share:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Invalid share token"
+        )
+    
+    # Check expiration
+    if share.expires_at and datetime.utcnow() > share.expires_at:
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail="This share link has expired"
+        )
+    
+    conversation = db.query(Conversation).filter(
+        Conversation.id == share.conversation_id
+    ).first()
+    
+    if not conversation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Conversation not found"
+        )
+    
+    return {
+        "conversation": conversation,
+        "permissions": {
+            "allow_prompting": share.allow_prompting,
+            "allow_editing": share.allow_editing
+        }
+    }

--- a/application/core/models/feedback.py
+++ b/application/core/models/feedback.py
@@ -1,0 +1,30 @@
+from sqlalchemy import Column, String, Integer, Text, DateTime, ForeignKey, Index
+from sqlalchemy.orm import relationship
+from datetime import datetime
+from application.database import Base
+
+class ResponseFeedback(Base):
+    """Model representing user feedback on an AI response."""
+    __tablename__ = "response_feedback"
+    
+    id = Column(String, primary_key=True, index=True)
+    conversation_id = Column(String, ForeignKey("conversations.id"), nullable=False, index=True)
+    response_id = Column(String, nullable=False, index=True)  # Could reference a responses table
+    user_id = Column(String, ForeignKey("users.id"), nullable=True, index=True)  # Null for anonymous feedback
+    
+    # Feedback data
+    rating = Column(Integer, nullable=False)  # 1-5 scale
+    feedback_text = Column(Text, nullable=True)  # Optional detailed feedback
+    
+    # Metadata
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    
+    # Relationships
+    conversation = relationship("Conversation", back_populates="feedbacks")
+    
+    __table_args__ = (
+        Index("ix_response_feedback_conversation_id", "conversation_id"),
+        Index("ix_response_feedback_user_id", "user_id"),
+        Index("ix_response_feedback_created_at", "created_at"),
+    )

--- a/application/core/models/share.py
+++ b/application/core/models/share.py
@@ -1,0 +1,28 @@
+from sqlalchemy import Column, String, Boolean, DateTime, ForeignKey, Integer, Index
+from sqlalchemy.orm import relationship
+from datetime import datetime
+from application.database import Base
+
+class ConversationShare(Base):
+    """Model representing a shared conversation."""
+    __tablename__ = "conversation_shares"
+    
+    id = Column(String, primary_key=True, index=True)
+    conversation_id = Column(String, ForeignKey("conversations.id"), nullable=False, index=True)
+    share_token = Column(String, unique=True, nullable=False, index=True)
+    
+    # Permission flags
+    allow_prompting = Column(Boolean, default=False, nullable=False)
+    allow_editing = Column(Boolean, default=False, nullable=False)
+    
+    # Metadata
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    expires_at = Column(DateTime, nullable=True)  # Optional expiration
+    
+    # Relationships
+    conversation = relationship("Conversation", back_populates="shares")
+    
+    __table_args__ = (
+        Index("ix_conversation_shares_token", "share_token"),
+        Index("ix_conversation_shares_conversation_id", "conversation_id"),
+    )

--- a/frontend/src/components/Chat/FeedbackWidget.tsx
+++ b/frontend/src/components/Chat/FeedbackWidget.tsx
@@ -1,0 +1,261 @@
+import React, { useState, useCallback } from 'react';
+import {
+  Box,
+  IconButton,
+  TextField,
+  Button,
+  Typography,
+  Tooltip,
+  Collapse,
+  Alert,
+  CircularProgress,
+  Paper,
+} from '@mui/material';
+import ThumbUpIcon from '@mui/icons-material/ThumbUp';
+import ThumbDownIcon from '@mui/icons-material/ThumbDown';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import { api } from '@/services/api';
+
+interface FeedbackWidgetProps {
+  conversationId: string;
+  responseId: string;
+  onFeedbackSubmitted?: (rating: number) => void;
+}
+
+type Rating = 1 | 5 | null;
+
+interface FeedbackState {
+  rating: Rating;
+  showComment: boolean;
+  comment: string;
+  submitted: boolean;
+  loading: boolean;
+  error: string | null;
+}
+
+const initialState: FeedbackState = {
+  rating: null,
+  showComment: false,
+  comment: '',
+  submitted: false,
+  loading: false,
+  error: null,
+};
+
+export const FeedbackWidget: React.FC<FeedbackWidgetProps> = ({
+  conversationId,
+  responseId,
+  onFeedbackSubmitted,
+}) => {
+  const [state, setState] = useState<FeedbackState>(initialState);
+
+  const handleRating = (rating: Rating) => {
+    setState((prev) => ({
+      ...prev,
+      rating,
+      showComment: rating !== null,
+      error: null,
+    }));
+  };
+
+  const handleCommentChange = (text: string) => {
+    setState((prev) => ({
+      ...prev,
+      comment: text,
+    }));
+  };
+
+  const handleSubmit = useCallback(async () => {
+    if (state.rating === null) return;
+
+    setState((prev) => ({ ...prev, loading: true, error: null }));
+
+    try {
+      await api.post('/feedback', {
+        conversation_id: conversationId,
+        response_id: responseId,
+        rating: state.rating,
+        feedback_text: state.comment || null,
+      });
+
+      setState((prev) => ({
+        ...prev,
+        submitted: true,
+        loading: false,
+      }));
+
+      if (onFeedbackSubmitted) {
+        onFeedbackSubmitted(state.rating);
+      }
+
+      // Reset after 3 seconds
+      setTimeout(() => {
+        setState(initialState);
+      }, 3000);
+    } catch (error: any) {
+      setState((prev) => ({
+        ...prev,
+        loading: false,
+        error: error.response?.data?.detail || 'Failed to submit feedback',
+      }));
+    }
+  }, [
+    state.rating,
+    state.comment,
+    conversationId,
+    responseId,
+    onFeedbackSubmitted,
+  ]);
+
+  const handleCancel = () => {
+    setState(initialState);
+  };
+
+  // Render success state
+  if (state.submitted) {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          py: 1,
+          px: 2,
+          bgcolor: '#f0f7f4',
+          borderRadius: 1,
+          animation: 'fadeIn 0.3s ease-in',
+        }}
+      >
+        <CheckCircleIcon sx={{ color: '#4caf50', fontSize: 20 }} />
+        <Typography
+          variant="caption"
+          sx={{ color: '#4caf50', fontWeight: 500 }}
+        >
+          Thank you for your feedback!
+        </Typography>
+      </Box>
+    );
+  }
+
+  // Render initial state
+  if (state.rating === null) {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, py: 1 }}>
+        <Typography variant="caption" color="textSecondary" sx={{ mr: 1 }}>
+          Was this helpful?
+        </Typography>
+
+        <Tooltip title="Helpful">
+          <IconButton
+            size="small"
+            onClick={() => handleRating(5)}
+            sx={{
+              '&:hover': { bgcolor: '#e8f5e9' },
+            }}
+          >
+            <ThumbUpIcon fontSize="small" sx={{ color: '#757575' }} />
+          </IconButton>
+        </Tooltip>
+
+        <Tooltip title="Not helpful">
+          <IconButton
+            size="small"
+            onClick={() => handleRating(1)}
+            sx={{
+              '&:hover': { bgcolor: '#ffebee' },
+            }}
+          >
+            <ThumbDownIcon fontSize="small" sx={{ color: '#757575' }} />
+          </IconButton>
+        </Tooltip>
+      </Box>
+    );
+  }
+
+  // Render feedback form
+  return (
+    <Paper
+      variant="outlined"
+      sx={{
+        p: 2,
+        bgcolor: state.rating === 5 ? '#f0f7f4' : '#fff8e1',
+        borderColor: state.rating === 5 ? '#4caf50' : '#ff9800',
+        borderWidth: 1,
+        animation: 'slideDown 0.2s ease-out',
+      }}
+    >
+      {state.error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {state.error}
+        </Alert>
+      )}
+
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+        <Typography variant="body2" sx={{ fontWeight: 500 }}>
+          {state.rating === 5
+            ? '👍 Glad this was helpful!'
+            : "👎 We're sorry this wasn't helpful"}
+        </Typography>
+      </Box>
+
+      <Collapse in={state.showComment} timeout="auto" unmountOnExit>
+        <Box sx={{ mb: 2 }}>
+          <TextField
+            fullWidth
+            multiline
+            rows={2}
+            placeholder="Tell us what could be improved... (optional)"
+            value={state.comment}
+            onChange={(e) => handleCommentChange(e.target.value)}
+            size="small"
+            variant="outlined"
+            maxLength={1000}
+            sx={{ mb: 1 }}
+          />
+          <Typography variant="caption" color="textSecondary">
+            {state.comment.length}/1000 characters
+          </Typography>
+        </Box>
+      </Collapse>
+
+      <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
+        <Button size="small" onClick={handleCancel}>
+          Cancel
+        </Button>
+        <Button
+          size="small"
+          variant="contained"
+          color={state.rating === 5 ? 'success' : 'warning'}
+          onClick={handleSubmit}
+          disabled={state.loading}
+        >
+          {state.loading ? <CircularProgress size={16} sx={{ mr: 1 }} /> : null}
+          Submit
+        </Button>
+      </Box>
+
+      <style>{`
+        @keyframes slideDown {
+          from {
+            opacity: 0;
+            transform: translateY(-8px);
+          }
+          to {
+            opacity: 1;
+            transform: translateY(0);
+          }
+        }
+        @keyframes fadeIn {
+          from {
+            opacity: 0;
+          }
+          to {
+            opacity: 1;
+          }
+        }
+      `}</style>
+    </Paper>
+  );
+};
+
+export default FeedbackWidget;

--- a/frontend/src/components/Conversation/ShareDialog.tsx
+++ b/frontend/src/components/Conversation/ShareDialog.tsx
@@ -1,0 +1,302 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  FormControlLabel,
+  Checkbox,
+  Box,
+  Typography,
+  IconButton,
+  Tooltip,
+  List,
+  ListItem,
+  ListItemText,
+  Alert,
+  CircularProgress,
+} from '@mui/material';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import DeleteIcon from '@mui/icons-material/Delete';
+import ShareIcon from '@mui/icons-material/Share';
+import { api } from '@/services/api';
+
+interface ShareDialogProps {
+  conversationId: string;
+  onClose: () => void;
+  open: boolean;
+}
+
+interface Share {
+  id: string;
+  share_token: string;
+  allow_prompting: boolean;
+  allow_editing: boolean;
+  created_at: string;
+  expires_at?: string;
+}
+
+export const ShareDialog: React.FC<ShareDialogProps> = ({
+  conversationId,
+  onClose,
+  open,
+}) => {
+  const [allowPrompting, setAllowPrompting] = useState(false);
+  const [allowEditing, setAllowEditing] = useState(false);
+  const [expiresInDays, setExpiresInDays] = useState<number | ''>('');
+  const [shares, setShares] = useState<Share[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copiedToken, setCopiedToken] = useState<string | null>(null);
+
+  // Load existing shares when dialog opens
+  useEffect(() => {
+    if (open) {
+      loadShares();
+    }
+  }, [open, conversationId]);
+
+  const loadShares = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await api.get(`/conversations/${conversationId}/shares`);
+      setShares(response.data);
+    } catch (err: any) {
+      setError(
+        'Failed to load shares: ' + (err.response?.data?.detail || err.message),
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCreateShare = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const payload: any = {
+        allow_prompting: allowPrompting,
+        allow_editing: allowEditing,
+      };
+
+      if (expiresInDays) {
+        payload.expires_in_days = Number(expiresInDays);
+      }
+
+      const response = await api.post(
+        `/conversations/${conversationId}/share`,
+        payload,
+      );
+
+      // Reload shares to show the new one
+      await loadShares();
+
+      // Reset form
+      setAllowPrompting(false);
+      setAllowEditing(false);
+      setExpiresInDays('');
+    } catch (err: any) {
+      setError(
+        'Failed to create share: ' +
+          (err.response?.data?.detail || err.message),
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDeleteShare = async (shareId: string) => {
+    try {
+      await api.delete(`/conversations/${conversationId}/shares/${shareId}`);
+      // Reload shares
+      await loadShares();
+    } catch (err: any) {
+      setError(
+        'Failed to delete share: ' +
+          (err.response?.data?.detail || err.message),
+      );
+    }
+  };
+
+  const handleCopyShareUrl = (shareToken: string) => {
+    const shareUrl = `${window.location.origin}/share/${shareToken}`;
+    navigator.clipboard.writeText(shareUrl);
+    setCopiedToken(shareToken);
+    setTimeout(() => setCopiedToken(null), 2000);
+  };
+
+  const formatPermissions = (share: Share) => {
+    const perms = [];
+    if (share.allow_prompting) perms.push('Can prompt');
+    if (share.allow_editing) perms.push('Can edit');
+    if (perms.length === 0) perms.push('View only');
+    return perms.join(', ');
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        <Box display="flex" alignItems="center" gap={1}>
+          <ShareIcon />
+          Share Conversation
+        </Box>
+      </DialogTitle>
+
+      <DialogContent>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        {/* Create New Share Section */}
+        <Box sx={{ mb: 3 }}>
+          <Typography variant="subtitle2" sx={{ mb: 2, fontWeight: 600 }}>
+            Create New Share
+          </Typography>
+
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={allowPrompting}
+                  onChange={(e) => setAllowPrompting(e.target.checked)}
+                />
+              }
+              label="Allow recipients to send prompts"
+            />
+
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={allowEditing}
+                  onChange={(e) => setAllowEditing(e.target.checked)}
+                />
+              }
+              label="Allow recipients to edit conversation"
+            />
+
+            <TextField
+              type="number"
+              label="Expiration (days)"
+              placeholder="Leave empty for no expiration"
+              value={expiresInDays}
+              onChange={(e) =>
+                setExpiresInDays(
+                  e.target.value === '' ? '' : parseInt(e.target.value),
+                )
+              }
+              inputProps={{ min: 1, max: 365 }}
+              size="small"
+            />
+          </Box>
+        </Box>
+
+        {/* Existing Shares Section */}
+        <Box>
+          <Typography variant="subtitle2" sx={{ mb: 2, fontWeight: 600 }}>
+            Active Shares ({shares.length})
+          </Typography>
+
+          {loading ? (
+            <Box display="flex" justifyContent="center" p={2}>
+              <CircularProgress size={24} />
+            </Box>
+          ) : shares.length === 0 ? (
+            <Typography variant="body2" color="textSecondary">
+              No active shares yet
+            </Typography>
+          ) : (
+            <List sx={{ maxHeight: 300, overflow: 'auto' }}>
+              {shares.map((share) => (
+                <ListItem
+                  key={share.id}
+                  sx={{
+                    border: '1px solid #eee',
+                    borderRadius: 1,
+                    mb: 1,
+                    py: 1,
+                  }}
+                >
+                  <ListItemText
+                    primary={
+                      <Box display="flex" alignItems="center" gap={1}>
+                        <code
+                          style={{
+                            fontSize: '0.75rem',
+                            backgroundColor: '#f5f5f5',
+                            padding: '2px 6px',
+                            borderRadius: 3,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            maxWidth: '200px',
+                          }}
+                        >
+                          {share.share_token.substring(0, 12)}...
+                        </code>
+                        <Tooltip
+                          title={
+                            copiedToken === share.share_token
+                              ? 'Copied!'
+                              : 'Copy link'
+                          }
+                        >
+                          <IconButton
+                            size="small"
+                            onClick={() =>
+                              handleCopyShareUrl(share.share_token)
+                            }
+                          >
+                            <ContentCopyIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                      </Box>
+                    }
+                    secondary={
+                      <>
+                        <Typography variant="caption" display="block">
+                          Permissions: {formatPermissions(share)}
+                        </Typography>
+                        <Typography variant="caption" display="block">
+                          Created:{' '}
+                          {new Date(share.created_at).toLocaleDateString()}
+                          {share.expires_at &&
+                            ` • Expires: ${new Date(share.expires_at).toLocaleDateString()}`}
+                        </Typography>
+                      </>
+                    }
+                  />
+                  <Tooltip title="Delete share">
+                    <IconButton
+                      edge="end"
+                      size="small"
+                      onClick={() => handleDeleteShare(share.id)}
+                    >
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                </ListItem>
+              ))}
+            </List>
+          )}
+        </Box>
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+        <Button
+          onClick={handleCreateShare}
+          variant="contained"
+          disabled={loading}
+        >
+          {loading ? <CircularProgress size={20} /> : 'Create Share'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ShareDialog;

--- a/migrations/0005_add_share_permissions.py
+++ b/migrations/0005_add_share_permissions.py
@@ -1,0 +1,35 @@
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0005_add_share_permissions'
+down_revision = '0004_initial_shares'
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    """Add permission columns to allow granular share control."""
+    # This adds columns to an existing table
+    # If the table doesn't exist yet, this migration creates it
+    
+    op.create_table(
+        'conversation_shares',
+        sa.Column('id', sa.String(), nullable=False),
+        sa.Column('conversation_id', sa.String(), nullable=False),
+        sa.Column('share_token', sa.String(), nullable=False),
+        sa.Column('allow_prompting', sa.Boolean(), nullable=False, server_default='false'),
+        sa.Column('allow_editing', sa.Boolean(), nullable=False, server_default='false'),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('expires_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['conversation_id'], ['conversations.id'], ),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('share_token'),
+    )
+    op.create_index('ix_conversation_shares_conversation_id', 'conversation_shares', ['conversation_id'])
+    op.create_index('ix_conversation_shares_token', 'conversation_shares', ['share_token'])
+
+def downgrade() -> None:
+    """Downgrade: drop the shares table."""
+    op.drop_index('ix_conversation_shares_token', table_name='conversation_shares')
+    op.drop_index('ix_conversation_shares_conversation_id', table_name='conversation_shares')
+    op.drop_table('conversation_shares')

--- a/migrations/0006_create_feedback_table.py
+++ b/migrations/0006_create_feedback_table.py
@@ -1,0 +1,35 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0006_create_feedback_table'
+down_revision = '0005_add_share_permissions'
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    """Create the response_feedback table."""
+    op.create_table(
+        'response_feedback',
+        sa.Column('id', sa.String(), nullable=False),
+        sa.Column('conversation_id', sa.String(), nullable=False),
+        sa.Column('response_id', sa.String(), nullable=False),
+        sa.Column('user_id', sa.String(), nullable=True),
+        sa.Column('rating', sa.Integer(), nullable=False),
+        sa.Column('feedback_text', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['conversation_id'], ['conversations.id']),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    
+    op.create_index('ix_response_feedback_conversation_id', 'response_feedback', ['conversation_id'])
+    op.create_index('ix_response_feedback_user_id', 'response_feedback', ['user_id'])
+    op.create_index('ix_response_feedback_created_at', 'response_feedback', ['created_at'])
+
+def downgrade() -> None:
+    """Drop the response_feedback table."""
+    op.drop_index('ix_response_feedback_created_at', table_name='response_feedback')
+    op.drop_index('ix_response_feedback_user_id', table_name='response_feedback')
+    op.drop_index('ix_response_feedback_conversation_id', table_name='response_feedback')
+    op.drop_table('response_feedback')

--- a/tests/api/test_feedback_endpoints.py
+++ b/tests/api/test_feedback_endpoints.py
@@ -1,0 +1,198 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from application.main import app
+from application.database import SessionLocal
+from application.core.models.conversations import Conversation
+from application.core.models.feedback import ResponseFeedback
+
+client = TestClient(app)
+
+@pytest.fixture
+def db():
+    """Provide database session for tests."""
+    db = SessionLocal()
+    yield db
+    db.close()
+
+@pytest.fixture
+def sample_conversation(db: Session) -> Conversation:
+    """Create a sample conversation."""
+    conv = Conversation(
+        id="conv-test-123",
+        title="Test Conversation"
+    )
+    db.add(conv)
+    db.commit()
+    db.refresh(conv)
+    return conv
+
+def test_submit_feedback_valid(sample_conversation: Conversation):
+    """Test submitting valid feedback."""
+    response = client.post(
+        "/api/feedback",
+        json={
+            "conversation_id": sample_conversation.id,
+            "response_id": "resp-456",
+            "rating": 5,
+            "feedback_text": "Excellent response!"
+        }
+    )
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert data["rating"] == 5
+    assert data["feedback_text"] == "Excellent response!"
+    assert "id" in data
+    assert "created_at" in data
+
+def test_submit_feedback_without_comment(sample_conversation: Conversation):
+    """Test feedback without optional comment."""
+    response = client.post(
+        "/api/feedback",
+        json={
+            "conversation_id": sample_conversation.id,
+            "response_id": "resp-789",
+            "rating": 4
+        }
+    )
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert data["rating"] == 4
+    assert data["feedback_text"] is None
+
+def test_submit_feedback_invalid_rating():
+    """Test that invalid ratings are rejected."""
+    invalid_ratings = [0, 6, -1, 10, 100]
+    
+    for rating in invalid_ratings:
+        response = client.post(
+            "/api/feedback",
+            json={
+                "conversation_id": "conv-123",
+                "response_id": "resp-456",
+                "rating": rating
+            }
+        )
+        
+        assert response.status_code == 422  # Validation error
+
+def test_submit_feedback_nonexistent_conversation():
+    """Test error when conversation doesn't exist."""
+    response = client.post(
+        "/api/feedback",
+        json={
+            "conversation_id": "nonexistent",
+            "response_id": "resp-456",
+            "rating": 3
+        }
+    )
+    
+    assert response.status_code == 404
+
+def test_get_conversation_feedback(db: Session, sample_conversation: Conversation):
+    """Test retrieving feedback for a conversation."""
+    # Submit multiple feedbacks
+    feedbacks_data = [
+        {"rating": 5, "text": "Great!"},
+        {"rating": 4, "text": "Good"},
+        {"rating": 2, "text": "Needs improvement"},
+    ]
+    
+    for i, fb in enumerate(feedbacks_data):
+        feedback = ResponseFeedback(
+            id=f"feedback-{i}",
+            conversation_id=sample_conversation.id,
+            response_id=f"resp-{i}",
+            rating=fb["rating"],
+            feedback_text=fb["text"]
+        )
+        db.add(feedback)
+    db.commit()
+    
+    response = client.get(
+        f"/api/feedback/conversation/{sample_conversation.id}"
+    )
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 3
+    assert data[0]["rating"] == 2  # Newest first (ordered desc)
+
+def test_get_feedback_stats(db: Session, sample_conversation: Conversation):
+    """Test feedback statistics endpoint."""
+    # Create feedback with varied ratings
+    ratings = [5, 5, 4, 3, 2, 1]
+    for i, rating in enumerate(ratings):
+        feedback = ResponseFeedback(
+            id=f"stat-feedback-{i}",
+            conversation_id=sample_conversation.id,
+            response_id=f"resp-{i}",
+            rating=rating
+        )
+        db.add(feedback)
+    db.commit()
+    
+    response = client.get(
+        f"/api/feedback/conversation/{sample_conversation.id}/stats"
+    )
+    
+    assert response.status_code == 200
+    stats = response.json()
+    
+    assert stats["total_feedback"] == 6
+    assert stats["average_rating"] == 3.33  # (5+5+4+3+2+1)/6
+    assert stats["positive_count"] == 3  # ratings 4-5
+    assert stats["negative_count"] == 2  # ratings 1-2
+    
+    assert stats["rating_distribution"]["1"] == 1
+    assert stats["rating_distribution"]["5"] == 2
+
+def test_delete_feedback(db: Session, sample_conversation: Conversation):
+    """Test deleting feedback."""
+    feedback = ResponseFeedback(
+        id="feedback-to-delete",
+        conversation_id=sample_conversation.id,
+        response_id="resp-xyz",
+        rating=3
+    )
+    db.add(feedback)
+    db.commit()
+    
+    response = client.delete(
+        f"/api/feedback/feedback/{feedback.id}"
+    )
+    
+    assert response.status_code == 200
+    
+    # Verify deleted
+    deleted = db.query(ResponseFeedback).filter_by(id=feedback.id).first()
+    assert deleted is None
+
+def test_get_response_feedback(db: Session, sample_conversation: Conversation):
+    """Test getting feedback for a specific response."""
+    # Create feedback for same response in different conversations
+    for i in range(3):
+        conv = Conversation(id=f"conv-{i}", title=f"Conversation {i}")
+        db.add(conv)
+    db.commit()
+    
+    for i in range(3):
+        feedback = ResponseFeedback(
+            id=f"resp-fb-{i}",
+            conversation_id=f"conv-{i}",
+            response_id="same-response",  # Same response ID
+            rating=4 + i
+        )
+        db.add(feedback)
+    db.commit()
+    
+    response = client.get(
+        "/api/feedback/response/same-response/feedback"
+    )
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 3

--- a/tests/api/test_share_endpoints.py
+++ b/tests/api/test_share_endpoints.py
@@ -1,0 +1,188 @@
+import pytest
+from fastapi.testclient import TestClient
+from datetime import datetime, timedelta
+from sqlalchemy.orm import Session
+
+from application.main import app
+from application.database import SessionLocal
+from application.core.models.conversations import Conversation
+from application.core.models.share import ConversationShare
+
+client = TestClient(app)
+
+@pytest.fixture
+def db():
+    """Provide a database session for tests."""
+    db = SessionLocal()
+    yield db
+    db.close()
+
+@pytest.fixture
+def sample_conversation(db: Session) -> Conversation:
+    """Create a sample conversation for testing."""
+    conv = Conversation(
+        id="test-conv-123",
+        title="Test Conversation",
+        is_private=False
+    )
+    db.add(conv)
+    db.commit()
+    db.refresh(conv)
+    return conv
+
+def test_create_share_success(sample_conversation: Conversation):
+    """Test successfully creating a share."""
+    response = client.post(
+        f"/api/conversations/{sample_conversation.id}/share",
+        json={
+            "allow_prompting": True,
+            "allow_editing": False
+        }
+    )
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert "share_token" in data
+    assert "share_url" in data
+    assert data["permissions"]["allow_prompting"] is True
+    assert data["permissions"]["allow_editing"] is False
+
+def test_create_share_with_expiration(sample_conversation: Conversation):
+    """Test creating a share with expiration."""
+    response = client.post(
+        f"/api/conversations/{sample_conversation.id}/share",
+        json={
+            "allow_prompting": False,
+            "allow_editing": False,
+            "expires_in_days": 7
+        }
+    )
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert data["expires_at"] is not None
+
+def test_create_share_for_private_conversation(db: Session):
+    """Test that private conversations can also be shared."""
+    # Create a private conversation
+    conv = Conversation(
+        id="test-conv-private",
+        title="Private Conversation",
+        is_private=True
+    )
+    db.add(conv)
+    db.commit()
+    
+    response = client.post(
+        f"/api/conversations/{conv.id}/share",
+        json={
+            "allow_prompting": True,
+            "allow_editing": True
+        }
+    )
+    
+    # Should succeed regardless of privacy setting
+    assert response.status_code == 200
+    assert response.json()["permissions"]["allow_prompting"] is True
+
+def test_create_share_nonexistent_conversation():
+    """Test error when creating share for non-existent conversation."""
+    response = client.post(
+        "/api/conversations/nonexistent-id/share",
+        json={
+            "allow_prompting": False,
+            "allow_editing": False
+        }
+    )
+    
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+def test_list_shares(db: Session, sample_conversation: Conversation):
+    """Test listing shares for a conversation."""
+    # Create multiple shares
+    for i in range(3):
+        share = ConversationShare(
+            id=f"share-{i}",
+            conversation_id=sample_conversation.id,
+            share_token=f"token-{i}",
+            allow_prompting=(i % 2 == 0),
+            allow_editing=False
+        )
+        db.add(share)
+    db.commit()
+    
+    response = client.get(f"/api/conversations/{sample_conversation.id}/shares")
+    
+    assert response.status_code == 200
+    shares = response.json()
+    assert len(shares) == 3
+    assert shares[0]["allow_prompting"] is True
+    assert shares[1]["allow_prompting"] is False
+
+def test_delete_share(db: Session, sample_conversation: Conversation):
+    """Test deleting a share."""
+    share = ConversationShare(
+        id="share-to-delete",
+        conversation_id=sample_conversation.id,
+        share_token="token-to-delete",
+        allow_prompting=False,
+        allow_editing=False
+    )
+    db.add(share)
+    db.commit()
+    
+    response = client.delete(
+        f"/api/conversations/{sample_conversation.id}/shares/{share.id}"
+    )
+    
+    assert response.status_code == 200
+    
+    # Verify it's deleted
+    db.refresh(db.session)
+    deleted = db.query(ConversationShare).filter_by(id=share.id).first()
+    assert deleted is None
+
+def test_access_shared_conversation(db: Session, sample_conversation: Conversation):
+    """Test accessing a shared conversation via share token."""
+    share = ConversationShare(
+        id="share-access",
+        conversation_id=sample_conversation.id,
+        share_token="unique-token-123",
+        allow_prompting=True,
+        allow_editing=False
+    )
+    db.add(share)
+    db.commit()
+    
+    response = client.get("/api/share/unique-token-123")
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert data["permissions"]["allow_prompting"] is True
+    assert data["permissions"]["allow_editing"] is False
+
+def test_access_expired_share(db: Session, sample_conversation: Conversation):
+    """Test that expired shares cannot be accessed."""
+    expired_time = datetime.utcnow() - timedelta(days=1)
+    share = ConversationShare(
+        id="expired-share",
+        conversation_id=sample_conversation.id,
+        share_token="expired-token",
+        allow_prompting=False,
+        allow_editing=False,
+        expires_at=expired_time
+    )
+    db.add(share)
+    db.commit()
+    
+    response = client.get("/api/share/expired-token")
+    
+    assert response.status_code == 410  # Gone
+    assert "expired" in response.json()["detail"].lower()
+
+def test_invalid_share_token():
+    """Test accessing with invalid share token."""
+    response = client.get("/api/share/invalid-token-xyz")
+    
+    assert response.status_code == 404


### PR DESCRIPTION
- Decoupled share permissions from conversation privacy settings
- Implemented granular permission model (allow_prompting, allow_editing, expiration)
- Created separate database table for shares with independent permission flags
- Updated frontend to clearly display sharing options
