### PR TITLE
Handle long model names in dropdown with proper truncation

### DIFF
--- a/frontend/src/components/DropdownModel.tsx
+++ b/frontend/src/components/DropdownModel.tsx
@@ -113,7 +113,7 @@ export default function DropdownModel() {
                 className={`border-gray-3000/75 dark:border-purple-taupe/50 hover:bg-gray-3000/75 dark:hover:bg-purple-taupe flex h-10 w-full cursor-pointer items-center justify-between border-t`}
               >
                 <div className="flex w-full items-center justify-between">
-                  <p className="overflow-hidden py-3 pr-2 pl-5 overflow-ellipsis whitespace-nowrap">
+                  <p className="flex-1 truncate py-3 pr-2 pl-5">
                     {model.display_name}
                   </p>
                   {model.id === selectedModel?.id ? (


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR fixes a UI issue where long model names would overflow the dropdown container, breaking the layout on smaller screens.
- **Why was this change needed?** (You can also link to an open issue here)
Fixed #2226 
- **Other information**:
Actually I replaced the invalid **overflow-ellipsis** class with the correct Tailwind utility **truncate**. And added `flex-1` to the text container to ensure it correctly fills the available space and truncates when necessary.

As suggested, I verified the fix locally by temporarily injecting placeholder models with long names. The text now gracefully ellipsizes instead of overflowing - 

<img width="1907" height="828" alt="image" src="https://github.com/user-attachments/assets/6970380f-d2c7-4502-b1b7-f5a345671c9d" />

