### PR TITLE
fix: enforce response size limit in ReadWebpageTool to prevent resource exhaustion

### DIFF
--- a/application/agents/tools/read_webpage.py
+++ b/application/agents/tools/read_webpage.py
@@ -3,6 +3,9 @@ from markdownify import markdownify
 from application.agents.tools.base import Tool
 from application.core.url_validation import validate_url, SSRFError
 
+MAX_CONTENT_BYTES = 10 * 1024 * 1024  # 10 MB
+
+
 class ReadWebpageTool(Tool):
     """
     Read Webpage (browser)
@@ -38,15 +41,36 @@ class ReadWebpageTool(Tool):
             return f"Error: URL validation failed - {e}"
 
         try:
-            response = requests.get(url, timeout=10, headers={'User-Agent': 'DocsGPT-Agent/1.0'})
-            response.raise_for_status()  # Raise an exception for HTTP errors (4xx or 5xx)
-            
-            html_content = response.text
-            #soup = BeautifulSoup(html_content, 'html.parser')
-            
-            
-            markdown_content = markdownify(html_content, heading_style="ATX", newline_style="BACKSLASH")
-            
+            response = requests.get(
+                url,
+                timeout=10,
+                headers={"User-Agent": "DocsGPT-Agent/1.0"},
+                stream=True,
+            )
+            response.raise_for_status()
+
+            content_length = response.headers.get("Content-Length")
+            if content_length and int(content_length) > MAX_CONTENT_BYTES:
+                response.close()
+                max_mb = MAX_CONTENT_BYTES // (1024 * 1024)
+                return f"Error: Response too large. Maximum allowed size is {max_mb} MB."
+
+            chunks = []
+            total_bytes = 0
+            for chunk in response.iter_content(chunk_size=8192):
+                total_bytes += len(chunk)
+                if total_bytes > MAX_CONTENT_BYTES:
+                    response.close()
+                    max_mb = MAX_CONTENT_BYTES // (1024 * 1024)
+                    return f"Error: Response too large. Maximum allowed size is {max_mb} MB."
+                chunks.append(chunk)
+
+            html_content = b"".join(chunks).decode(
+                response.encoding or "utf-8", errors="replace"
+            )
+            markdown_content = markdownify(
+                html_content, heading_style="ATX", newline_style="BACKSLASH"
+            )
             return markdown_content
 
         except requests.exceptions.RequestException as e:

--- a/tests/agents/test_read_webpage_tool.py
+++ b/tests/agents/test_read_webpage_tool.py
@@ -5,12 +5,23 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
-from application.agents.tools.read_webpage import ReadWebpageTool
+from application.agents.tools.read_webpage import MAX_CONTENT_BYTES, ReadWebpageTool
 
 
 @pytest.fixture
 def tool():
     return ReadWebpageTool()
+
+
+def _make_streaming_response(html: str, encoding: str = "utf-8", headers: dict = None):
+    """Helper: build a mock streaming response for the given HTML string."""
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status.return_value = None
+    mock_resp.headers = headers or {}
+    mock_resp.encoding = encoding
+    raw = html.encode(encoding)
+    mock_resp.iter_content.return_value = iter([raw])
+    return mock_resp
 
 
 @pytest.mark.unit
@@ -29,10 +40,9 @@ class TestReadWebpageExecuteAction:
     @patch("application.agents.tools.read_webpage.requests.get")
     def test_successful_fetch(self, mock_get, mock_validate, tool):
         mock_validate.return_value = "https://example.com"
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.text = "<html><body><h1>Title</h1><p>Content</p></body></html>"
-        mock_get.return_value = mock_resp
+        mock_get.return_value = _make_streaming_response(
+            "<html><body><h1>Title</h1><p>Content</p></body></html>"
+        )
 
         result = tool.execute_action("read_webpage", url="https://example.com")
 
@@ -71,6 +81,78 @@ class TestReadWebpageExecuteAction:
         result = tool.execute_action("read_webpage", url="https://example.com/404")
 
         assert "Error fetching URL" in result
+
+    @patch("application.agents.tools.read_webpage.validate_url")
+    @patch("application.agents.tools.read_webpage.requests.get")
+    def test_content_length_too_large_rejected(self, mock_get, mock_validate, tool):
+        mock_validate.return_value = "https://example.com/huge"
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.headers = {"Content-Length": str(MAX_CONTENT_BYTES + 1)}
+        mock_get.return_value = mock_resp
+
+        result = tool.execute_action("read_webpage", url="https://example.com/huge")
+
+        assert "too large" in result.lower()
+        mock_resp.iter_content.assert_not_called()
+        mock_resp.close.assert_called_once()
+
+    @patch("application.agents.tools.read_webpage.validate_url")
+    @patch("application.agents.tools.read_webpage.requests.get")
+    def test_streaming_body_too_large_rejected(self, mock_get, mock_validate, tool):
+        mock_validate.return_value = "https://example.com/stream"
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.headers = {}
+        # each chunk is 8192 bytes; send enough to exceed MAX_CONTENT_BYTES
+        chunk = b"x" * 8192
+        num_chunks = (MAX_CONTENT_BYTES // 8192) + 2
+        mock_resp.iter_content.return_value = iter([chunk] * num_chunks)
+        mock_get.return_value = mock_resp
+
+        result = tool.execute_action("read_webpage", url="https://example.com/stream")
+
+        assert "too large" in result.lower()
+        mock_resp.close.assert_called_once()
+
+    @patch("application.agents.tools.read_webpage.validate_url")
+    @patch("application.agents.tools.read_webpage.requests.get")
+    def test_content_at_limit_allowed(self, mock_get, mock_validate, tool):
+        mock_validate.return_value = "https://example.com/ok"
+        html = "<p>ok</p>"
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.headers = {"Content-Length": str(MAX_CONTENT_BYTES)}
+        mock_resp.encoding = "utf-8"
+        mock_resp.iter_content.return_value = iter([html.encode("utf-8")])
+        mock_get.return_value = mock_resp
+
+        result = tool.execute_action("read_webpage", url="https://example.com/ok")
+
+        assert "too large" not in result.lower()
+        assert "ok" in result
+
+    @patch("application.agents.tools.read_webpage.validate_url")
+    @patch("application.agents.tools.read_webpage.requests.get")
+    def test_uses_stream_true(self, mock_get, mock_validate, tool):
+        mock_validate.return_value = "https://example.com"
+        mock_get.return_value = _make_streaming_response("<p>hi</p>")
+
+        tool.execute_action("read_webpage", url="https://example.com")
+
+        call_kwargs = mock_get.call_args[1]
+        assert call_kwargs.get("stream") is True
+
+    @patch("application.agents.tools.read_webpage.validate_url")
+    @patch("application.agents.tools.read_webpage.requests.get")
+    def test_user_agent_header_sent(self, mock_get, mock_validate, tool):
+        mock_validate.return_value = "https://example.com"
+        mock_get.return_value = _make_streaming_response("<p>hi</p>")
+
+        tool.execute_action("read_webpage", url="https://example.com")
+
+        headers = mock_get.call_args[1]["headers"]
+        assert headers["User-Agent"] == "DocsGPT-Agent/1.0"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Vulnerability Summary

**CWE-400: Uncontrolled Resource Consumption** in `application/agents/tools/read_webpage.py`

### Problem

`ReadWebpageTool.execute_action` fetched the full response body unconditionally via `response.text` before converting it with `markdownify`:

```python
response = requests.get(url, timeout=10, ...)
html_content = response.text          # loads entire body into memory
markdown_content = markdownify(html_content, ...)
```

An attacker can prompt the agent to call `read_webpage` with a URL that serves a multi-GB response (e.g. a large file host or a server under attacker control). The server allocates memory proportional to the response size, with no upper bound, which can cause OOM crashes or severe performance degradation.

### Data flow

```
User chat prompt (attacker-influenced)
  → LLM function-calling output
    → ToolActionParser.parse_args → call_args
      → tool_executor.execute → parameters dict
        → ReadWebpageTool.execute_action(url=<LLM-controlled value>)
          → requests.get(url).text   ← unbounded memory sink
```

SSRF is already blocked by `validate_url()`. This is a separate, complementary defence against resource exhaustion via legitimate-but-oversized responses.

### Fix

- Switch to `stream=True` so the connection is opened without reading the body
- Reject immediately if `Content-Length` header exceeds `MAX_CONTENT_BYTES` (10 MB)
- Abort mid-stream if accumulated body bytes exceed `MAX_CONTENT_BYTES`
- Call `response.close()` on early exit to release the TCP connection

```diff
+MAX_CONTENT_BYTES = 10 * 1024 * 1024  # 10 MB

-response = requests.get(url, timeout=10, headers={...})
-response.raise_for_status()
-html_content = response.text
+response = requests.get(url, timeout=10, headers={...}, stream=True)
+response.raise_for_status()
+
+content_length = response.headers.get("Content-Length")
+if content_length and int(content_length) > MAX_CONTENT_BYTES:
+    response.close()
+    return f"Error: Response too large. Maximum allowed size is {max_mb} MB."
+
+chunks = []
+total_bytes = 0
+for chunk in response.iter_content(chunk_size=8192):
+    total_bytes += len(chunk)
+    if total_bytes > MAX_CONTENT_BYTES:
+        response.close()
+        return f"Error: Response too large. Maximum allowed size is {max_mb} MB."
+    chunks.append(chunk)
+
+html_content = b"".join(chunks).decode(response.encoding or "utf-8", errors="replace")
```

### Tests added (5 new cases)

| Test | What it verifies |
|---|---|
| `test_content_length_too_large_rejected` | Rejects before reading body when `Content-Length` exceeds limit; `iter_content` never called |
| `test_streaming_body_too_large_rejected` | Aborts mid-stream when accumulated bytes exceed limit |
| `test_content_at_limit_allowed` | Accepts a response exactly at the limit (boundary check) |
| `test_uses_stream_true` | Confirms `stream=True` is passed to `requests.get` |
| `test_user_agent_header_sent` | Confirms `User-Agent` header is still sent on streaming request |

Existing tests updated to mock `iter_content` instead of `.text` to match the streaming code path.

All 13 tests pass (`python -m pytest tests/agents/test_read_webpage_tool.py -v`).

---

Screenshots: N/A — backend-only change with no UI impact.