### PR TITLE
fix: correct stream error return order and add timeout to Brave search

### DIFF
--- a/application/agents/tools/brave.py
+++ b/application/agents/tools/brave.py
@@ -6,6 +6,8 @@ from application.agents.tools.base import Tool
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_TIMEOUT = 30  # seconds
+
 
 class BraveSearchTool(Tool):
     """
@@ -73,7 +75,7 @@ class BraveSearchTool(Tool):
             "X-Subscription-Token": self.token,
         }
 
-        response = requests.get(url, params=params, headers=headers)
+        response = requests.get(url, params=params, headers=headers, timeout=DEFAULT_TIMEOUT)
 
         if response.status_code == 200:
             return {
@@ -118,7 +120,7 @@ class BraveSearchTool(Tool):
             "X-Subscription-Token": self.token,
         }
 
-        response = requests.get(url, params=params, headers=headers)
+        response = requests.get(url, params=params, headers=headers, timeout=DEFAULT_TIMEOUT)
 
         if response.status_code == 200:
             return {

--- a/application/api/answer/routes/base.py
+++ b/application/api/answer/routes/base.py
@@ -452,7 +452,7 @@ class BaseAnswerResource:
                     thought = event["thought"]
                 elif event["type"] == "error":
                     logger.error(f"Error from stream: {event['error']}")
-                    return None, None, None, None, event["error"], None
+                    return None, None, None, None, None, event["error"]
                 elif event["type"] == "end":
                     stream_ended = True
             except (json.JSONDecodeError, KeyError) as e:
@@ -460,7 +460,7 @@ class BaseAnswerResource:
                 continue
         if not stream_ended:
             logger.error("Stream ended unexpectedly without an 'end' event.")
-            return None, None, None, None, "Stream ended unexpectedly", None
+            return None, None, None, None, None, "Stream ended unexpectedly"
         result = (
             conversation_id,
             response_full,


### PR DESCRIPTION
Two independent fixes.

**Stream error return order** (`application/api/answer/routes/base.py`)

`process_response_stream` returns a 6-tuple `(conversation_id, response, sources, tool_calls, thought, error)`. Both error paths had the last two positions swapped — `event["error"]` landed in `thought` and `None` landed in `error`. The caller checks `if error` to decide whether to surface a 400; with `error` always `None` on failure, every stream error came back as HTTP 200 with a null answer and the message hidden in `thought`. Swapped the positions so the error surfaces correctly.

**Missing timeout on Brave search** (`application/agents/tools/brave.py`)

Both `_web_search` and `_image_search` called `requests.get` with no `timeout`. Every other HTTP tool in the codebase sets one. Without it, a slow or unresponsive Brave API will block a worker thread with no upper bound. Added a 30s `DEFAULT_TIMEOUT` constant matching the pattern used elsewhere.