### PR TITLE
feat: Add Astraflow (UCloud ModelVerse) LLM provider support

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -9,6 +9,8 @@ INTERNAL_KEY=<internal key for worker-to-backend authentication>
 # GOOGLE_API_KEY=<your-google-api-key>
 # GROQ_API_KEY=<your-groq-api-key>
 # NOVITA_API_KEY=<your-novita-api-key>
+# ASTRAFLOW_API_KEY=<your-astraflow-api-key>
+# ASTRAFLOW_CN_API_KEY=<your-astraflow-cn-api-key>
 # OPEN_ROUTER_API_KEY=<your-openrouter-api-key>
 
 # Remote Embeddings (Optional - for using a remote embeddings API instead of local SentenceTransformer)

--- a/application/core/settings.py
+++ b/application/core/settings.py
@@ -94,6 +94,8 @@ class Settings(BaseSettings):
     HUGGINGFACE_API_KEY: Optional[str] = None
     OPEN_ROUTER_API_KEY: Optional[str] = None
     NOVITA_API_KEY: Optional[str] = None
+    ASTRAFLOW_API_KEY: Optional[str] = None
+    ASTRAFLOW_CN_API_KEY: Optional[str] = None
 
     OPENAI_API_BASE: Optional[str] = None  # azure openai api base url
     OPENAI_API_VERSION: Optional[str] = None  # azure openai api version
@@ -192,6 +194,8 @@ class Settings(BaseSettings):
         "GROQ_API_KEY",
         "HUGGINGFACE_API_KEY",
         "NOVITA_API_KEY",
+        "ASTRAFLOW_API_KEY",
+        "ASTRAFLOW_CN_API_KEY",
         "EMBEDDINGS_KEY",
         "FALLBACK_LLM_API_KEY",
         "QDRANT_API_KEY",

--- a/application/llm/llm_creator.py
+++ b/application/llm/llm_creator.py
@@ -10,6 +10,7 @@ from application.llm.openai import AzureOpenAILLM, OpenAILLM
 from application.llm.premai import PremAILLM
 from application.llm.sagemaker import SagemakerAPILLM
 from application.llm.open_router import OpenRouterLLM
+from application.llm.novita import AstraflowCNLLM, AstraflowLLM
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +28,15 @@ class LLMCreator:
         "google": GoogleLLM,
         "novita": NovitaLLM,
         "openrouter": OpenRouterLLM,
+        # Astraflow (UCloud ModelVerse) – global
+        "astraflow": AstraflowLLM,
+        "astra-flow": AstraflowLLM,
+        "astra_flow": AstraflowLLM,
+        "modelverse": AstraflowLLM,
+        # Astraflow – China region
+        "astraflow-cn": AstraflowCNLLM,
+        "astraflow-china": AstraflowCNLLM,
+        "astraflow_cn": AstraflowCNLLM,
     }
 
     @classmethod

--- a/application/llm/novita.py
+++ b/application/llm/novita.py
@@ -13,3 +13,37 @@ class NovitaLLM(OpenAILLM):
             *args,
             **kwargs,
         )
+
+
+# ---------------------------------------------------------------------------
+# Astraflow (UCloud ModelVerse) provider
+# ---------------------------------------------------------------------------
+
+ASTRAFLOW_BASE_URL = "https://api.astraflow.com/v1"
+ASTRAFLOW_CN_BASE_URL = "https://api.modelverse.cn/v1"
+
+
+class AstraflowLLM(OpenAILLM):
+    """Astraflow (UCloud ModelVerse) – global endpoint."""
+
+    def __init__(self, api_key=None, user_api_key=None, base_url=None, *args, **kwargs):
+        super().__init__(
+            api_key=api_key or settings.ASTRAFLOW_API_KEY or settings.API_KEY,
+            user_api_key=user_api_key,
+            base_url=base_url or ASTRAFLOW_BASE_URL,
+            *args,
+            **kwargs,
+        )
+
+
+class AstraflowCNLLM(OpenAILLM):
+    """Astraflow (UCloud ModelVerse) – China-region endpoint."""
+
+    def __init__(self, api_key=None, user_api_key=None, base_url=None, *args, **kwargs):
+        super().__init__(
+            api_key=api_key or settings.ASTRAFLOW_CN_API_KEY or settings.API_KEY,
+            user_api_key=user_api_key,
+            base_url=base_url or ASTRAFLOW_CN_BASE_URL,
+            *args,
+            **kwargs,
+        )


### PR DESCRIPTION
## Summary

This PR adds **Astraflow** (UCloud ModelVerse) as a supported LLM provider in DocsGPT, covering both the global endpoint and the China-region endpoint.

## Changes

### `application/llm/novita.py` (extended)
Appends two new provider classes after the existing `NovitaLLM` class:
- `AstraflowLLM` — global endpoint (`https://api.astraflow.com/v1`)
- `AstraflowCNLLM` — China-region endpoint (`https://api.modelverse.cn/v1`)

Both classes extend `OpenAILLM` (OpenAI-compatible API), following the same pattern as `NovitaLLM` and `OpenRouterLLM`.

### `application/llm/llm_creator.py`
- Imports `AstraflowLLM` and `AstraflowCNLLM` from `application.llm.novita`
- Registers primary keys and all required aliases:

| Key | Maps to |
|-----|---------|
| `astraflow` | `AstraflowLLM` |
| `astra-flow` | `AstraflowLLM` |
| `astra_flow` | `AstraflowLLM` |
| `modelverse` | `AstraflowLLM` |
| `astraflow-cn` | `AstraflowCNLLM` |
| `astraflow-china` | `AstraflowCNLLM` |
| `astraflow_cn` | `AstraflowCNLLM` |

### `application/core/settings.py`
- Adds `ASTRAFLOW_API_KEY: Optional[str] = None`
- Adds `ASTRAFLOW_CN_API_KEY: Optional[str] = None`
- Both keys are registered in the `normalize_api_key` `@field_validator` list so that `"None"` / empty values are normalized to `None`

### `.env-template`
Adds commented-out example entries for both new API keys alongside the existing provider keys.
