### PR TITLE
Add GitHub Actions zizmor security workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,25 @@
+name: GitHub Actions Security Analysis
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2


### PR DESCRIPTION
### Motivation
- Add a repository-level security analysis workflow that runs Zizmor to produce SARIF results and surface them in GitHub's security view using the `zizmorcore/zizmor-action`.

### Description
- Add ` .github/workflows/zizmor.yml` which runs on pushes to `master` and on all pull requests and defines a `zizmor` job on `ubuntu-latest` that grants `security-events: write` for SARIF upload, checks out the repo with a pinned `actions/checkout` SHA, and runs a pinned `zizmorcore/zizmor-action`.

### Testing
- No automated tests were run locally for this workflow change; the workflow will be exercised by GitHub Actions when a push to `master` or a pull request is created.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de6df6c4c8832780cafe11d66d6d83)