### PR TITLE
Fix: Import external-link.svg properly in AgentDetailsModal

### DIFF
--- a/frontend/src/modals/AgentDetailsModal.tsx
+++ b/frontend/src/modals/AgentDetailsModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-
+import ExternalLinkIcon from '../assets/external-link.svg';
 import { Agent } from '../agents/types';
 import userService from '../api/services/userService';
 import CopyButton from '../components/CopyButton';
@@ -123,7 +123,7 @@ export default function AgentDetailsModal({
                     {t('modals.agentDetails.learnMore')}
                   </span>
                   <img
-                    src="/src/assets/external-link.svg"
+                    src={ExternalLinkIcon}
                     alt="External link"
                     className="h-3 w-3"
                   />
@@ -168,7 +168,7 @@ export default function AgentDetailsModal({
                     >
                       {t('modals.agentDetails.test')}
                       <img
-                        src="/src/assets/external-link.svg"
+                        src={ExternalLinkIcon}
                         alt="External link"
                         className="h-3 w-3 group-hover:brightness-0 group-hover:invert"
                       />
@@ -210,7 +210,7 @@ export default function AgentDetailsModal({
                     {t('modals.agentDetails.learnMore')}
                   </span>
                   <img
-                    src="/src/assets/external-link.svg"
+                    src={ExternalLinkIcon}
                     alt="External link"
                     className="h-3 w-3"
                   />


### PR DESCRIPTION
- **Bug fix** #2167

-  The external-link.svg icon in the Test button next to API keys was not loading properly because it was referenced using hardcoded paths (/src/assets/external-link.svg) instead of being properly imported. This caused the SVG to fail loading in production builds, resulting in broken icons in the agent creation flow.

- **Other information**:
<img width="1438" height="775" alt="Screenshot 2025-12-12 at 10 28 33 PM" src="https://github.com/user-attachments/assets/f4ccffd5-ecbf-486a-a1d5-64c577a4cff2" />
