### PR TITLE
security: migrate AES-CBC to AES-GCM authenticated encryption

### DIFF
--- a/application/security/encryption.py
+++ b/application/security/encryption.py
@@ -2,6 +2,7 @@ import base64
 import json
 import os
 
+from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
@@ -37,10 +38,11 @@ def encrypt_credentials(credentials: dict, user_id: str) -> str:
         nonce = os.urandom(12)
         key = _derive_key(user_id, salt)
 
+        aad = user_id.encode()
         json_bytes = json.dumps(credentials).encode()
 
         aesgcm = AESGCM(key)
-        ciphertext_with_tag = aesgcm.encrypt(nonce, json_bytes, None)
+        ciphertext_with_tag = aesgcm.encrypt(nonce, json_bytes, aad)
 
         result = _VERSION_GCM + salt + nonce + ciphertext_with_tag
         return base64.b64encode(result).decode()
@@ -55,10 +57,16 @@ def decrypt_credentials(encrypted_data: str, user_id: str) -> dict:
     try:
         data = base64.b64decode(encrypted_data.encode())
 
+        # Try GCM first (version-prefixed format). If the GCM tag check fails
+        # (InvalidTag), fall back to legacy CBC — this avoids the 1/256 collision
+        # where a legacy salt's first byte happens to be 0x01.
         if data[0:1] == _VERSION_GCM:
-            return _decrypt_gcm(data[1:], user_id)
-        else:
-            return _decrypt_legacy_cbc(data, user_id)
+            try:
+                return _decrypt_gcm(data[1:], user_id)
+            except InvalidTag:
+                pass
+
+        return _decrypt_legacy_cbc(data, user_id)
     except Exception as e:
         print(f"Warning: Failed to decrypt credentials: {e}")
         return {}
@@ -70,9 +78,10 @@ def _decrypt_gcm(data: bytes, user_id: str) -> dict:
     ciphertext_with_tag = data[28:]
 
     key = _derive_key(user_id, salt)
+    aad = user_id.encode()
 
     aesgcm = AESGCM(key)
-    plaintext = aesgcm.decrypt(nonce, ciphertext_with_tag, None)
+    plaintext = aesgcm.decrypt(nonce, ciphertext_with_tag, aad)
 
     return json.loads(plaintext.decode())
 

--- a/application/security/encryption.py
+++ b/application/security/encryption.py
@@ -5,9 +5,12 @@ import os
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
 from application.core.settings import settings
+
+_VERSION_GCM = b"\x01"
 
 
 def _derive_key(user_id: str, salt: bytes) -> bytes:
@@ -31,18 +34,15 @@ def encrypt_credentials(credentials: dict, user_id: str) -> str:
         return ""
     try:
         salt = os.urandom(16)
-        iv = os.urandom(16)
+        nonce = os.urandom(12)
         key = _derive_key(user_id, salt)
 
-        json_str = json.dumps(credentials)
+        json_bytes = json.dumps(credentials).encode()
 
-        cipher = Cipher(algorithms.AES(key), modes.CBC(iv), backend=default_backend())
-        encryptor = cipher.encryptor()
+        aesgcm = AESGCM(key)
+        ciphertext_with_tag = aesgcm.encrypt(nonce, json_bytes, None)
 
-        padded_data = _pad_data(json_str.encode())
-        encrypted_data = encryptor.update(padded_data) + encryptor.finalize()
-
-        result = salt + iv + encrypted_data
+        result = _VERSION_GCM + salt + nonce + ciphertext_with_tag
         return base64.b64encode(result).decode()
     except Exception as e:
         print(f"Warning: Failed to encrypt credentials: {e}")
@@ -55,22 +55,43 @@ def decrypt_credentials(encrypted_data: str, user_id: str) -> dict:
     try:
         data = base64.b64decode(encrypted_data.encode())
 
-        salt = data[:16]
-        iv = data[16:32]
-        encrypted_content = data[32:]
-
-        key = _derive_key(user_id, salt)
-
-        cipher = Cipher(algorithms.AES(key), modes.CBC(iv), backend=default_backend())
-        decryptor = cipher.decryptor()
-
-        decrypted_padded = decryptor.update(encrypted_content) + decryptor.finalize()
-        decrypted_data = _unpad_data(decrypted_padded)
-
-        return json.loads(decrypted_data.decode())
+        if data[0:1] == _VERSION_GCM:
+            return _decrypt_gcm(data[1:], user_id)
+        else:
+            return _decrypt_legacy_cbc(data, user_id)
     except Exception as e:
         print(f"Warning: Failed to decrypt credentials: {e}")
         return {}
+
+
+def _decrypt_gcm(data: bytes, user_id: str) -> dict:
+    salt = data[:16]
+    nonce = data[16:28]
+    ciphertext_with_tag = data[28:]
+
+    key = _derive_key(user_id, salt)
+
+    aesgcm = AESGCM(key)
+    plaintext = aesgcm.decrypt(nonce, ciphertext_with_tag, None)
+
+    return json.loads(plaintext.decode())
+
+
+def _decrypt_legacy_cbc(data: bytes, user_id: str) -> dict:
+    """Decrypt data encrypted with the old AES-CBC format for backward compatibility."""
+    salt = data[:16]
+    iv = data[16:32]
+    encrypted_content = data[32:]
+
+    key = _derive_key(user_id, salt)
+
+    cipher = Cipher(algorithms.AES(key), modes.CBC(iv), backend=default_backend())
+    decryptor = cipher.decryptor()
+
+    decrypted_padded = decryptor.update(encrypted_content) + decryptor.finalize()
+    decrypted_data = _unpad_data(decrypted_padded)
+
+    return json.loads(decrypted_data.decode())
 
 
 def _pad_data(data: bytes) -> bytes:

--- a/tests/security/test_encryption.py
+++ b/tests/security/test_encryption.py
@@ -134,6 +134,59 @@ def test_tampered_gcm_ciphertext_returns_empty(monkeypatch):
 
 
 @pytest.mark.unit
+def test_gcm_cross_user_replay_returns_empty(monkeypatch):
+    """GCM ciphertext encrypted for one user must not decrypt under another user."""
+    monkeypatch.setattr(encryption.settings, "ENCRYPTION_SECRET_KEY", "test-secret")
+    monkeypatch.setattr(encryption.os, "urandom", lambda length: b"\x00" * length)
+
+    credentials = {"secret": "value"}
+    encrypted = encryption.encrypt_credentials(credentials, "user-A")
+
+    assert encryption.decrypt_credentials(encrypted, "user-B") == {}
+
+
+@pytest.mark.unit
+def test_legacy_cbc_salt_starting_with_version_byte(monkeypatch):
+    """Legacy CBC blob whose salt starts with 0x01 must still decrypt via fallback."""
+    monkeypatch.setattr(encryption.settings, "ENCRYPTION_SECRET_KEY", "test-secret")
+
+    # Salt intentionally starts with 0x01 — same as _VERSION_GCM
+    salt = b"\x01" + bytes(range(1, 16))
+    iv = bytes(range(16, 32))
+    key = encryption._derive_key("user-123", salt)
+
+    import json
+
+    plaintext = json.dumps({"token": "collision-test"}).encode()
+    padded = encryption._pad_data(plaintext)
+
+    cipher = Cipher(algorithms.AES(key), modes.CBC(iv), backend=default_backend())
+    encryptor = cipher.encryptor()
+    ciphertext = encryptor.update(padded) + encryptor.finalize()
+
+    legacy_blob = base64.b64encode(salt + iv + ciphertext).decode()
+
+    result = encryption.decrypt_credentials(legacy_blob, "user-123")
+    assert result == {"token": "collision-test"}
+
+
+@pytest.mark.unit
+def test_corrupt_legacy_cbc_payload_returns_empty(monkeypatch):
+    """Structurally valid but corrupt CBC payload should return {} via unpad error."""
+    monkeypatch.setattr(encryption.settings, "ENCRYPTION_SECRET_KEY", "test-secret")
+
+    salt = bytes(range(16))
+    iv = bytes(range(16, 32))
+
+    # 16 bytes of garbage — valid block size but invalid padding and JSON
+    corrupt_ciphertext = bytes(range(32, 48))
+
+    corrupt_blob = base64.b64encode(salt + iv + corrupt_ciphertext).decode()
+
+    assert encryption.decrypt_credentials(corrupt_blob, "user-123") == {}
+
+
+@pytest.mark.unit
 def test_pad_and_unpad_are_inverse():
     original = b"secret-data"
 

--- a/tests/security/test_encryption.py
+++ b/tests/security/test_encryption.py
@@ -4,6 +4,7 @@ import pytest
 from application.security import encryption
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
 
@@ -41,16 +42,19 @@ def test_derive_key_uses_secret_and_user(monkeypatch):
 def test_encrypt_and_decrypt_round_trip(monkeypatch):
     monkeypatch.setattr(encryption.settings, "ENCRYPTION_SECRET_KEY", "test-secret")
     salt = bytes(range(16))
-    iv = bytes(range(16, 32))
-    monkeypatch.setattr(encryption.os, "urandom", _fake_os_urandom_factory([salt, iv]))
+    nonce = bytes(range(12))
+    monkeypatch.setattr(
+        encryption.os, "urandom", _fake_os_urandom_factory([salt, nonce])
+    )
 
     credentials = {"token": "abc123", "refresh": "xyz789"}
 
     encrypted = encryption.encrypt_credentials(credentials, "user-123")
 
     decoded = base64.b64decode(encrypted)
-    assert decoded[:16] == salt
-    assert decoded[16:32] == iv
+    assert decoded[0:1] == encryption._VERSION_GCM
+    assert decoded[1:17] == salt
+    assert decoded[17:29] == nonce
 
     decrypted = encryption.decrypt_credentials(encrypted, "user-123")
 
@@ -87,6 +91,46 @@ def test_decrypt_credentials_returns_empty_for_invalid_input(monkeypatch):
 
     invalid_payload = base64.b64encode(b"short").decode()
     assert encryption.decrypt_credentials(invalid_payload, "user-123") == {}
+
+
+@pytest.mark.unit
+def test_decrypt_legacy_cbc_format(monkeypatch):
+    """Old AES-CBC encrypted data should still decrypt correctly."""
+    monkeypatch.setattr(encryption.settings, "ENCRYPTION_SECRET_KEY", "test-secret")
+
+    salt = bytes(range(16))
+    iv = bytes(range(16, 32))
+    key = encryption._derive_key("user-123", salt)
+
+    import json
+
+    plaintext = json.dumps({"token": "legacy-abc"}).encode()
+    padded = encryption._pad_data(plaintext)
+
+    cipher = Cipher(algorithms.AES(key), modes.CBC(iv), backend=default_backend())
+    encryptor = cipher.encryptor()
+    ciphertext = encryptor.update(padded) + encryptor.finalize()
+
+    legacy_blob = base64.b64encode(salt + iv + ciphertext).decode()
+
+    result = encryption.decrypt_credentials(legacy_blob, "user-123")
+    assert result == {"token": "legacy-abc"}
+
+
+@pytest.mark.unit
+def test_tampered_gcm_ciphertext_returns_empty(monkeypatch):
+    """Tampered GCM ciphertext must fail authentication and return {}."""
+    monkeypatch.setattr(encryption.settings, "ENCRYPTION_SECRET_KEY", "test-secret")
+    monkeypatch.setattr(encryption.os, "urandom", lambda length: b"\x00" * length)
+
+    credentials = {"secret": "value"}
+    encrypted = encryption.encrypt_credentials(credentials, "user-123")
+
+    raw = bytearray(base64.b64decode(encrypted))
+    raw[-1] ^= 0xFF  # flip last byte of ciphertext+tag
+    tampered = base64.b64encode(bytes(raw)).decode()
+
+    assert encryption.decrypt_credentials(tampered, "user-123") == {}
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- **Replaced AES-CBC (no message authentication) with AES-GCM** in `application/security/encryption.py`, providing both confidentiality and integrity for stored credentials
- **Backward-compatible decryption**: existing CBC-encrypted data is auto-detected via a version byte prefix and decrypted through the legacy path
- **Added tests** for GCM round-trip, legacy CBC compatibility, tamper detection, and cross-user replay rejection

Fixes #2503

## Motivation
AES-CBC without HMAC lacks ciphertext integrity protection. While the practical Padding Oracle attack surface is limited (no direct decrypt endpoint), the absence of authenticated encryption is a cryptographic deficiency. AES-GCM resolves this in a single primitive.

## Changes
| File | Change |
|------|--------|
| `application/security/encryption.py` | `encrypt_credentials` -> AES-256-GCM with `user_id` bound as AAD; `decrypt_credentials` -> GCM-first versioned decrypt with legacy CBC fallback |
| `tests/security/test_encryption.py` | Updated round-trip test; added legacy CBC compatibility, tamper detection, cross-user replay, version-byte collision fallback, and corrupt legacy payload coverage |

## Test plan
- [x] `/tmp/docsgpt-pr2331-venv/bin/python -m pytest tests/security/test_encryption.py -q --no-cov` - 11 passed
- [x] GCM encrypt/decrypt round-trip verified
- [x] Legacy CBC data still decrypts correctly
- [x] Tampered GCM ciphertext correctly rejected (returns `{}`)
- [x] GCM ciphertext encrypted for one user is rejected for another user

🤖 Generated with [Claude Code](https://claude.com/claude-code)
