### PR TITLE
feat: add Baidu Qianfan as a first-class LLM provider

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -9,6 +9,7 @@ INTERNAL_KEY=<internal key for worker-to-backend authentication>
 # GOOGLE_API_KEY=<your-google-api-key>
 # GROQ_API_KEY=<your-groq-api-key>
 # NOVITA_API_KEY=<your-novita-api-key>
+# QIANFAN_API_KEY=<your-qianfan-api-key>
 # OPEN_ROUTER_API_KEY=<your-openrouter-api-key>
 
 # Remote Embeddings (Optional - for using a remote embeddings API instead of local SentenceTransformer)

--- a/application/core/model_settings.py
+++ b/application/core/model_settings.py
@@ -26,6 +26,7 @@ class ModelProvider(str, Enum):
     PREMAI = "premai"
     SAGEMAKER = "sagemaker"
     NOVITA = "novita"
+    QIANFAN = "qianfan"
 
 
 @dataclass

--- a/application/core/models/qianfan.yaml
+++ b/application/core/models/qianfan.yaml
@@ -1,0 +1,11 @@
+provider: qianfan
+defaults:
+  supports_tools: false
+  supports_structured_output: false
+  supports_streaming: true
+  context_window: 128000
+
+models:
+  - id: ernie-5.0
+    display_name: ERNIE 5.0
+    description: Baidu Qianfan flagship text chat model

--- a/application/core/settings.py
+++ b/application/core/settings.py
@@ -113,6 +113,7 @@ class Settings(BaseSettings):
     HUGGINGFACE_API_KEY: Optional[str] = None
     OPEN_ROUTER_API_KEY: Optional[str] = None
     NOVITA_API_KEY: Optional[str] = None
+    QIANFAN_API_KEY: Optional[str] = None
 
     OPENAI_API_BASE: Optional[str] = None  # azure openai api base url
     OPENAI_API_VERSION: Optional[str] = None  # azure openai api version
@@ -250,6 +251,7 @@ class Settings(BaseSettings):
         "GROQ_API_KEY",
         "HUGGINGFACE_API_KEY",
         "NOVITA_API_KEY",
+        "QIANFAN_API_KEY",
         "EMBEDDINGS_KEY",
         "FALLBACK_LLM_API_KEY",
         "QDRANT_API_KEY",

--- a/application/llm/handlers/handler_creator.py
+++ b/application/llm/handlers/handler_creator.py
@@ -8,6 +8,7 @@ class LLMHandlerCreator:
         "openai": OpenAILLMHandler,
         "google": GoogleLLMHandler,
         "novita": OpenAILLMHandler,  # Novita uses OpenAI-compatible API
+        "qianfan": OpenAILLMHandler,  # Qianfan uses an OpenAI-compatible chat API
         "default": OpenAILLMHandler,
     }
 

--- a/application/llm/providers/__init__.py
+++ b/application/llm/providers/__init__.py
@@ -23,6 +23,7 @@ from application.llm.providers.openai import OpenAIProvider
 from application.llm.providers.openai_compatible import OpenAICompatibleProvider
 from application.llm.providers.openrouter import OpenRouterProvider
 from application.llm.providers.premai import PremAIProvider
+from application.llm.providers.qianfan import QianfanProvider
 from application.llm.providers.sagemaker import SagemakerProvider
 
 # Order here is the order the registry iterates providers (and therefore
@@ -40,6 +41,7 @@ ALL_PROVIDERS: List[Provider] = [
     GroqProvider(),
     OpenRouterProvider(),
     NovitaProvider(),
+    QianfanProvider(),
     HuggingFaceProvider(),
     LlamaCppProvider(),
     PremAIProvider(),

--- a/application/llm/providers/qianfan.py
+++ b/application/llm/providers/qianfan.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from application.llm.providers._apikey_or_llm_name import (
+    filter_models_by_llm_name,
+    get_api_key,
+)
+from application.llm.providers.base import Provider
+from application.llm.qianfan import QianfanLLM
+
+
+class QianfanProvider(Provider):
+    name = "qianfan"
+    llm_class = QianfanLLM
+
+    def get_api_key(self, settings) -> Optional[str]:
+        return get_api_key(settings, self.name, settings.QIANFAN_API_KEY)
+
+    def filter_yaml_models(self, settings, models):
+        return filter_models_by_llm_name(
+            settings, self.name, settings.QIANFAN_API_KEY, models
+        )

--- a/application/llm/qianfan.py
+++ b/application/llm/qianfan.py
@@ -1,0 +1,27 @@
+from application.core.settings import settings
+from application.llm.openai import OpenAILLM
+
+QIANFAN_BASE_URL = "https://qianfan.baidubce.com/v2"
+
+
+class QianfanLLM(OpenAILLM):
+    def __init__(self, api_key=None, user_api_key=None, base_url=None, *args, **kwargs):
+        super().__init__(
+            api_key=api_key or settings.QIANFAN_API_KEY or settings.API_KEY,
+            user_api_key=user_api_key,
+            base_url=base_url or QIANFAN_BASE_URL,
+            *args,
+            **kwargs,
+        )
+
+    def get_supported_attachment_types(self):
+        """Keep the first Qianfan integration text-only until attachment support is verified."""
+        return []
+
+    def _supports_tools(self):
+        """Disable tools until Qianfan tool-calling is verified end-to-end."""
+        return False
+
+    def _supports_structured_output(self):
+        """Disable structured output until JSON schema support is verified end-to-end."""
+        return False

--- a/application/utils.py
+++ b/application/utils.py
@@ -35,6 +35,7 @@ def get_gpt_model() -> str:
         "anthropic": "claude-2",
         "groq": "llama3-8b-8192",
         "novita": "deepseek/deepseek-r1",
+        "qianfan": "ernie-5.0",
     }
     return settings.LLM_NAME or model_map.get(settings.LLM_PROVIDER, "")
 

--- a/docs/content/Deploying/DocsGPT-Settings.mdx
+++ b/docs/content/Deploying/DocsGPT-Settings.mdx
@@ -47,6 +47,7 @@ Here are some of the most fundamental settings you'll likely want to configure:
     - `google`: Use Google's Vertex AI or Gemini models.
     - `anthropic`: Use Anthropic's Claude models.
     - `groq`: Use Groq's models.
+    - `qianfan`: Use Baidu Qianfan models.
     - `huggingface`: Use HuggingFace Inference API.
     - `azure_openai`: Use Azure OpenAI Service.
     - `openai` (when using local inference engines like Ollama, Llama.cpp, TGI, etc.): This signals DocsGPT to use an OpenAI-compatible API format, even if the actual LLM is running locally.
@@ -56,7 +57,25 @@ Here are some of the most fundamental settings you'll likely want to configure:
   - **Examples:**
     - For `LLM_PROVIDER=openai`: `gpt-4o`
     - For `LLM_PROVIDER=google`: `gemini-2.0-flash`
+    - For `LLM_PROVIDER=qianfan`: `ernie-5.0`
     - For local models (e.g., Ollama): `llama3.2:1b` (or any model name available in your setup).
+
+### Example for Cloud API Provider (Baidu Qianfan)
+
+To use Baidu Qianfan's `ernie-5.0` model, configure your `.env` file like this:
+
+```env
+LLM_PROVIDER=qianfan
+QIANFAN_API_KEY=YOUR_QIANFAN_API_KEY
+LLM_NAME=ernie-5.0
+```
+
+You can also reuse the generic `API_KEY` variable with `LLM_PROVIDER=qianfan`, but `QIANFAN_API_KEY` is clearer when you configure multiple providers in the same deployment.
+
+The first Qianfan integration is intentionally conservative:
+
+- Text chat is supported.
+- Attachments, tool calling, and structured output are left disabled until they are verified end-to-end against the Qianfan API.
 
 - **`EMBEDDINGS_NAME`**: This setting defines which embedding model DocsGPT will use to generate vector embeddings for your documents. Embeddings are numerical representations of text that allow DocsGPT to understand the semantic meaning of your documents for efficient search and retrieval.
 

--- a/docs/content/Models/cloud-providers.mdx
+++ b/docs/content/Models/cloud-providers.mdx
@@ -33,6 +33,9 @@ DocsGPT offers direct, streamlined support for the following cloud LLM providers
 | Prem AI                      | `premai`       | (See Prem AI docs)          |
 | AWS SageMaker                | `sagemaker`    | (See SageMaker docs)        |
 | Novita AI                    | `novita`       | (See Novita docs)           |
+| Baidu Qianfan                | `qianfan`      | `ernie-5.0`                 |
+
+The first Qianfan integration in DocsGPT is scoped to text chat with `ernie-5.0`. Attachment handling, tool calling, and structured output are intentionally disabled until they are verified end-to-end.
 
 ## Connecting to OpenAI-Compatible Cloud APIs
 

--- a/tests/core/test_model_registry_yaml.py
+++ b/tests/core/test_model_registry_yaml.py
@@ -63,6 +63,7 @@ EXPECTED_IDS = {
     },
     "docsgpt": {"docsgpt-local"},
     "huggingface": {"huggingface-local"},
+    "qianfan": {"ernie-5.0"},
 }
 
 
@@ -78,6 +79,7 @@ def _make_settings(**overrides):
     s.OPEN_ROUTER_API_KEY = None
     s.NOVITA_API_KEY = None
     s.HUGGINGFACE_API_KEY = None
+    s.QIANFAN_API_KEY = None
     s.LLM_PROVIDER = ""
     s.LLM_NAME = None
     s.API_KEY = None
@@ -227,6 +229,24 @@ class TestRegistryPermutations:
         ids = {m.id for m in reg.get_all_models()}
         assert ids == EXPECTED_IDS["huggingface"] | EXPECTED_IDS["docsgpt"]
 
+    def test_qianfan_only(self):
+        s = _make_settings(QIANFAN_API_KEY="qianfan-test")
+        with patch("application.core.settings.settings", s):
+            reg = ModelRegistry()
+        ids = {m.id for m in reg.get_all_models()}
+        assert ids == EXPECTED_IDS["qianfan"] | EXPECTED_IDS["docsgpt"]
+
+    def test_qianfan_via_llm_provider_with_llm_name(self):
+        s = _make_settings(
+            LLM_PROVIDER="qianfan", API_KEY="key", LLM_NAME="ernie-5.0"
+        )
+        with patch("application.core.settings.settings", s):
+            reg = ModelRegistry()
+        qianfan_ids = {
+            m.id for m in reg.get_all_models() if m.provider.value == "qianfan"
+        }
+        assert qianfan_ids == {"ernie-5.0"}
+
     def test_no_credentials_only_docsgpt(self):
         s = _make_settings()
         with patch("application.core.settings.settings", s):
@@ -256,6 +276,7 @@ class TestRegistryPermutations:
             GROQ_API_KEY="x",
             OPEN_ROUTER_API_KEY="x",
             NOVITA_API_KEY="x",
+            QIANFAN_API_KEY="x",
             HUGGINGFACE_API_KEY="x",
             OPENAI_API_BASE="x",
         )

--- a/tests/core/test_model_settings.py
+++ b/tests/core/test_model_settings.py
@@ -38,6 +38,7 @@ class TestModelProvider:
         assert ModelProvider.PREMAI == "premai"
         assert ModelProvider.LLAMA_CPP == "llama.cpp"
         assert ModelProvider.AZURE_OPENAI == "azure_openai"
+        assert ModelProvider.QIANFAN == "qianfan"
 
 
 class TestModelCapabilities:

--- a/tests/core/test_model_utils.py
+++ b/tests/core/test_model_utils.py
@@ -120,6 +120,16 @@ class TestGetApiKeyForProvider:
             assert get_api_key_for_provider("novita") == "sk-novita"
 
     @pytest.mark.unit
+    def test_qianfan_key(self):
+        with patch("application.core.settings.settings") as mock_settings:
+            mock_settings.QIANFAN_API_KEY = "sk-qianfan"
+            mock_settings.API_KEY = "sk-fallback"
+
+            from application.core.model_utils import get_api_key_for_provider
+
+            assert get_api_key_for_provider("qianfan") == "sk-qianfan"
+
+    @pytest.mark.unit
     def test_huggingface_key(self):
         with patch("application.core.settings.settings") as mock_settings:
             mock_settings.HUGGINGFACE_API_KEY = "hf-key"

--- a/tests/llm/handlers/test_handler_creator.py
+++ b/tests/llm/handlers/test_handler_creator.py
@@ -72,6 +72,7 @@ class TestLLMHandlerCreator:
             "openai": OpenAILLMHandler,
             "google": GoogleLLMHandler,
             "novita": OpenAILLMHandler,
+            "qianfan": OpenAILLMHandler,
             "default": OpenAILLMHandler,
         }
 

--- a/tests/llm/test_qianfan_llm.py
+++ b/tests/llm/test_qianfan_llm.py
@@ -1,0 +1,141 @@
+"""Tests for the Qianfan LLM provider."""
+
+import types
+from unittest.mock import patch
+
+import pytest
+
+from application.llm.qianfan import QIANFAN_BASE_URL, QianfanLLM
+
+
+class FakeChatCompletions:
+    def __init__(self):
+        self.last_kwargs = None
+
+    class _Msg:
+        def __init__(self, content=None):
+            self.content = content
+
+    class _Delta:
+        def __init__(self, content=None):
+            self.content = content
+
+    class _Choice:
+        def __init__(self, content=None, delta=None):
+            self.message = FakeChatCompletions._Msg(content=content)
+            self.delta = FakeChatCompletions._Delta(content=delta)
+
+    class _StreamChunk:
+        def __init__(self, choice):
+            self.choices = [choice]
+
+    class _Response:
+        def __init__(self, choices=None, lines=None):
+            self._choices = choices or []
+            self._lines = lines or []
+
+        @property
+        def choices(self):
+            return self._choices
+
+        def __iter__(self):
+            for line in self._lines:
+                yield line
+
+    def create(self, **kwargs):
+        self.last_kwargs = kwargs
+        if not kwargs.get("stream"):
+            return FakeChatCompletions._Response(
+                choices=[FakeChatCompletions._Choice(content="qianfan response")]
+            )
+        return FakeChatCompletions._Response(
+            lines=[
+                FakeChatCompletions._StreamChunk(
+                    FakeChatCompletions._Choice(delta="part1")
+                ),
+                FakeChatCompletions._StreamChunk(
+                    FakeChatCompletions._Choice(delta="part2")
+                ),
+            ]
+        )
+
+
+class FakeClient:
+    def __init__(self):
+        self.chat = types.SimpleNamespace(completions=FakeChatCompletions())
+
+
+@pytest.mark.unit
+def test_qianfan_base_url_constant():
+    assert QIANFAN_BASE_URL == "https://qianfan.baidubce.com/v2"
+
+
+@pytest.mark.unit
+def test_qianfan_llm_uses_qianfan_base_url():
+    llm = QianfanLLM(api_key="test-key", user_api_key=None)
+    assert str(llm.client.base_url) == QIANFAN_BASE_URL + "/"
+
+
+@pytest.mark.unit
+def test_qianfan_llm_uses_qianfan_api_key():
+    with patch("application.llm.qianfan.settings") as mock_settings:
+        mock_settings.QIANFAN_API_KEY = "qianfan-test-key"
+        mock_settings.API_KEY = "fallback-key"
+        mock_settings.OPENAI_BASE_URL = None
+
+        llm = QianfanLLM(api_key=None, user_api_key=None)
+        assert llm.api_key == "qianfan-test-key"
+
+
+@pytest.mark.unit
+def test_qianfan_llm_falls_back_to_api_key():
+    with patch("application.llm.qianfan.settings") as mock_settings:
+        mock_settings.QIANFAN_API_KEY = None
+        mock_settings.API_KEY = "fallback-key"
+        mock_settings.OPENAI_BASE_URL = None
+
+        llm = QianfanLLM(api_key=None, user_api_key=None)
+        assert llm.api_key == "fallback-key"
+
+
+@pytest.mark.unit
+def test_qianfan_llm_returns_no_attachment_types():
+    llm = QianfanLLM(api_key="test-key", user_api_key=None)
+    assert llm.get_supported_attachment_types() == []
+
+
+@pytest.mark.unit
+def test_qianfan_llm_disables_tools():
+    llm = QianfanLLM(api_key="test-key", user_api_key=None)
+    assert llm._supports_tools() is False
+
+
+@pytest.mark.unit
+def test_qianfan_llm_disables_structured_output():
+    llm = QianfanLLM(api_key="test-key", user_api_key=None)
+    assert llm._supports_structured_output() is False
+
+
+@pytest.mark.unit
+def test_qianfan_llm_gen_calls_client():
+    llm = QianfanLLM(api_key="test-key", user_api_key=None)
+    llm.client = FakeClient()
+
+    msgs = [{"role": "user", "content": "hello"}]
+    result = llm._raw_gen(llm, model="ernie-5.0", messages=msgs, stream=False)
+
+    assert result == "qianfan response"
+    assert llm.client.chat.completions.last_kwargs["model"] == "ernie-5.0"
+
+
+@pytest.mark.unit
+def test_qianfan_llm_gen_stream_yields_chunks():
+    llm = QianfanLLM(api_key="test-key", user_api_key=None)
+    llm.client = FakeClient()
+
+    msgs = [{"role": "user", "content": "hi"}]
+    gen = llm._raw_gen_stream(llm, model="ernie-5.0", messages=msgs, stream=True)
+    chunks = list(gen)
+
+    assert "part1" in "".join(chunks)
+    assert "part2" in "".join(chunks)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,6 +62,13 @@ class TestGetGptModel:
             s.LLM_PROVIDER = "unknown"
             assert get_gpt_model() == ""
 
+    @pytest.mark.unit
+    def test_qianfan_provider_default_model(self):
+        with patch("application.utils.settings") as s:
+            s.LLM_NAME = ""
+            s.LLM_PROVIDER = "qianfan"
+            assert get_gpt_model() == "ernie-5.0"
+
 
 class TestSafeFilename:
 


### PR DESCRIPTION
- What kind of change does this PR introduce?
Feature

- Why was this change needed?
DocsGPT already supports several first-class cloud LLM providers, but Baidu Qianfan users still had to rely on the generic OpenAI-compatible configuration path.

This change adds Qianfan as a dedicated provider so it can be configured more clearly in `.env`, registered in the model registry, and documented alongside the other supported providers.

To keep the initial integration easy to review and maintain, this first version is intentionally scoped to text chat with `ernie-5.0`. Attachments, tool calling, and structured output remain disabled until they are verified end-to-end against the Qianfan API.

- Other information
What changed:
- Added a dedicated `QianfanLLM` provider under `application/llm`
- Registered `qianfan` in the LLM creator, handler creator, settings, and model utilities
- Added `QIANFAN_API_KEY` support for multi-provider deployments
- Registered `ernie-5.0` as the first built-in Qianfan model
- Updated deployment and cloud provider docs with Qianfan configuration examples and scope notes
- Added focused unit tests for provider wiring, model registry, API key resolution, and handler mapping

User-facing configuration:
- `LLM_PROVIDER=qianfan`
- `QIANFAN_API_KEY=YOUR_QIANFAN_API_KEY`
- `LLM_NAME=ernie-5.0`

The initial integration is intentionally scoped to text chat only.

Tests / validation:
- Added unit tests for the new Qianfan provider
- Added registry and API key resolution coverage for `qianfan`
- Added handler mapping coverage
- Verified the Qianfan default model path in utils

Focused test subset run locally:
- `tests/llm/test_qianfan_llm.py`
- `tests/llm/handlers/test_handler_creator.py`
- `tests/core/test_model_settings.py`
- `tests/core/test_model_utils.py`
- `tests/test_utils.py -k qianfan`

Notes for reviewers:
- This follows the same dedicated-provider pattern already used for other OpenAI-compatible providers such as Novita
- The first version intentionally keeps advanced capabilities disabled until they are verified end-to-end
- I did not rely on a broad full-suite pass here because the existing offline test environment has unrelated `tiktoken` download failures in utility tests
