### PR TITLE
feat: add ModelsLab as LLM provider

### DIFF
--- a/application/core/model_configs.py
+++ b/application/core/model_configs.py
@@ -222,3 +222,37 @@ def create_custom_openai_model(model_name: str, base_url: str) -> AvailableModel
             supported_attachment_types=OPENAI_ATTACHMENTS,
         ),
     )
+
+
+MODELSLAB_MODELS = [
+    AvailableModel(
+        id="meta-llama/Meta-Llama-3-8B-Instruct",
+        provider=ModelProvider.MODELSLAB,
+        display_name="Llama 3 8B (ModelsLab)",
+        description="Meta Llama 3 8B instruction-tuned model via ModelsLab API",
+        capabilities=ModelCapabilities(
+            supports_tools=False,
+            context_window=8192,
+        ),
+    ),
+    AvailableModel(
+        id="meta-llama/Meta-Llama-3-70B-Instruct",
+        provider=ModelProvider.MODELSLAB,
+        display_name="Llama 3 70B (ModelsLab)",
+        description="Meta Llama 3 70B instruction-tuned model via ModelsLab API",
+        capabilities=ModelCapabilities(
+            supports_tools=False,
+            context_window=8192,
+        ),
+    ),
+    AvailableModel(
+        id="mistralai/Mistral-7B-Instruct-v0.2",
+        provider=ModelProvider.MODELSLAB,
+        display_name="Mistral 7B (ModelsLab)",
+        description="Mistral 7B instruction-tuned model via ModelsLab API",
+        capabilities=ModelCapabilities(
+            supports_tools=False,
+            context_window=32768,
+        ),
+    ),
+]

--- a/application/core/model_settings.py
+++ b/application/core/model_settings.py
@@ -19,6 +19,7 @@ class ModelProvider(str, Enum):
     PREMAI = "premai"
     SAGEMAKER = "sagemaker"
     NOVITA = "novita"
+    MODELSLAB = "modelslab"
 
 
 @dataclass
@@ -114,6 +115,10 @@ class ModelRegistry:
             settings.LLM_PROVIDER == "openrouter" and settings.API_KEY
         ):
             self._add_openrouter_models(settings)
+        if settings.MODELSLAB_API_KEY or (
+            settings.LLM_PROVIDER == "modelslab" and settings.API_KEY
+        ):
+            self._add_modelslab_models(settings)
         if settings.HUGGINGFACE_API_KEY or (
             settings.LLM_PROVIDER == "huggingface" and settings.API_KEY
         ):
@@ -243,6 +248,21 @@ class ModelRegistry:
                     self.models[model.id] = model
                     return
         for model in OPENROUTER_MODELS:
+            self.models[model.id] = model
+
+    def _add_modelslab_models(self, settings):
+        from application.core.model_configs import MODELSLAB_MODELS
+
+        if settings.MODELSLAB_API_KEY:
+            for model in MODELSLAB_MODELS:
+                self.models[model.id] = model
+            return
+        if settings.LLM_PROVIDER == "modelslab" and settings.LLM_NAME:
+            for model in MODELSLAB_MODELS:
+                if model.id == settings.LLM_NAME:
+                    self.models[model.id] = model
+                    return
+        for model in MODELSLAB_MODELS:
             self.models[model.id] = model
 
     def _add_docsgpt_models(self, settings):

--- a/application/core/model_utils.py
+++ b/application/core/model_utils.py
@@ -15,6 +15,7 @@ def get_api_key_for_provider(provider: str) -> Optional[str]:
         "groq": settings.GROQ_API_KEY,
         "huggingface": settings.HUGGINGFACE_API_KEY,
         "azure_openai": settings.API_KEY,
+        "modelslab": settings.MODELSLAB_API_KEY,
         "docsgpt": None,
         "llama.cpp": None,
     }

--- a/application/core/settings.py
+++ b/application/core/settings.py
@@ -83,6 +83,7 @@ class Settings(BaseSettings):
     GROQ_API_KEY: Optional[str] = None
     HUGGINGFACE_API_KEY: Optional[str] = None
     OPEN_ROUTER_API_KEY: Optional[str] = None
+    MODELSLAB_API_KEY: Optional[str] = None
 
     OPENAI_API_BASE: Optional[str] = None  # azure openai api base url
     OPENAI_API_VERSION: Optional[str] = None  # azure openai api version

--- a/application/llm/llm_creator.py
+++ b/application/llm/llm_creator.py
@@ -5,6 +5,7 @@ from application.llm.docsgpt_provider import DocsGPTAPILLM
 from application.llm.google_ai import GoogleLLM
 from application.llm.groq import GroqLLM
 from application.llm.llama_cpp import LlamaCpp
+from application.llm.modelslab import ModelsLabLLM
 from application.llm.novita import NovitaLLM
 from application.llm.openai import AzureOpenAILLM, OpenAILLM
 from application.llm.premai import PremAILLM
@@ -25,6 +26,7 @@ class LLMCreator:
         "premai": PremAILLM,
         "groq": GroqLLM,
         "google": GoogleLLM,
+        "modelslab": ModelsLabLLM,
         "novita": NovitaLLM,
         "openrouter": OpenRouterLLM,
     }

--- a/application/llm/modelslab.py
+++ b/application/llm/modelslab.py
@@ -1,0 +1,15 @@
+from application.core.settings import settings
+from application.llm.openai import OpenAILLM
+
+MODELSLAB_BASE_URL = "https://modelslab.com/api/uncensored-chat/v1"
+
+
+class ModelsLabLLM(OpenAILLM):
+    def __init__(self, api_key=None, user_api_key=None, base_url=None, *args, **kwargs):
+        super().__init__(
+            api_key=api_key or settings.MODELSLAB_API_KEY or settings.API_KEY,
+            user_api_key=user_api_key,
+            base_url=base_url or MODELSLAB_BASE_URL,
+            *args,
+            **kwargs,
+        )

--- a/tests/llm/test_modelslab_llm.py
+++ b/tests/llm/test_modelslab_llm.py
@@ -1,0 +1,85 @@
+"""Tests for the ModelsLab LLM provider."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from application.llm.modelslab import MODELSLAB_BASE_URL, ModelsLabLLM
+
+
+class TestModelsLabLLM:
+    """Tests for ModelsLabLLM provider."""
+
+    def test_inherits_openai_llm(self):
+        """ModelsLabLLM should extend OpenAILLM."""
+        from application.llm.openai import OpenAILLM
+
+        assert issubclass(ModelsLabLLM, OpenAILLM)
+
+    def test_default_base_url(self):
+        """MODELSLAB_BASE_URL constant should point to ModelsLab uncensored chat API."""
+        assert MODELSLAB_BASE_URL == "https://modelslab.com/api/uncensored-chat/v1"
+
+    @patch("application.llm.openai.OpenAI")
+    def test_uses_modelslab_base_url_when_no_override(self, mock_openai):
+        """When no base_url is provided, use MODELSLAB_BASE_URL."""
+        mock_openai.return_value = MagicMock()
+        llm = ModelsLabLLM(api_key="test-key")
+        call_kwargs = mock_openai.call_args[1]
+        assert call_kwargs.get("base_url") == MODELSLAB_BASE_URL
+
+    @patch("application.llm.openai.OpenAI")
+    def test_custom_base_url_override(self, mock_openai):
+        """When base_url is provided, it should override the default."""
+        mock_openai.return_value = MagicMock()
+        custom_url = "https://custom.modelslab.com/v1"
+        llm = ModelsLabLLM(api_key="test-key", base_url=custom_url)
+        call_kwargs = mock_openai.call_args[1]
+        assert call_kwargs.get("base_url") == custom_url
+
+    @patch("application.llm.openai.OpenAI")
+    def test_uses_provided_api_key(self, mock_openai):
+        """API key passed directly should be used."""
+        mock_openai.return_value = MagicMock()
+        llm = ModelsLabLLM(api_key="modelslab-key-123")
+        call_kwargs = mock_openai.call_args[1]
+        assert call_kwargs.get("api_key") == "modelslab-key-123"
+
+    @patch("application.llm.openai.OpenAI")
+    @patch("application.llm.modelslab.settings")
+    def test_falls_back_to_settings_api_key(self, mock_settings, mock_openai):
+        """Falls back to MODELSLAB_API_KEY from settings when no key provided."""
+        mock_openai.return_value = MagicMock()
+        mock_settings.MODELSLAB_API_KEY = "settings-key"
+        mock_settings.API_KEY = None
+        llm = ModelsLabLLM()
+        call_kwargs = mock_openai.call_args[1]
+        assert call_kwargs.get("api_key") == "settings-key"
+
+
+class TestModelsLabRegistration:
+    """Tests for ModelsLab registration in LLMCreator."""
+
+    def test_modelslab_in_llm_creator(self):
+        """ModelsLab should be registered in LLMCreator.llms."""
+        from application.llm.llm_creator import LLMCreator
+
+        assert "modelslab" in LLMCreator.llms
+        assert LLMCreator.llms["modelslab"] is ModelsLabLLM
+
+    def test_modelslab_provider_enum(self):
+        """ModelProvider enum should include MODELSLAB."""
+        from application.core.model_settings import ModelProvider
+
+        assert hasattr(ModelProvider, "MODELSLAB")
+        assert ModelProvider.MODELSLAB.value == "modelslab"
+
+    def test_modelslab_models_defined(self):
+        """MODELSLAB_MODELS should contain at least one model."""
+        from application.core.model_configs import MODELSLAB_MODELS
+        from application.core.model_settings import ModelProvider
+
+        assert len(MODELSLAB_MODELS) > 0
+        for model in MODELSLAB_MODELS:
+            assert model.provider == ModelProvider.MODELSLAB
+            assert model.id
+            assert model.display_name


### PR DESCRIPTION
## Summary

Adds **ModelsLab** as an OpenAI-compatible LLM provider, following the same pattern as the existing OpenRouter and Novita integrations.

ModelsLab provides access to 10,000+ open-source models (Llama 3, Mistral, DeepSeek, and more) through an OpenAI-compatible chat endpoint.

**API docs:** https://docs.modelslab.com  
**API key:** https://modelslab.com/account/api-key  
**Endpoint:** `https://modelslab.com/api/uncensored-chat/v1`

## Changes

| File | What |
|------|------|
| `application/llm/modelslab.py` | `ModelsLabLLM` class extending `OpenAILLM` |
| `application/llm/llm_creator.py` | Register `"modelslab"` provider |
| `application/core/settings.py` | Add `MODELSLAB_API_KEY` env var |
| `application/core/model_settings.py` | `ModelProvider.MODELSLAB` + `_add_modelslab_models()` |
| `application/core/model_configs.py` | `MODELSLAB_MODELS` (Llama 3 8B/70B, Mistral 7B) |
| `application/core/model_utils.py` | Add `modelslab` to `provider_key_map` |
| `tests/llm/test_modelslab_llm.py` | Pytest tests (7 cases) |

## Usage

```env
LLM_PROVIDER=modelslab
LLM_NAME=meta-llama/Meta-Llama-3-8B-Instruct
MODELSLAB_API_KEY=your_key_here
```

## Why ModelsLab?

- **300K+ developers** using the API
- **10,000+ hosted open-source models** on their own datacenter (vertically integrated with GPULab)
- OpenAI-compatible endpoint — zero friction to add
- Same integration pattern as the existing Novita provider in this repo

## Checklist

- [x] Follows existing OpenRouter/Novita provider pattern
- [x] `MODELSLAB_API_KEY` wired through settings + model_utils provider_key_map
- [x] Models added to registry with proper capabilities
- [x] Pytest tests added covering instantiation, URL defaults, key fallback, and registration
- [x] PEP 8 / ruff-compatible code