### PR TITLE
feat: add MiniMax as a first-class LLM and TTS provider (M3 default)

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -8,6 +8,9 @@ INTERNAL_KEY=<internal key for worker-to-backend authentication>
 EMBEDDINGS_BASE_URL=
 EMBEDDINGS_KEY=
 
+#For MiniMax (optional - for using MiniMax models)
+MINIMAX_API_KEY=
+
 #For Azure (you can delete it if you don't use Azure)
 OPENAI_API_BASE=
 OPENAI_API_VERSION=

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
     <li><strong>🔑 Streamlined API Keys:</strong>  Generate keys linked to your settings, documents, and models, simplifying chatbot and integration setup.</li>
     <li><strong>🔗 Actionable Tooling:</strong> Connect to APIs, tools, and other services to enable LLM actions.</li>
     <li><strong>🧩 Pre-built Integrations:</strong> Use readily available HTML/React chat widgets, search tools, Discord/Telegram bots, and more.</li>
-    <li><strong>🔌 Flexible Deployment:</strong> Works with major LLMs (OpenAI, Google, Anthropic) and local models (Ollama, llama_cpp).</li>
+    <li><strong>🔌 Flexible Deployment:</strong> Works with major LLMs (OpenAI, Google, Anthropic, MiniMax) and local models (Ollama, llama_cpp).</li>
     <li><strong>🏢 Secure & Scalable:</strong> Run privately and securely with Kubernetes support, designed for enterprise-grade reliability.</li>
 </ul>
 

--- a/application/core/model_configs.py
+++ b/application/core/model_configs.py
@@ -193,6 +193,34 @@ OPENROUTER_MODELS = [
     ),
 ]
 
+MINIMAX_ATTACHMENTS = IMAGE_ATTACHMENTS
+
+MINIMAX_MODELS = [
+    AvailableModel(
+        id="MiniMax-M2.5",
+        provider=ModelProvider.MINIMAX,
+        display_name="MiniMax M2.5",
+        description="MiniMax flagship model with 204K context window",
+        capabilities=ModelCapabilities(
+            supports_tools=True,
+            supported_attachment_types=MINIMAX_ATTACHMENTS,
+            context_window=204800,
+        ),
+    ),
+    AvailableModel(
+        id="MiniMax-M2.5-highspeed",
+        provider=ModelProvider.MINIMAX,
+        display_name="MiniMax M2.5 Highspeed",
+        description="Fast, cost-effective MiniMax model with 204K context window",
+        capabilities=ModelCapabilities(
+            supports_tools=True,
+            supported_attachment_types=MINIMAX_ATTACHMENTS,
+            context_window=204800,
+        ),
+    ),
+]
+
+
 AZURE_OPENAI_MODELS = [
     AvailableModel(
         id="azure-gpt-4",

--- a/application/core/model_configs.py
+++ b/application/core/model_configs.py
@@ -197,10 +197,21 @@ MINIMAX_ATTACHMENTS = IMAGE_ATTACHMENTS
 
 MINIMAX_MODELS = [
     AvailableModel(
-        id="MiniMax-M2.5",
+        id="MiniMax-M3",
         provider=ModelProvider.MINIMAX,
-        display_name="MiniMax M2.5",
-        description="MiniMax flagship model with 204K context window",
+        display_name="MiniMax M3",
+        description="Latest MiniMax flagship model with 512K context window, 128K max output, and image input support",
+        capabilities=ModelCapabilities(
+            supports_tools=True,
+            supported_attachment_types=MINIMAX_ATTACHMENTS,
+            context_window=512000,
+        ),
+    ),
+    AvailableModel(
+        id="MiniMax-M2.7",
+        provider=ModelProvider.MINIMAX,
+        display_name="MiniMax M2.7",
+        description="Previous-generation MiniMax model with 204K context window",
         capabilities=ModelCapabilities(
             supports_tools=True,
             supported_attachment_types=MINIMAX_ATTACHMENTS,
@@ -208,9 +219,9 @@ MINIMAX_MODELS = [
         ),
     ),
     AvailableModel(
-        id="MiniMax-M2.5-highspeed",
+        id="MiniMax-M2.7-highspeed",
         provider=ModelProvider.MINIMAX,
-        display_name="MiniMax M2.5 Highspeed",
+        display_name="MiniMax M2.7 Highspeed",
         description="Fast, cost-effective MiniMax model with 204K context window",
         capabilities=ModelCapabilities(
             supports_tools=True,

--- a/application/core/model_settings.py
+++ b/application/core/model_settings.py
@@ -19,6 +19,7 @@ class ModelProvider(str, Enum):
     PREMAI = "premai"
     SAGEMAKER = "sagemaker"
     NOVITA = "novita"
+    MINIMAX = "minimax"
 
 
 @dataclass
@@ -118,6 +119,10 @@ class ModelRegistry:
             settings.LLM_PROVIDER == "huggingface" and settings.API_KEY
         ):
             self._add_huggingface_models(settings)
+        if settings.MINIMAX_API_KEY or (
+            settings.LLM_PROVIDER == "minimax" and settings.API_KEY
+        ):
+            self._add_minimax_models(settings)
         # Default model selection
         if settings.LLM_NAME:
             # Parse LLM_NAME (may be comma-separated)
@@ -272,6 +277,21 @@ class ModelRegistry:
             ),
         )
         self.models[model_id] = model
+
+    def _add_minimax_models(self, settings):
+        from application.core.model_configs import MINIMAX_MODELS
+
+        if settings.MINIMAX_API_KEY:
+            for model in MINIMAX_MODELS:
+                self.models[model.id] = model
+            return
+        if settings.LLM_PROVIDER == "minimax" and settings.LLM_NAME:
+            for model in MINIMAX_MODELS:
+                if model.id == settings.LLM_NAME:
+                    self.models[model.id] = model
+                    return
+        for model in MINIMAX_MODELS:
+            self.models[model.id] = model
 
     def _parse_model_names(self, llm_name: str) -> List[str]:
         """

--- a/application/core/model_utils.py
+++ b/application/core/model_utils.py
@@ -14,6 +14,7 @@ def get_api_key_for_provider(provider: str) -> Optional[str]:
         "google": settings.GOOGLE_API_KEY,
         "groq": settings.GROQ_API_KEY,
         "huggingface": settings.HUGGINGFACE_API_KEY,
+        "minimax": settings.MINIMAX_API_KEY,
         "azure_openai": settings.API_KEY,
         "docsgpt": None,
         "llama.cpp": None,

--- a/application/core/settings.py
+++ b/application/core/settings.py
@@ -90,6 +90,7 @@ class Settings(BaseSettings):
     GROQ_API_KEY: Optional[str] = None
     HUGGINGFACE_API_KEY: Optional[str] = None
     OPEN_ROUTER_API_KEY: Optional[str] = None
+    MINIMAX_API_KEY: Optional[str] = None
 
     OPENAI_API_BASE: Optional[str] = None  # azure openai api base url
     OPENAI_API_VERSION: Optional[str] = None  # azure openai api version
@@ -174,6 +175,7 @@ class Settings(BaseSettings):
         "GOOGLE_API_KEY",
         "GROQ_API_KEY",
         "HUGGINGFACE_API_KEY",
+        "MINIMAX_API_KEY",
         "EMBEDDINGS_KEY",
         "FALLBACK_LLM_API_KEY",
         "QDRANT_API_KEY",

--- a/application/llm/llm_creator.py
+++ b/application/llm/llm_creator.py
@@ -9,6 +9,7 @@ from application.llm.novita import NovitaLLM
 from application.llm.openai import AzureOpenAILLM, OpenAILLM
 from application.llm.premai import PremAILLM
 from application.llm.sagemaker import SagemakerAPILLM
+from application.llm.minimax import MiniMaxLLM
 from application.llm.open_router import OpenRouterLLM
 
 logger = logging.getLogger(__name__)
@@ -27,6 +28,7 @@ class LLMCreator:
         "google": GoogleLLM,
         "novita": NovitaLLM,
         "openrouter": OpenRouterLLM,
+        "minimax": MiniMaxLLM,
     }
 
     @classmethod

--- a/application/llm/minimax.py
+++ b/application/llm/minimax.py
@@ -1,0 +1,74 @@
+from application.core.settings import settings
+from application.llm.openai import OpenAILLM
+
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+
+
+class MiniMaxLLM(OpenAILLM):
+    def __init__(self, api_key=None, user_api_key=None, base_url=None, *args, **kwargs):
+        super().__init__(
+            api_key=api_key or settings.MINIMAX_API_KEY or settings.API_KEY,
+            user_api_key=user_api_key,
+            base_url=base_url or MINIMAX_BASE_URL,
+            *args,
+            **kwargs,
+        )
+
+    @staticmethod
+    def _clamp_temperature(kwargs):
+        """Clamp temperature to MiniMax's valid range (0.0, 1.0]."""
+        if "temperature" in kwargs:
+            temp = kwargs["temperature"]
+            if temp is not None:
+                temp = float(temp)
+                if temp <= 0:
+                    kwargs["temperature"] = 0.01
+                elif temp > 1.0:
+                    kwargs["temperature"] = 1.0
+
+    def _raw_gen(
+        self,
+        baseself,
+        model,
+        messages,
+        stream=False,
+        tools=None,
+        response_format=None,
+        **kwargs,
+    ):
+        self._clamp_temperature(kwargs)
+        # MiniMax does not support response_format; drop it
+        return super()._raw_gen(
+            baseself,
+            model,
+            messages,
+            stream=stream,
+            tools=tools,
+            response_format=None,
+            **kwargs,
+        )
+
+    def _raw_gen_stream(
+        self,
+        baseself,
+        model,
+        messages,
+        stream=True,
+        tools=None,
+        response_format=None,
+        **kwargs,
+    ):
+        self._clamp_temperature(kwargs)
+        # MiniMax does not support response_format; drop it
+        return super()._raw_gen_stream(
+            baseself,
+            model,
+            messages,
+            stream=stream,
+            tools=tools,
+            response_format=None,
+            **kwargs,
+        )
+
+    def _supports_structured_output(self):
+        return False

--- a/application/tts/minimax_tts.py
+++ b/application/tts/minimax_tts.py
@@ -1,0 +1,74 @@
+import base64
+import json
+import logging
+
+import requests
+
+from application.core.settings import settings
+from application.tts.base import BaseTTS
+
+logger = logging.getLogger(__name__)
+
+MINIMAX_TTS_BASE_URL = "https://api.minimax.io"
+
+MINIMAX_TTS_VOICES = [
+    "English_Graceful_Lady",
+    "English_Insightful_Speaker",
+    "English_radiant_girl",
+    "English_Persuasive_Man",
+    "English_Lucky_Robot",
+    "English_expressive_narrator",
+]
+
+
+class MiniMaxTTS(BaseTTS):
+    def __init__(self):
+        self.api_key = settings.MINIMAX_API_KEY
+        self.base_url = MINIMAX_TTS_BASE_URL
+
+    def text_to_speech(self, text):
+        lang = "en"
+        url = f"{self.base_url}/v1/t2a_v2"
+
+        payload = {
+            "model": "speech-2.8-hd",
+            "text": text,
+            "stream": False,
+            "voice_setting": {
+                "voice_id": "English_Graceful_Lady",
+                "speed": 1,
+                "vol": 1,
+                "pitch": 0,
+            },
+            "audio_setting": {
+                "sample_rate": 32000,
+                "bitrate": 128000,
+                "format": "mp3",
+                "channel": 1,
+            },
+        }
+
+        response = requests.post(
+            url,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.api_key}",
+            },
+            json=payload,
+            timeout=30,
+        )
+        response.raise_for_status()
+
+        result = response.json()
+        status_code = result.get("base_resp", {}).get("status_code", -1)
+        if status_code != 0:
+            status_msg = result.get("base_resp", {}).get("status_msg", "unknown error")
+            raise RuntimeError(f"MiniMax TTS error ({status_code}): {status_msg}")
+
+        hex_audio = result.get("data", {}).get("audio", "")
+        if not hex_audio:
+            raise RuntimeError("MiniMax TTS returned empty audio data")
+
+        audio_bytes = bytes.fromhex(hex_audio)
+        audio_base64 = base64.b64encode(audio_bytes).decode("utf-8")
+        return audio_base64, lang

--- a/application/tts/tts_creator.py
+++ b/application/tts/tts_creator.py
@@ -1,5 +1,6 @@
 from application.tts.google_tts import GoogleTTS
 from application.tts.elevenlabs import ElevenlabsTTS
+from application.tts.minimax_tts import MiniMaxTTS
 from application.tts.base import BaseTTS
 
 
@@ -8,6 +9,7 @@ class TTSCreator:
     tts_providers = {
         "google_tts": GoogleTTS,
         "elevenlabs": ElevenlabsTTS,
+        "minimax_tts": MiniMaxTTS,
     }
 
     @classmethod

--- a/docs/content/Models/cloud-providers.mdx
+++ b/docs/content/Models/cloud-providers.mdx
@@ -33,6 +33,7 @@ DocsGPT offers direct, streamlined support for the following cloud LLM providers
 | Prem AI                      | `premai`       | (See Prem AI docs)          |
 | AWS SageMaker                | `sagemaker`    | (See SageMaker docs)        |
 | Novita AI                    | `novita`       | (See Novita docs)           |
+| MiniMax                      | `minimax`      | `MiniMax-M2.5`              |
 
 ## Connecting to OpenAI-Compatible Cloud APIs
 

--- a/docs/content/Models/cloud-providers.mdx
+++ b/docs/content/Models/cloud-providers.mdx
@@ -33,7 +33,7 @@ DocsGPT offers direct, streamlined support for the following cloud LLM providers
 | Prem AI                      | `premai`       | (See Prem AI docs)          |
 | AWS SageMaker                | `sagemaker`    | (See SageMaker docs)        |
 | Novita AI                    | `novita`       | (See Novita docs)           |
-| MiniMax                      | `minimax`      | `MiniMax-M2.5`              |
+| MiniMax                      | `minimax`      | `MiniMax-M3`                |
 
 ## Connecting to OpenAI-Compatible Cloud APIs
 

--- a/setup.ps1
+++ b/setup.ps1
@@ -268,9 +268,10 @@ function Prompt-CloudAPIProviderOptions {
     Write-ColorText "5) HuggingFace Inference API" -ForegroundColor "Yellow"
     Write-ColorText "6) Azure OpenAI" -ForegroundColor "Yellow"
     Write-ColorText "7) Novita" -ForegroundColor "Yellow"
+    Write-ColorText "8) MiniMax" -ForegroundColor "Yellow"
     Write-ColorText "b) Back to Main Menu" -ForegroundColor "Yellow"
     Write-Host ""
-    $script:provider_choice = Read-Host "Choose option (1-7, or b)"
+    $script:provider_choice = Read-Host "Choose option (1-8, or b)"
 }
 
 # Function to prompt for Ollama CPU/GPU options
@@ -982,11 +983,18 @@ function Connect-CloudAPIProvider {
                 Get-APIKey
                 break
             }
+            "8" {  # MiniMax
+                $script:provider_name = "MiniMax"
+                $script:llm_name = "minimax"
+                $script:model_name = "MiniMax-M2.5"
+                Get-APIKey
+                break
+            }
             "b" { Clear-Host; return }
             "B" { Clear-Host; return }
             default {
                 Write-Host ""
-                Write-ColorText "Invalid choice. Please choose 1-7, or b." -ForegroundColor "Red"
+                Write-ColorText "Invalid choice. Please choose 1-8, or b." -ForegroundColor "Red"
                 Start-Sleep -Seconds 1
             }
         }

--- a/setup.ps1
+++ b/setup.ps1
@@ -986,7 +986,7 @@ function Connect-CloudAPIProvider {
             "8" {  # MiniMax
                 $script:provider_name = "MiniMax"
                 $script:llm_name = "minimax"
-                $script:model_name = "MiniMax-M2.5"
+                $script:model_name = "MiniMax-M3"
                 Get-APIKey
                 break
             }

--- a/setup.sh
+++ b/setup.sh
@@ -154,9 +154,10 @@ prompt_cloud_api_provider_options() {
     echo -e "${YELLOW}5) HuggingFace Inference API${NC}"
     echo -e "${YELLOW}6) Azure OpenAI${NC}"
     echo -e "${YELLOW}7) Novita${NC}"
+    echo -e "${YELLOW}8) MiniMax${NC}"
     echo -e "${YELLOW}b) Back to Main Menu${NC}"
     echo
-    read -p "$(echo -e "${DEFAULT_FG}Choose option (1-7, or b): ${NC}")" provider_choice
+    read -p "$(echo -e "${DEFAULT_FG}Choose option (1-8, or b): ${NC}")" provider_choice
 }
 
 # Function to prompt for Ollama CPU/GPU options
@@ -707,8 +708,14 @@ connect_cloud_api_provider() {
                 model_name="deepseek/deepseek-r1"
                 get_api_key
                 break ;;
+            8) # MiniMax
+                provider_name="MiniMax"
+                llm_provider="minimax"
+                model_name="MiniMax-M2.5"
+                get_api_key
+                break ;;
             b|B) clear; return 1 ;; # Clear screen and Back to Main Menu
-            *) echo -e "\n${RED}Invalid choice. Please choose 1-7, or b.${NC}" ; sleep 1 ;;
+            *) echo -e "\n${RED}Invalid choice. Please choose 1-8, or b.${NC}" ; sleep 1 ;;
         esac
     done
 

--- a/setup.sh
+++ b/setup.sh
@@ -711,7 +711,7 @@ connect_cloud_api_provider() {
             8) # MiniMax
                 provider_name="MiniMax"
                 llm_provider="minimax"
-                model_name="MiniMax-M2.5"
+                model_name="MiniMax-M3"
                 get_api_key
                 break ;;
             b|B) clear; return 1 ;; # Clear screen and Back to Main Menu

--- a/tests/llm/test_minimax_llm.py
+++ b/tests/llm/test_minimax_llm.py
@@ -1,0 +1,212 @@
+import types
+
+import pytest
+from application.llm.minimax import MiniMaxLLM
+
+
+class FakeChatCompletions:
+    def __init__(self):
+        self.last_kwargs = None
+
+    class _Msg:
+        def __init__(self, content=None, tool_calls=None):
+            self.content = content
+            self.tool_calls = tool_calls
+
+    class _Delta:
+        def __init__(self, content=None, reasoning_content=None, tool_calls=None):
+            self.content = content
+            self.reasoning_content = reasoning_content
+            self.tool_calls = tool_calls
+
+    class _Choice:
+        def __init__(
+            self,
+            content=None,
+            delta=None,
+            reasoning_content=None,
+            tool_calls=None,
+            finish_reason="stop",
+        ):
+            self.message = FakeChatCompletions._Msg(content=content)
+            self.delta = FakeChatCompletions._Delta(
+                content=delta,
+                reasoning_content=reasoning_content,
+                tool_calls=tool_calls,
+            )
+            self.finish_reason = finish_reason
+
+    class _StreamLine:
+        def __init__(self, deltas):
+            choices = []
+            for delta in deltas:
+                if isinstance(delta, dict):
+                    choices.append(
+                        FakeChatCompletions._Choice(
+                            delta=delta.get("content"),
+                            reasoning_content=delta.get("reasoning_content"),
+                            tool_calls=delta.get("tool_calls"),
+                            finish_reason=delta.get("finish_reason", "stop"),
+                        )
+                    )
+                else:
+                    choices.append(FakeChatCompletions._Choice(delta=delta))
+            self.choices = choices
+
+    class _Response:
+        def __init__(self, choices=None, lines=None):
+            self._choices = choices or []
+            self._lines = lines or []
+
+        @property
+        def choices(self):
+            return self._choices
+
+        def __iter__(self):
+            for line in self._lines:
+                yield line
+
+    def create(self, **kwargs):
+        self.last_kwargs = kwargs
+        if not kwargs.get("stream"):
+            return FakeChatCompletions._Response(
+                choices=[FakeChatCompletions._Choice(content="hello from minimax")]
+            )
+        return FakeChatCompletions._Response(
+            lines=[
+                FakeChatCompletions._StreamLine(["chunk1"]),
+                FakeChatCompletions._StreamLine(["chunk2"]),
+            ]
+        )
+
+
+class FakeClient:
+    def __init__(self):
+        self.chat = types.SimpleNamespace(completions=FakeChatCompletions())
+
+
+@pytest.fixture
+def minimax_llm(monkeypatch):
+    llm = MiniMaxLLM(api_key="minimax-test-key", user_api_key=None)
+    llm.storage = types.SimpleNamespace(
+        get_file=lambda path: types.SimpleNamespace(read=lambda: b"img"),
+        file_exists=lambda path: True,
+        process_file=lambda path, processor_func, **kwargs: "file_id_123",
+    )
+    llm.client = FakeClient()
+    return llm
+
+
+@pytest.mark.unit
+def test_minimax_uses_correct_base_url():
+    from application.llm.minimax import MINIMAX_BASE_URL
+
+    assert MINIMAX_BASE_URL == "https://api.minimax.io/v1"
+
+
+@pytest.mark.unit
+def test_raw_gen_returns_content(minimax_llm):
+    msgs = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hello"},
+    ]
+    content = minimax_llm._raw_gen(
+        minimax_llm, model="MiniMax-M2.5", messages=msgs, stream=False
+    )
+    assert content == "hello from minimax"
+
+    passed = minimax_llm.client.chat.completions.last_kwargs
+    assert passed["model"] == "MiniMax-M2.5"
+    assert passed["stream"] is False
+
+
+@pytest.mark.unit
+def test_raw_gen_stream_yields_chunks(minimax_llm):
+    msgs = [{"role": "user", "content": "hi"}]
+    gen = minimax_llm._raw_gen_stream(
+        minimax_llm, model="MiniMax-M2.5", messages=msgs, stream=True
+    )
+    chunks = list(gen)
+    assert "chunk1" in "".join(chunks)
+    assert "chunk2" in "".join(chunks)
+
+
+@pytest.mark.unit
+def test_temperature_clamped_to_minimum(minimax_llm):
+    msgs = [{"role": "user", "content": "test"}]
+    minimax_llm._raw_gen(
+        minimax_llm,
+        model="MiniMax-M2.5",
+        messages=msgs,
+        stream=False,
+        temperature=0,
+    )
+    passed = minimax_llm.client.chat.completions.last_kwargs
+    assert passed["temperature"] == 0.01
+
+
+@pytest.mark.unit
+def test_temperature_clamped_to_maximum(minimax_llm):
+    msgs = [{"role": "user", "content": "test"}]
+    minimax_llm._raw_gen(
+        minimax_llm,
+        model="MiniMax-M2.5",
+        messages=msgs,
+        stream=False,
+        temperature=2.0,
+    )
+    passed = minimax_llm.client.chat.completions.last_kwargs
+    assert passed["temperature"] == 1.0
+
+
+@pytest.mark.unit
+def test_valid_temperature_passed_through(minimax_llm):
+    msgs = [{"role": "user", "content": "test"}]
+    minimax_llm._raw_gen(
+        minimax_llm,
+        model="MiniMax-M2.5",
+        messages=msgs,
+        stream=False,
+        temperature=0.7,
+    )
+    passed = minimax_llm.client.chat.completions.last_kwargs
+    assert passed["temperature"] == 0.7
+
+
+@pytest.mark.unit
+def test_stream_temperature_clamped(minimax_llm):
+    msgs = [{"role": "user", "content": "test"}]
+    gen = minimax_llm._raw_gen_stream(
+        minimax_llm,
+        model="MiniMax-M2.5",
+        messages=msgs,
+        stream=True,
+        temperature=0,
+    )
+    list(gen)  # consume the generator
+    passed = minimax_llm.client.chat.completions.last_kwargs
+    assert passed["temperature"] == 0.01
+
+
+@pytest.mark.unit
+def test_response_format_dropped(minimax_llm):
+    msgs = [{"role": "user", "content": "test"}]
+    minimax_llm._raw_gen(
+        minimax_llm,
+        model="MiniMax-M2.5",
+        messages=msgs,
+        stream=False,
+        response_format={"type": "json_object"},
+    )
+    passed = minimax_llm.client.chat.completions.last_kwargs
+    assert "response_format" not in passed
+
+
+@pytest.mark.unit
+def test_does_not_support_structured_output(minimax_llm):
+    assert minimax_llm._supports_structured_output() is False
+
+
+@pytest.mark.unit
+def test_supports_tools(minimax_llm):
+    assert minimax_llm._supports_tools() is True

--- a/tests/llm/test_minimax_llm.py
+++ b/tests/llm/test_minimax_llm.py
@@ -111,12 +111,12 @@ def test_raw_gen_returns_content(minimax_llm):
         {"role": "user", "content": "hello"},
     ]
     content = minimax_llm._raw_gen(
-        minimax_llm, model="MiniMax-M2.5", messages=msgs, stream=False
+        minimax_llm, model="MiniMax-M3", messages=msgs, stream=False
     )
     assert content == "hello from minimax"
 
     passed = minimax_llm.client.chat.completions.last_kwargs
-    assert passed["model"] == "MiniMax-M2.5"
+    assert passed["model"] == "MiniMax-M3"
     assert passed["stream"] is False
 
 
@@ -124,7 +124,7 @@ def test_raw_gen_returns_content(minimax_llm):
 def test_raw_gen_stream_yields_chunks(minimax_llm):
     msgs = [{"role": "user", "content": "hi"}]
     gen = minimax_llm._raw_gen_stream(
-        minimax_llm, model="MiniMax-M2.5", messages=msgs, stream=True
+        minimax_llm, model="MiniMax-M3", messages=msgs, stream=True
     )
     chunks = list(gen)
     assert "chunk1" in "".join(chunks)
@@ -136,7 +136,7 @@ def test_temperature_clamped_to_minimum(minimax_llm):
     msgs = [{"role": "user", "content": "test"}]
     minimax_llm._raw_gen(
         minimax_llm,
-        model="MiniMax-M2.5",
+        model="MiniMax-M3",
         messages=msgs,
         stream=False,
         temperature=0,
@@ -150,7 +150,7 @@ def test_temperature_clamped_to_maximum(minimax_llm):
     msgs = [{"role": "user", "content": "test"}]
     minimax_llm._raw_gen(
         minimax_llm,
-        model="MiniMax-M2.5",
+        model="MiniMax-M3",
         messages=msgs,
         stream=False,
         temperature=2.0,
@@ -164,7 +164,7 @@ def test_valid_temperature_passed_through(minimax_llm):
     msgs = [{"role": "user", "content": "test"}]
     minimax_llm._raw_gen(
         minimax_llm,
-        model="MiniMax-M2.5",
+        model="MiniMax-M3",
         messages=msgs,
         stream=False,
         temperature=0.7,
@@ -178,7 +178,7 @@ def test_stream_temperature_clamped(minimax_llm):
     msgs = [{"role": "user", "content": "test"}]
     gen = minimax_llm._raw_gen_stream(
         minimax_llm,
-        model="MiniMax-M2.5",
+        model="MiniMax-M3",
         messages=msgs,
         stream=True,
         temperature=0,
@@ -193,7 +193,7 @@ def test_response_format_dropped(minimax_llm):
     msgs = [{"role": "user", "content": "test"}]
     minimax_llm._raw_gen(
         minimax_llm,
-        model="MiniMax-M2.5",
+        model="MiniMax-M3",
         messages=msgs,
         stream=False,
         response_format={"type": "json_object"},
@@ -210,3 +210,19 @@ def test_does_not_support_structured_output(minimax_llm):
 @pytest.mark.unit
 def test_supports_tools(minimax_llm):
     assert minimax_llm._supports_tools() is True
+
+
+@pytest.mark.unit
+def test_minimax_models_list():
+    """Verify the model catalog has M3 as default and excludes older M2.5 models."""
+    from application.core.model_configs import MINIMAX_MODELS
+
+    model_ids = [m.id for m in MINIMAX_MODELS]
+    assert "MiniMax-M3" in model_ids
+    assert "MiniMax-M2.7" in model_ids
+    assert "MiniMax-M2.7-highspeed" in model_ids
+    # Older models must be removed
+    for old in ("MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1", "MiniMax-M2", "MiniMax-M1"):
+        assert old not in model_ids
+    # M3 must be the first (default) entry
+    assert model_ids[0] == "MiniMax-M3"

--- a/tests/tts/test_minimax_tts.py
+++ b/tests/tts/test_minimax_tts.py
@@ -1,0 +1,104 @@
+import base64
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from application.tts.minimax_tts import MiniMaxTTS
+
+
+@pytest.fixture
+def minimax_tts(monkeypatch):
+    monkeypatch.setattr(
+        "application.tts.minimax_tts.settings",
+        SimpleNamespace(MINIMAX_API_KEY="test-minimax-key"),
+    )
+    return MiniMaxTTS()
+
+
+@pytest.mark.unit
+def test_minimax_tts_text_to_speech(minimax_tts, monkeypatch):
+    # Prepare fake hex-encoded audio data (MP3 ID3 header)
+    fake_audio_bytes = b"ID3\x04\x00\x00\x00\x00\x00"
+    fake_hex = fake_audio_bytes.hex()
+
+    fake_response = MagicMock()
+    fake_response.raise_for_status = MagicMock()
+    fake_response.json.return_value = {
+        "data": {"audio": fake_hex, "status": 2},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }
+
+    monkeypatch.setattr(
+        "application.tts.minimax_tts.requests.post",
+        lambda *args, **kwargs: fake_response,
+    )
+
+    audio_base64, lang = minimax_tts.text_to_speech("Hello world")
+
+    assert lang == "en"
+    decoded = base64.b64decode(audio_base64)
+    assert decoded == fake_audio_bytes
+
+
+@pytest.mark.unit
+def test_minimax_tts_api_error(minimax_tts, monkeypatch):
+    fake_response = MagicMock()
+    fake_response.raise_for_status = MagicMock()
+    fake_response.json.return_value = {
+        "data": {},
+        "base_resp": {"status_code": 1004, "status_msg": "authentication failed"},
+    }
+
+    monkeypatch.setattr(
+        "application.tts.minimax_tts.requests.post",
+        lambda *args, **kwargs: fake_response,
+    )
+
+    with pytest.raises(RuntimeError, match="MiniMax TTS error"):
+        minimax_tts.text_to_speech("Hello")
+
+
+@pytest.mark.unit
+def test_minimax_tts_empty_audio(minimax_tts, monkeypatch):
+    fake_response = MagicMock()
+    fake_response.raise_for_status = MagicMock()
+    fake_response.json.return_value = {
+        "data": {"audio": "", "status": 2},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }
+
+    monkeypatch.setattr(
+        "application.tts.minimax_tts.requests.post",
+        lambda *args, **kwargs: fake_response,
+    )
+
+    with pytest.raises(RuntimeError, match="empty audio"):
+        minimax_tts.text_to_speech("Hello")
+
+
+@pytest.mark.unit
+def test_minimax_tts_correct_request_params(minimax_tts, monkeypatch):
+    captured = {}
+
+    def fake_post(*args, **kwargs):
+        captured["url"] = args[0] if args else kwargs.get("url")
+        captured["headers"] = kwargs.get("headers")
+        captured["json"] = kwargs.get("json")
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {
+            "data": {"audio": "4944330400", "status": 2},
+            "base_resp": {"status_code": 0, "status_msg": "success"},
+        }
+        return resp
+
+    monkeypatch.setattr("application.tts.minimax_tts.requests.post", fake_post)
+
+    minimax_tts.text_to_speech("Test text")
+
+    assert captured["url"] == "https://api.minimax.io/v1/t2a_v2"
+    assert captured["headers"]["Authorization"] == "Bearer test-minimax-key"
+    assert captured["json"]["model"] == "speech-2.8-hd"
+    assert captured["json"]["text"] == "Test text"
+    assert captured["json"]["voice_setting"]["voice_id"] == "English_Graceful_Lady"

--- a/tests/tts/test_tts_creator.py
+++ b/tests/tts/test_tts_creator.py
@@ -57,5 +57,7 @@ def test_tts_providers_integrity(tts_creator):
     providers = tts_creator.tts_providers
     assert "google_tts" in providers
     assert "elevenlabs" in providers
+    assert "minimax_tts" in providers
     assert callable(providers["google_tts"])
     assert callable(providers["elevenlabs"])
+    assert callable(providers["minimax_tts"])


### PR DESCRIPTION
## Summary

Add [MiniMax](https://www.minimaxi.com) as a native provider for both LLM inference and text-to-speech in DocsGPT, giving users access to the latest MiniMax model lineup via the OpenAI-compatible API at `https://api.minimax.io/v1`.

### What's included

- **LLM provider** (`application/llm/minimax.py`): Extends `OpenAILLM` with MiniMax's base URL, temperature clamping to the valid range `(0, 1]`, and structured output passthrough disabled (MiniMax does not support `response_format`)
- **TTS provider** (`application/tts/minimax_tts.py`): MiniMax `speech-2.8-hd` model with hex-to-base64 audio decoding
- **Model registry** (default = M3):
  - `MiniMax-M3` — latest flagship, 512K context, 128K max output, image input support (default)
  - `MiniMax-M2.7` — previous-generation, 204K context
  - `MiniMax-M2.7-highspeed` — previous-generation low-latency variant, 204K context
  - Older `MiniMax-M2.5` / `MiniMax-M2.5-highspeed` have been removed
- **Settings**: `MINIMAX_API_KEY` environment variable with normalizer validation
- **Setup scripts**: MiniMax option added to both bash and PowerShell setup wizards
- **Documentation**: Updated `cloud-providers.mdx` table and `README.md` feature list
- **Tests**: 11 LLM unit tests (incl. a new model-list assertion) + 4 TTS unit tests, all passing

### Files changed

| File | Change |
|------|--------|
| `application/llm/minimax.py` | New — MiniMax LLM provider |
| `application/tts/minimax_tts.py` | New — MiniMax TTS provider |
| `application/core/settings.py` | Add `MINIMAX_API_KEY` |
| `application/core/model_settings.py` | Add `MINIMAX` to `ModelProvider` enum |
| `application/core/model_configs.py` | Add `MINIMAX_MODELS` definitions (M3 default) |
| `application/core/model_utils.py` | Add minimax to provider key map |
| `application/llm/llm_creator.py` | Register `MiniMaxLLM` in factory |
| `application/tts/tts_creator.py` | Register `MiniMaxTTS` in factory |
| `.env-template` | Add `MINIMAX_API_KEY` |
| `setup.sh` / `setup.ps1` | Add MiniMax option (default model `MiniMax-M3`) |
| `docs/content/Models/cloud-providers.mdx` | Add MiniMax row (default `MiniMax-M3`) |
| `README.md` | Add MiniMax to provider list |
| `tests/llm/test_minimax_llm.py` | 11 unit tests |
| `tests/tts/test_minimax_tts.py` | 4 unit tests |
| `tests/tts/test_tts_creator.py` | Register MiniMaxTTS test |

## Why M3 as default

MiniMax-M3 is the latest model with a 512K context window, 128K max output, and image input support. The model list now reads M3 → M2.7 → M2.7-highspeed, with the older M2.5 / M2.5-highspeed removed.

## Test plan

- [x] All 11 MiniMax LLM unit tests pass (`pytest tests/llm/test_minimax_llm.py`)
- [x] All 4 MiniMax TTS unit tests pass (`pytest tests/tts/test_minimax_tts.py`)
- [x] New test asserts model catalog contains M3 / M2.7 / M2.7-highspeed and excludes older models
- [x] Existing OpenAI LLM tests still pass (no regressions)
- [x] Existing TTS tests still pass (no regressions)
- [x] Integration check: `LLMCreator.llms['minimax']` correctly resolves to `MiniMaxLLM`
- [x] Model configs validate: 3 models registered with correct provider enum, M3 is the first entry