### PR TITLE
feat: implement local folder upload support (#1771)

### DIFF
--- a/application/api/user/sources/upload.py
+++ b/application/api/user/sources/upload.py
@@ -83,19 +83,38 @@ class UploadFile(Resource):
             storage = StorageCreator.get_storage()
 
             for file in files:
-                original_filename = os.path.basename(file.filename)
-                safe_file = safe_filename(original_filename)
-                if original_filename:
-                    file_name_map[safe_file] = original_filename
+                # Handle potential folder uploads (from webkitdirectory or recursive drag-drop)
+                # file.filename may contain a relative path like 'folder/subfolder/file.txt'
+                original_filename = file.filename
+                if not original_filename:
+                    continue
+
+                # Ensure path uses forward slashes and clean it
+                relative_path = original_filename.replace("\\", "/").strip("/")
+                if ".." in relative_path or relative_path.startswith("/"):
+                    # Basic security check to prevent path traversal
+                    continue
+
+                # Split and make each part of the path safe
+                path_parts = relative_path.split("/")
+                safe_parts = [safe_filename(part) for part in path_parts if part]
+                if not safe_parts:
+                    continue
+
+                safe_relative_path = "/".join(safe_parts)
+                safe_file_basename = safe_parts[-1]
+
+                # Map the safe path to original name for display purposes
+                file_name_map[safe_relative_path] = original_filename
 
                 with tempfile.TemporaryDirectory() as temp_dir:
-                    temp_file_path = os.path.join(temp_dir, safe_file)
+                    temp_file_path = os.path.join(temp_dir, safe_file_basename)
                     file.save(temp_file_path)
-                    _enforce_audio_path_size_limit(temp_file_path, safe_file)
+                    _enforce_audio_path_size_limit(temp_file_path, safe_file_basename)
 
                     # Only extract actual .zip files, not Office formats (.docx, .xlsx, .pptx)
                     # which are technically zip archives but should be processed as-is
-                    is_office_format = safe_file.lower().endswith(
+                    is_office_format = safe_file_basename.lower().endswith(
                         (".docx", ".xlsx", ".pptx", ".odt", ".ods", ".odp", ".epub")
                     )
                     if zipfile.is_zipfile(temp_file_path) and not is_office_format:
@@ -104,18 +123,25 @@ class UploadFile(Resource):
                                 zip_ref.extractall(path=temp_dir)
 
                                 # Walk through extracted files and upload them
-
-                                for root, _, files in os.walk(temp_dir):
-                                    for extracted_file in files:
+                                for root, _, extracted_files in os.walk(temp_dir):
+                                    for extracted_file in extracted_files:
                                         if (
                                             os.path.join(root, extracted_file)
                                             == temp_file_path
                                         ):
                                             continue
-                                        rel_path = os.path.relpath(
+                                        ext_rel_path = os.path.relpath(
                                             os.path.join(root, extracted_file), temp_dir
                                         )
-                                        storage_path = f"{base_path}/{rel_path}"
+                                        # When extracting a zip, we might want to put it in its own folder or root
+                                        # The previous logic put it under base_path/rel_path
+                                        # If the zip itself was in a subfolder, we should probably prepend that
+                                        zip_prefix = "/".join(safe_parts[:-1])
+                                        if zip_prefix:
+                                            storage_path = f"{base_path}/{zip_prefix}/{ext_rel_path}"
+                                        else:
+                                            storage_path = f"{base_path}/{ext_rel_path}"
+                                        
                                         _enforce_audio_path_size_limit(
                                             os.path.join(root, extracted_file),
                                             extracted_file,
@@ -130,16 +156,14 @@ class UploadFile(Resource):
                                 f"Error extracting zip: {e}", exc_info=True
                             )
                             # If zip extraction fails, save the original zip file
-
-                            file_path = f"{base_path}/{safe_file}"
+                            storage_path = f"{base_path}/{safe_relative_path}"
                             with open(temp_file_path, "rb") as f:
-                                storage.save_file(f, file_path)
+                                storage.save_file(f, storage_path)
                     else:
-                        # For non-zip files, save directly
-
-                        file_path = f"{base_path}/{safe_file}"
+                        # For non-zip files, save directly preserving directory structure
+                        storage_path = f"{base_path}/{safe_relative_path}"
                         with open(temp_file_path, "rb") as f:
-                            storage.save_file(f, file_path)
+                            storage.save_file(f, storage_path)
             task = ingest.delay(
                 settings.UPLOAD_FOLDER,
                 list(SUPPORTED_SOURCE_EXTENSIONS),

--- a/frontend/src/locale/en.json
+++ b/frontend/src/locale/en.json
@@ -270,6 +270,7 @@
       "start": "Start Chatting",
       "name": "Name",
       "choose": "Choose Files",
+      "chooseFolder": "Choose Folder",
       "info": "Please upload .pdf, .txt, .rst, .csv, .xlsx, .docx, .md, .html, .epub, .json, .pptx, .zip limited to 25mb",
       "uploadedFiles": "Uploaded Files",
       "cancel": "Cancel",

--- a/frontend/src/upload/Upload.tsx
+++ b/frontend/src/upload/Upload.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import React, { useCallback, useState, useRef } from 'react';
 import { nanoid } from '@reduxjs/toolkit';
 import { useDropzone } from 'react-dropzone';
 import { useTranslation } from 'react-i18next';
@@ -32,7 +32,7 @@ import { FormField, IngestorConfig, IngestorType } from './types/ingestor';
 
 import { FilePicker } from '../components/FilePicker';
 import GoogleDrivePicker from '../components/GoogleDrivePicker';
-import { FILE_UPLOAD_ACCEPT } from '../constants/fileUpload';
+import { FILE_UPLOAD_ACCEPT, FILE_UPLOAD_ACCEPT_ATTR } from '../constants/fileUpload';
 
 import ChevronRight from '../assets/chevron-right.svg';
 
@@ -61,6 +61,86 @@ function Upload({
   // File picker state
   const [selectedFiles, setSelectedFiles] = useState<string[]>([]);
   const [selectedFolders, setSelectedFolders] = useState<string[]>([]);
+  const folderInputRef = useRef<HTMLInputElement>(null);
+
+  const isSupportedFile = (file: File) => {
+    const extension = '.' + file.name.split('.').pop()?.toLowerCase();
+    return (
+      FILE_UPLOAD_ACCEPT_ATTR.split(',').includes(extension) ||
+      file.name.toLowerCase().endsWith('.zip')
+    );
+  };
+
+  const traverseDirectory = useCallback(
+    async (entry: any, path = ''): Promise<File[]> => {
+      const filesList: File[] = [];
+      if (entry.isFile) {
+        const file = await new Promise<File>((resolve) => entry.file(resolve));
+        const relativePath = path ? `${path}/${file.name}` : file.name;
+        // We use Object.defineProperty to set webkitRelativePath as it's often read-only
+        try {
+          Object.defineProperty(file, 'webkitRelativePath', {
+            value: relativePath,
+            writable: true,
+            configurable: true,
+          });
+        } catch (e) {
+          // Fallback if defineProperty fails
+          (file as any).relativePath = relativePath;
+        }
+        filesList.push(file);
+      } else if (entry.isDirectory) {
+        const reader = entry.createReader();
+        const entries = await new Promise<any[]>((resolve) => {
+          const allEntries: any[] = [];
+          const read = () => {
+            reader.readEntries((results: any[]) => {
+              if (results.length) {
+                allEntries.push(...results);
+                read();
+              } else {
+                resolve(allEntries);
+              }
+            });
+          };
+          read();
+        });
+        for (const subEntry of entries) {
+          const subFiles = await traverseDirectory(
+            subEntry,
+            path ? `${path}/${entry.name}` : entry.name,
+          );
+          filesList.push(...subFiles);
+        }
+      }
+      return filesList;
+    },
+    [],
+  );
+
+  const handleFolderButtonClick = () => {
+    if (folderInputRef.current) {
+      folderInputRef.current.click();
+    }
+  };
+
+  const onFolderSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      const selectedFilesList = (Array.from(e.target.files) as File[]).filter(
+        isSupportedFile,
+      );
+      setfiles(selectedFilesList);
+      if (!nameTouched && selectedFilesList.length > 0) {
+        // Find the root folder name from webkitRelativePath
+        const firstPath = selectedFilesList[0].webkitRelativePath;
+        const rootFolder = firstPath.split('/')[0];
+        setIngestor((prev: IngestorConfig) => ({
+          ...prev,
+          name: rootFolder || prev.name,
+        }));
+      }
+    }
+  };
 
   const renderFormFields = () => {
     if (!ingestor.type) return null;
@@ -110,7 +190,7 @@ function Upload({
             value={String(
               ingestor.config[field.name as keyof typeof ingestor.config],
             )}
-            onChange={(e) =>
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
               handleIngestorChange(
                 field.name as keyof IngestorConfig['config'],
                 e.target.value,
@@ -197,6 +277,22 @@ function Upload({
               <span className="text-purple-30 dark:text-silver inline-block rounded-3xl border border-[#7F7F82] bg-transparent px-4 py-2 font-medium hover:cursor-pointer">
                 <input type="button" {...getInputProps()} />
                 {t('modals.uploadDoc.choose')}
+              </span>
+              <span
+                className="text-purple-30 dark:text-silver ml-2 inline-block rounded-3xl border border-[#7F7F82] bg-transparent px-4 py-2 font-medium hover:cursor-pointer"
+                onClick={handleFolderButtonClick}
+              >
+                <input
+                  type="file"
+                  ref={folderInputRef}
+                  className="hidden"
+                  onChange={onFolderSelect}
+                  {...({
+                    webkitdirectory: 'true',
+                    directory: 'true',
+                  } as any)}
+                />
+                {t('modals.uploadDoc.chooseFolder')}
               </span>
             </div>
             <div className="mt-4 max-w-full">
@@ -428,25 +524,44 @@ function Upload({
   );
 
   const onDrop = useCallback(
-    (acceptedFiles: File[]) => {
-      setfiles(acceptedFiles);
-      const pickedName = acceptedFiles[0]?.name;
+    async (acceptedFiles: File[], fileRejections: any[], event: any) => {
+      let finalFiles = acceptedFiles;
+
+      // Handle directory drops via webkitGetAsEntry if available
+      if (event.dataTransfer && event.dataTransfer.items) {
+        const items = event.dataTransfer.items;
+        const traversePromises = [];
+        for (let i = 0; i < items.length; i++) {
+          const entry = items[i].webkitGetAsEntry();
+          if (entry) {
+            traversePromises.push(traverseDirectory(entry));
+          }
+        }
+        if (traversePromises.length > 0) {
+          const results = await Promise.all(traversePromises);
+          finalFiles = results.flat();
+        }
+      }
+
+      setfiles(finalFiles);
+      const pickedName =
+        finalFiles[0]?.webkitRelativePath?.split('/')[0] || finalFiles[0]?.name;
       if (!nameTouched && pickedName) {
-        setIngestor((prev) => ({ ...prev, name: pickedName }));
+        setIngestor((prev: IngestorConfig) => ({ ...prev, name: pickedName }));
       }
 
       // If we're in local_file mode, update the ingestor config
       if (ingestor.type === 'local_file') {
-        setIngestor((prevState) => ({
+        setIngestor((prevState: IngestorConfig) => ({
           ...prevState,
           config: {
             ...prevState.config,
-            files: acceptedFiles,
+            files: finalFiles,
           },
         }));
       }
     },
-    [ingestor.type, nameTouched],
+    [ingestor.type, nameTouched, traverseDirectory],
   );
 
   const doNothing = () => undefined;
@@ -454,7 +569,9 @@ function Upload({
   const uploadFile = (clientTaskId: string) => {
     const formData = new FormData();
     files.forEach((file) => {
-      formData.append('file', file);
+      const relativePath =
+        file.webkitRelativePath || (file as any).relativePath || file.name;
+      formData.append('file', file, relativePath);
     });
 
     formData.append('name', ingestor.name);
@@ -878,9 +995,9 @@ function Upload({
                   type="text"
                   colorVariant="silver"
                   value={ingestor.name}
-                  onChange={(e) => {
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                     setNameTouched(true);
-                    setIngestor((prevState) => ({
+                    setIngestor((prevState: IngestorConfig) => ({
                       ...prevState,
                       name: e.target.value,
                     }));


### PR DESCRIPTION
This PR adds the ability for users to upload entire local folders to DocsGPT, either via a new folder picker or by dragging and dropping folders into the upload area. This provides a more efficient workflow for ingesting structured documentation and large datasets.

Key Changes

Frontend (Upload.tsx):
Added a "Choose Folder" button that uses webkitdirectory for recursive folder selection.
Implemented a recursive directory traversal algorithm for the drag-and-drop area using webkitGetAsEntry, allowing users to simply drop folders to start ingestion.
Updated the upload logic to preserve and transmit relative paths, ensuring the backend knows the folder structure.

Backend (upload.py):
Enhanced the /api/upload endpoint to handle relative paths in file.filename.
Implemented a secure path-cleansing mechanism to safely recreate the directory hierarchy in temporary storage.
Integrated with the folder-aware ingestion logic introduced in #1770 to correctly map subdirectories in the knowledge base.

UX & Localization:
Added translation keys for folder selection.
Implemented automatic source naming based on the root folder name.