### PR TITLE
feat: Add Astraflow (UCloud ModelVerse) LLM provider support

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -9,6 +9,8 @@ INTERNAL_KEY=<internal key for worker-to-backend authentication>
 # GOOGLE_API_KEY=<your-google-api-key>
 # GROQ_API_KEY=<your-groq-api-key>
 # NOVITA_API_KEY=<your-novita-api-key>
+# ASTRAFLOW_API_KEY=<your-astraflow-api-key>
+# ASTRAFLOW_CN_API_KEY=<your-astraflow-china-api-key>
 # OPEN_ROUTER_API_KEY=<your-openrouter-api-key>
 
 # Remote Embeddings (Optional - for using a remote embeddings API instead of local SentenceTransformer)

--- a/application/core/model_configs.py
+++ b/application/core/model_configs.py
@@ -28,6 +28,7 @@ ANTHROPIC_ATTACHMENTS = IMAGE_ATTACHMENTS
 OPENROUTER_ATTACHMENTS = IMAGE_ATTACHMENTS
 
 NOVITA_ATTACHMENTS = IMAGE_ATTACHMENTS
+ASTRAFLOW_ATTACHMENTS = IMAGE_ATTACHMENTS
 
 
 OPENAI_MODELS = [
@@ -246,6 +247,61 @@ AZURE_OPENAI_MODELS = [
             supports_structured_output=True,
             supported_attachment_types=OPENAI_ATTACHMENTS,
             context_window=8192,
+        ),
+    ),
+]
+
+
+ASTRAFLOW_MODELS = [
+    AvailableModel(
+        id="deepseek-ai/DeepSeek-V3",
+        provider=ModelProvider.ASTRAFLOW,
+        display_name="DeepSeek V3",
+        description="DeepSeek V3 via Astraflow (UCloud ModelVerse)",
+        capabilities=ModelCapabilities(
+            supports_tools=True,
+            supports_structured_output=True,
+            supported_attachment_types=ASTRAFLOW_ATTACHMENTS,
+            context_window=131072,
+        ),
+    ),
+    AvailableModel(
+        id="deepseek-ai/DeepSeek-R1",
+        provider=ModelProvider.ASTRAFLOW,
+        display_name="DeepSeek R1",
+        description="DeepSeek R1 reasoning model via Astraflow (UCloud ModelVerse)",
+        capabilities=ModelCapabilities(
+            supports_tools=False,
+            supports_structured_output=False,
+            supported_attachment_types=[],
+            context_window=131072,
+        ),
+    ),
+]
+
+ASTRAFLOW_CN_MODELS = [
+    AvailableModel(
+        id="deepseek-ai/DeepSeek-V3",
+        provider=ModelProvider.ASTRAFLOW_CN,
+        display_name="DeepSeek V3 (China)",
+        description="DeepSeek V3 via Astraflow China (UCloud ModelVerse CN)",
+        capabilities=ModelCapabilities(
+            supports_tools=True,
+            supports_structured_output=True,
+            supported_attachment_types=ASTRAFLOW_ATTACHMENTS,
+            context_window=131072,
+        ),
+    ),
+    AvailableModel(
+        id="deepseek-ai/DeepSeek-R1",
+        provider=ModelProvider.ASTRAFLOW_CN,
+        display_name="DeepSeek R1 (China)",
+        description="DeepSeek R1 reasoning model via Astraflow China (UCloud ModelVerse CN)",
+        capabilities=ModelCapabilities(
+            supports_tools=False,
+            supports_structured_output=False,
+            supported_attachment_types=[],
+            context_window=131072,
         ),
     ),
 ]

--- a/application/core/model_settings.py
+++ b/application/core/model_settings.py
@@ -19,6 +19,8 @@ class ModelProvider(str, Enum):
     PREMAI = "premai"
     SAGEMAKER = "sagemaker"
     NOVITA = "novita"
+    ASTRAFLOW = "astraflow"
+    ASTRAFLOW_CN = "astraflow-cn"
 
 
 @dataclass
@@ -118,6 +120,14 @@ class ModelRegistry:
             settings.LLM_PROVIDER == "novita" and settings.API_KEY
         ):
             self._add_novita_models(settings)
+        if settings.ASTRAFLOW_API_KEY or (
+            settings.LLM_PROVIDER == "astraflow" and settings.API_KEY
+        ):
+            self._add_astraflow_models(settings)
+        if settings.ASTRAFLOW_CN_API_KEY or (
+            settings.LLM_PROVIDER == "astraflow-cn" and settings.API_KEY
+        ):
+            self._add_astraflow_cn_models(settings)
         if settings.HUGGINGFACE_API_KEY or (
             settings.LLM_PROVIDER == "huggingface" and settings.API_KEY
         ):
@@ -262,6 +272,36 @@ class ModelRegistry:
                     self.models[model.id] = model
                     return
         for model in NOVITA_MODELS:
+            self.models[model.id] = model
+
+    def _add_astraflow_models(self, settings):
+        from application.core.model_configs import ASTRAFLOW_MODELS
+
+        if settings.ASTRAFLOW_API_KEY:
+            for model in ASTRAFLOW_MODELS:
+                self.models[model.id] = model
+            return
+        if settings.LLM_PROVIDER == "astraflow" and settings.LLM_NAME:
+            for model in ASTRAFLOW_MODELS:
+                if model.id == settings.LLM_NAME:
+                    self.models[model.id] = model
+                    return
+        for model in ASTRAFLOW_MODELS:
+            self.models[model.id] = model
+
+    def _add_astraflow_cn_models(self, settings):
+        from application.core.model_configs import ASTRAFLOW_CN_MODELS
+
+        if settings.ASTRAFLOW_CN_API_KEY:
+            for model in ASTRAFLOW_CN_MODELS:
+                self.models[model.id] = model
+            return
+        if settings.LLM_PROVIDER == "astraflow-cn" and settings.LLM_NAME:
+            for model in ASTRAFLOW_CN_MODELS:
+                if model.id == settings.LLM_NAME:
+                    self.models[model.id] = model
+                    return
+        for model in ASTRAFLOW_CN_MODELS:
             self.models[model.id] = model
 
     def _add_docsgpt_models(self, settings):

--- a/application/core/model_utils.py
+++ b/application/core/model_utils.py
@@ -11,6 +11,8 @@ def get_api_key_for_provider(provider: str) -> Optional[str]:
         "openai": settings.OPENAI_API_KEY,
         "openrouter": settings.OPEN_ROUTER_API_KEY,
         "novita": settings.NOVITA_API_KEY,
+        "astraflow": settings.ASTRAFLOW_API_KEY,
+        "astraflow-cn": settings.ASTRAFLOW_CN_API_KEY,
         "anthropic": settings.ANTHROPIC_API_KEY,
         "google": settings.GOOGLE_API_KEY,
         "groq": settings.GROQ_API_KEY,

--- a/application/core/settings.py
+++ b/application/core/settings.py
@@ -94,6 +94,8 @@ class Settings(BaseSettings):
     HUGGINGFACE_API_KEY: Optional[str] = None
     OPEN_ROUTER_API_KEY: Optional[str] = None
     NOVITA_API_KEY: Optional[str] = None
+    ASTRAFLOW_API_KEY: Optional[str] = None
+    ASTRAFLOW_CN_API_KEY: Optional[str] = None
 
     OPENAI_API_BASE: Optional[str] = None  # azure openai api base url
     OPENAI_API_VERSION: Optional[str] = None  # azure openai api version
@@ -192,6 +194,8 @@ class Settings(BaseSettings):
         "GROQ_API_KEY",
         "HUGGINGFACE_API_KEY",
         "NOVITA_API_KEY",
+        "ASTRAFLOW_API_KEY",
+        "ASTRAFLOW_CN_API_KEY",
         "EMBEDDINGS_KEY",
         "FALLBACK_LLM_API_KEY",
         "QDRANT_API_KEY",

--- a/application/llm/llm_creator.py
+++ b/application/llm/llm_creator.py
@@ -10,6 +10,7 @@ from application.llm.openai import AzureOpenAILLM, OpenAILLM
 from application.llm.premai import PremAILLM
 from application.llm.sagemaker import SagemakerAPILLM
 from application.llm.open_router import OpenRouterLLM
+from application.llm.astraflow import AstraflowCNLLM, AstraflowLLM
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +28,15 @@ class LLMCreator:
         "google": GoogleLLM,
         "novita": NovitaLLM,
         "openrouter": OpenRouterLLM,
+        # Astraflow (UCloud ModelVerse) — primary keys
+        "astraflow": AstraflowLLM,
+        "astraflow-cn": AstraflowCNLLM,
+        # Astraflow aliases
+        "astra-flow": AstraflowLLM,
+        "astra_flow": AstraflowLLM,
+        "modelverse": AstraflowLLM,
+        "astraflow-china": AstraflowCNLLM,
+        "astraflow_cn": AstraflowCNLLM,
     }
 
     @classmethod


### PR DESCRIPTION
## Summary

Adds **Astraflow** (UCloud ModelVerse) as a supported LLM provider in DocsGPT, including both the global endpoint and the China-region endpoint.

## Changes

### New File
- `application/llm/astraflow.py` — Defines `AstraflowLLM` (global) and `AstraflowCNLLM` (China) classes, both extending `OpenAILLM`.

### Modified Files
- **`application/llm/llm_creator.py`** — Imports and registers `AstraflowLLM` / `AstraflowCNLLM` under primary keys `"astraflow"` and `"astraflow-cn"`, plus all required aliases (`"astra-flow"`, `"astra_flow"`, `"modelverse"`, `"astraflow-china"`, `"astraflow_cn"`).
- **`application/core/settings.py`** — Adds `ASTRAFLOW_API_KEY` and `ASTRAFLOW_CN_API_KEY` fields; includes both in the sensitive-keys validator.
- **`application/core/model_utils.py`** — Adds `"astraflow"` and `"astraflow-cn"` entries to the provider-to-API-key mapping.
- **`application/core/model_settings.py`** — Adds `ASTRAFLOW` and `ASTRAFLOW_CN` to the `ModelProvider` enum; adds `_add_astraflow_models` and `_add_astraflow_cn_models` methods; registers them in `_load_models`.
- **`application/core/model_configs.py`** — Adds `ASTRAFLOW_ATTACHMENTS`, `ASTRAFLOW_MODELS`, and `ASTRAFLOW_CN_MODELS` lists with representative DeepSeek models.
- **`.env-template`** — Adds commented-out entries for the two new API key variables.

## Naming Convention

| Key | Type |
|-----|------|
| `astraflow` | Primary key (global) |
| `astraflow-cn` | Primary key (China region) |
| `astra-flow`, `astra_flow`, `modelverse` | Aliases → `astraflow` |
| `astraflow-china`, `astraflow_cn` | Aliases → `astraflow-cn` |

## Environment Variables

```
ASTRAFLOW_API_KEY=<your-astraflow-api-key>
ASTRAFLOW_CN_API_KEY=<your-astraflow-china-api-key>
```