### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/application/core/model_settings.py
+++ b/application/core/model_settings.py
@@ -5,16 +5,9 @@ from typing import Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
-# Re-exported here so existing call sites (and tests) that do
-# ``from application.core.model_settings import ModelRegistry`` keep
-# working. The implementation lives in ``application/core/model_registry.py``.
-# Imported lazily inside ``__getattr__`` to avoid an import cycle with
-# ``model_yaml`` → ``model_settings`` (this file).
-
 
 class ModelProvider(str, Enum):
     OPENAI = "openai"
-    OPENAI_COMPATIBLE = "openai_compatible"
     OPENROUTER = "openrouter"
     AZURE_OPENAI = "azure_openai"
     ANTHROPIC = "anthropic"
@@ -26,6 +19,7 @@ class ModelProvider(str, Enum):
     PREMAI = "premai"
     SAGEMAKER = "sagemaker"
     NOVITA = "novita"
+    LITELLM = "litellm"
 
 
 @dataclass
@@ -48,21 +42,11 @@ class AvailableModel:
     capabilities: ModelCapabilities = field(default_factory=ModelCapabilities)
     enabled: bool = True
     base_url: Optional[str] = None
-    # User-facing label distinct from dispatch provider (e.g. mistral
-    # routed through openai_compatible).
-    display_provider: Optional[str] = None
-    # Sent in the API call's ``model`` field; falls back to ``self.id``
-    # for built-ins where id IS the upstream name.
-    upstream_model_id: Optional[str] = None
-    # "builtin" for catalog YAMLs, "user" for BYOM records.
-    source: str = "builtin"
-    # Decrypted/resolved at registry-merge time. Never serialized.
-    api_key: Optional[str] = field(default=None, repr=False, compare=False)
 
     def to_dict(self) -> Dict:
         result = {
             "id": self.id,
-            "provider": self.display_provider or self.provider.value,
+            "provider": self.provider.value,
             "display_name": self.display_name,
             "description": self.description,
             "supported_attachment_types": self.capabilities.supported_attachment_types,
@@ -71,21 +55,289 @@ class AvailableModel:
             "supports_streaming": self.capabilities.supports_streaming,
             "context_window": self.capabilities.context_window,
             "enabled": self.enabled,
-            "source": self.source,
         }
         if self.base_url:
             result["base_url"] = self.base_url
         return result
 
 
-def __getattr__(name):
-    """Lazy re-export of ``ModelRegistry`` from ``model_registry.py``.
+class ModelRegistry:
+    _instance = None
+    _initialized = False
 
-    Done lazily to avoid an import cycle: ``model_registry`` imports
-    ``model_yaml`` which imports the dataclasses from this file.
-    """
-    if name == "ModelRegistry":
-        from application.core.model_registry import ModelRegistry as _MR
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
 
-        return _MR
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    def __init__(self):
+        if not ModelRegistry._initialized:
+            self.models: Dict[str, AvailableModel] = {}
+            self.default_model_id: Optional[str] = None
+            self._load_models()
+            ModelRegistry._initialized = True
+
+    @classmethod
+    def get_instance(cls) -> "ModelRegistry":
+        return cls()
+
+    def _load_models(self):
+        from application.core.settings import settings
+
+        self.models.clear()
+
+        # Skip DocsGPT model if using custom OpenAI-compatible endpoint
+        if not settings.OPENAI_BASE_URL:
+            self._add_docsgpt_models(settings)
+        if (
+            settings.OPENAI_API_KEY
+            or (settings.LLM_PROVIDER == "openai" and settings.API_KEY)
+            or settings.OPENAI_BASE_URL
+        ):
+            self._add_openai_models(settings)
+        if settings.OPENAI_API_BASE or (
+            settings.LLM_PROVIDER == "azure_openai" and settings.API_KEY
+        ):
+            self._add_azure_openai_models(settings)
+        if settings.ANTHROPIC_API_KEY or (
+            settings.LLM_PROVIDER == "anthropic" and settings.API_KEY
+        ):
+            self._add_anthropic_models(settings)
+        if settings.GOOGLE_API_KEY or (
+            settings.LLM_PROVIDER == "google" and settings.API_KEY
+        ):
+            self._add_google_models(settings)
+        if settings.GROQ_API_KEY or (
+            settings.LLM_PROVIDER == "groq" and settings.API_KEY
+        ):
+            self._add_groq_models(settings)
+        if settings.OPEN_ROUTER_API_KEY or (
+            settings.LLM_PROVIDER == "openrouter" and settings.API_KEY
+        ):
+            self._add_openrouter_models(settings)
+        if settings.NOVITA_API_KEY or (
+            settings.LLM_PROVIDER == "novita" and settings.API_KEY
+        ):
+            self._add_novita_models(settings)
+        if settings.HUGGINGFACE_API_KEY or (
+            settings.LLM_PROVIDER == "huggingface" and settings.API_KEY
+        ):
+            self._add_huggingface_models(settings)
+        if settings.LITELLM_API_KEY or (
+            settings.LLM_PROVIDER == "litellm" and settings.API_KEY
+        ):
+            self._add_litellm_models(settings)
+        # Default model selection
+        if settings.LLM_NAME:
+            # Parse LLM_NAME (may be comma-separated)
+            model_names = self._parse_model_names(settings.LLM_NAME)
+            # First model in the list becomes default
+            for model_name in model_names:
+                if model_name in self.models:
+                    self.default_model_id = model_name
+                    break
+            # Backward compat: try exact match if no parsed model found
+            if not self.default_model_id and settings.LLM_NAME in self.models:
+                self.default_model_id = settings.LLM_NAME
+
+        if not self.default_model_id:
+            if settings.LLM_PROVIDER and settings.API_KEY:
+                for model_id, model in self.models.items():
+                    if model.provider.value == settings.LLM_PROVIDER:
+                        self.default_model_id = model_id
+                        break
+
+        if not self.default_model_id and self.models:
+            self.default_model_id = next(iter(self.models.keys()))
+        logger.info(
+            f"ModelRegistry loaded {len(self.models)} models, default: {self.default_model_id}"
+        )
+
+    def _add_openai_models(self, settings):
+        from application.core.model_configs import (
+            OPENAI_MODELS,
+            create_custom_openai_model,
+        )
+
+        # Check if using local OpenAI-compatible endpoint (Ollama, LM Studio, etc.)
+        using_local_endpoint = bool(
+            settings.OPENAI_BASE_URL and settings.OPENAI_BASE_URL.strip()
+        )
+
+        if using_local_endpoint:
+            # When OPENAI_BASE_URL is set, ONLY register custom models from LLM_NAME
+            # Do NOT add standard OpenAI models (gpt-5.1, etc.)
+            if settings.LLM_NAME:
+                model_names = self._parse_model_names(settings.LLM_NAME)
+                for model_name in model_names:
+                    custom_model = create_custom_openai_model(
+                        model_name, settings.OPENAI_BASE_URL
+                    )
+                    self.models[model_name] = custom_model
+                    logger.info(
+                        f"Registered custom OpenAI model: {model_name} at {settings.OPENAI_BASE_URL}"
+                    )
+        else:
+            # Standard OpenAI API usage - add standard models if API key is valid
+            if settings.OPENAI_API_KEY:
+                for model in OPENAI_MODELS:
+                    self.models[model.id] = model
+
+    def _add_azure_openai_models(self, settings):
+        from application.core.model_configs import AZURE_OPENAI_MODELS
+
+        if settings.LLM_PROVIDER == "azure_openai" and settings.LLM_NAME:
+            for model in AZURE_OPENAI_MODELS:
+                if model.id == settings.LLM_NAME:
+                    self.models[model.id] = model
+                    return
+        for model in AZURE_OPENAI_MODELS:
+            self.models[model.id] = model
+
+    def _add_anthropic_models(self, settings):
+        from application.core.model_configs import ANTHROPIC_MODELS
+
+        if settings.ANTHROPIC_API_KEY:
+            for model in ANTHROPIC_MODELS:
+                self.models[model.id] = model
+            return
+        if settings.LLM_PROVIDER == "anthropic" and settings.LLM_NAME:
+            for model in ANTHROPIC_MODELS:
+                if model.id == settings.LLM_NAME:
+                    self.models[model.id] = model
+                    return
+        for model in ANTHROPIC_MODELS:
+            self.models[model.id] = model
+
+    def _add_google_models(self, settings):
+        from application.core.model_configs import GOOGLE_MODELS
+
+        if settings.GOOGLE_API_KEY:
+            for model in GOOGLE_MODELS:
+                self.models[model.id] = model
+            return
+        if settings.LLM_PROVIDER == "google" and settings.LLM_NAME:
+            for model in GOOGLE_MODELS:
+                if model.id == settings.LLM_NAME:
+                    self.models[model.id] = model
+                    return
+        for model in GOOGLE_MODELS:
+            self.models[model.id] = model
+
+    def _add_groq_models(self, settings):
+        from application.core.model_configs import GROQ_MODELS
+
+        if settings.GROQ_API_KEY:
+            for model in GROQ_MODELS:
+                self.models[model.id] = model
+            return
+        if settings.LLM_PROVIDER == "groq" and settings.LLM_NAME:
+            for model in GROQ_MODELS:
+                if model.id == settings.LLM_NAME:
+                    self.models[model.id] = model
+                    return
+        for model in GROQ_MODELS:
+            self.models[model.id] = model
+    
+    def _add_openrouter_models(self, settings):
+        from application.core.model_configs import OPENROUTER_MODELS
+
+        if settings.OPEN_ROUTER_API_KEY:
+            for model in OPENROUTER_MODELS:
+                self.models[model.id] = model
+            return
+        if settings.LLM_PROVIDER == "openrouter" and settings.LLM_NAME:
+            for model in OPENROUTER_MODELS:
+                if model.id == settings.LLM_NAME:
+                    self.models[model.id] = model
+                    return
+        for model in OPENROUTER_MODELS:
+            self.models[model.id] = model
+
+    def _add_novita_models(self, settings):
+        from application.core.model_configs import NOVITA_MODELS
+
+        if settings.NOVITA_API_KEY:
+            for model in NOVITA_MODELS:
+                self.models[model.id] = model
+            return
+        if settings.LLM_PROVIDER == "novita" and settings.LLM_NAME:
+            for model in NOVITA_MODELS:
+                if model.id == settings.LLM_NAME:
+                    self.models[model.id] = model
+                    return
+        for model in NOVITA_MODELS:
+            self.models[model.id] = model
+
+    def _add_litellm_models(self, settings):
+        """Register LiteLLM models from LLM_NAME.
+
+        LiteLLM is a meta-provider — the user specifies any
+        LiteLLM-supported model string via ``LLM_NAME`` (e.g.
+        ``anthropic/claude-3-haiku``, ``azure/gpt-4o``).
+        """
+        if not settings.LLM_NAME:
+            return
+        model_names = self._parse_model_names(settings.LLM_NAME)
+        for model_name in model_names:
+            if model_name not in self.models:
+                self.models[model_name] = AvailableModel(
+                    id=model_name,
+                    provider=ModelProvider.LITELLM,
+                    display_name=model_name,
+                    description=f"LiteLLM: {model_name}",
+                    capabilities=ModelCapabilities(
+                        supports_tools=True,
+                        context_window=128000,
+                        supported_attachment_types=[],
+                    ),
+                )
+
+    def _add_docsgpt_models(self, settings):
+        model_id = "docsgpt-local"
+        model = AvailableModel(
+            id=model_id,
+            provider=ModelProvider.DOCSGPT,
+            display_name="DocsGPT Model",
+            description="Local model",
+            capabilities=ModelCapabilities(
+                supports_tools=False,
+                supported_attachment_types=[],
+            ),
+        )
+        self.models[model_id] = model
+
+    def _add_huggingface_models(self, settings):
+        model_id = "huggingface-local"
+        model = AvailableModel(
+            id=model_id,
+            provider=ModelProvider.HUGGINGFACE,
+            display_name="Hugging Face Model",
+            description="Local Hugging Face model",
+            capabilities=ModelCapabilities(
+                supports_tools=False,
+                supported_attachment_types=[],
+            ),
+        )
+        self.models[model_id] = model
+
+    def _parse_model_names(self, llm_name: str) -> List[str]:
+        """
+        Parse LLM_NAME which may contain comma-separated model names.
+        E.g., 'deepseek-r1:1.5b,gemma:2b' -> ['deepseek-r1:1.5b', 'gemma:2b']
+        """
+        if not llm_name:
+            return []
+        return [name.strip() for name in llm_name.split(",") if name.strip()]
+
+    def get_model(self, model_id: str) -> Optional[AvailableModel]:
+        return self.models.get(model_id)
+
+    def get_all_models(self) -> List[AvailableModel]:
+        return list(self.models.values())
+
+    def get_enabled_models(self) -> List[AvailableModel]:
+        return [m for m in self.models.values() if m.enabled]
+
+    def model_exists(self, model_id: str) -> bool:
+        return model_id in self.models

--- a/application/core/model_settings.py
+++ b/application/core/model_settings.py
@@ -123,9 +123,7 @@ class ModelRegistry:
             settings.LLM_PROVIDER == "huggingface" and settings.API_KEY
         ):
             self._add_huggingface_models(settings)
-        if settings.LITELLM_API_KEY or (
-            settings.LLM_PROVIDER == "litellm" and settings.API_KEY
-        ):
+        if settings.LLM_PROVIDER == "litellm":
             self._add_litellm_models(settings)
         # Default model selection
         if settings.LLM_NAME:

--- a/application/core/model_utils.py
+++ b/application/core/model_utils.py
@@ -16,7 +16,7 @@ def get_api_key_for_provider(provider: str) -> Optional[str]:
         "groq": settings.GROQ_API_KEY,
         "huggingface": settings.HUGGINGFACE_API_KEY,
         "azure_openai": settings.API_KEY,
-        "litellm": settings.LITELLM_API_KEY,
+        "litellm": settings.API_KEY,
         "docsgpt": None,
         "llama.cpp": None,
     }

--- a/application/core/model_utils.py
+++ b/application/core/model_utils.py
@@ -1,59 +1,48 @@
 from typing import Any, Dict, Optional
 
-from application.core.model_registry import ModelRegistry
+from application.core.model_settings import ModelRegistry
 
 
 def get_api_key_for_provider(provider: str) -> Optional[str]:
-    """Get the appropriate API key for a provider.
-
-    Delegates to the provider plugin's ``get_api_key``. Falls back to the
-    generic ``settings.API_KEY`` for unknown providers.
-    """
+    """Get the appropriate API key for a provider"""
     from application.core.settings import settings
-    from application.llm.providers import PROVIDERS_BY_NAME
 
-    plugin = PROVIDERS_BY_NAME.get(provider)
-    if plugin is not None:
-        key = plugin.get_api_key(settings)
-        if key:
-            return key
+    provider_key_map = {
+        "openai": settings.OPENAI_API_KEY,
+        "openrouter": settings.OPEN_ROUTER_API_KEY,
+        "novita": settings.NOVITA_API_KEY,
+        "anthropic": settings.ANTHROPIC_API_KEY,
+        "google": settings.GOOGLE_API_KEY,
+        "groq": settings.GROQ_API_KEY,
+        "huggingface": settings.HUGGINGFACE_API_KEY,
+        "azure_openai": settings.API_KEY,
+        "litellm": settings.LITELLM_API_KEY,
+        "docsgpt": None,
+        "llama.cpp": None,
+    }
+
+    provider_key = provider_key_map.get(provider)
+    if provider_key:
+        return provider_key
     return settings.API_KEY
 
 
-def get_all_available_models(
-    user_id: Optional[str] = None,
-) -> Dict[str, Dict[str, Any]]:
-    """Get all available models with metadata for API response.
-
-    When ``user_id`` is supplied, the user's BYOM custom-model records
-    are merged into the result alongside the built-in catalog.
-    """
+def get_all_available_models() -> Dict[str, Dict[str, Any]]:
+    """Get all available models with metadata for API response"""
     registry = ModelRegistry.get_instance()
-    return {
-        model.id: model.to_dict()
-        for model in registry.get_enabled_models(user_id=user_id)
-    }
+    return {model.id: model.to_dict() for model in registry.get_enabled_models()}
 
 
-def validate_model_id(model_id: str, user_id: Optional[str] = None) -> bool:
-    """Check if a model ID exists in registry.
-
-    ``user_id`` enables resolution of per-user BYOM records (UUIDs).
-    Without it, only built-in catalog ids resolve.
-    """
+def validate_model_id(model_id: str) -> bool:
+    """Check if a model ID exists in registry"""
     registry = ModelRegistry.get_instance()
-    return registry.model_exists(model_id, user_id=user_id)
+    return registry.model_exists(model_id)
 
 
-def get_model_capabilities(
-    model_id: str, user_id: Optional[str] = None
-) -> Optional[Dict[str, Any]]:
-    """Get capabilities for a specific model.
-
-    ``user_id`` enables resolution of per-user BYOM records.
-    """
+def get_model_capabilities(model_id: str) -> Optional[Dict[str, Any]]:
+    """Get capabilities for a specific model"""
     registry = ModelRegistry.get_instance()
-    model = registry.get_model(model_id, user_id=user_id)
+    model = registry.get_model(model_id)
     if model:
         return {
             "supported_attachment_types": model.capabilities.supported_attachment_types,
@@ -70,68 +59,36 @@ def get_default_model_id() -> str:
     return registry.default_model_id
 
 
-def get_provider_from_model_id(
-    model_id: str, user_id: Optional[str] = None
-) -> Optional[str]:
-    """Get the provider name for a given model_id.
-
-    ``user_id`` enables resolution of per-user BYOM records (UUIDs).
-    Without it, BYOM model ids return ``None`` and the caller falls
-    back to the deployment default.
-    """
+def get_provider_from_model_id(model_id: str) -> Optional[str]:
+    """Get the provider name for a given model_id"""
     registry = ModelRegistry.get_instance()
-    model = registry.get_model(model_id, user_id=user_id)
+    model = registry.get_model(model_id)
     if model:
         return model.provider.value
     return None
 
 
-def get_token_limit(model_id: str, user_id: Optional[str] = None) -> int:
-    """Get context window (token limit) for a model.
-
-    Returns the model's ``context_window`` or ``DEFAULT_LLM_TOKEN_LIMIT``
-    if not found. ``user_id`` enables resolution of per-user BYOM records.
+def get_token_limit(model_id: str) -> int:
+    """
+    Get context window (token limit) for a model.
+    Returns model's context_window or default 128000 if model not found.
     """
     from application.core.settings import settings
 
     registry = ModelRegistry.get_instance()
-    model = registry.get_model(model_id, user_id=user_id)
+    model = registry.get_model(model_id)
     if model:
         return model.capabilities.context_window
     return settings.DEFAULT_LLM_TOKEN_LIMIT
 
 
-def get_base_url_for_model(
-    model_id: str, user_id: Optional[str] = None
-) -> Optional[str]:
-    """Get the custom base_url for a specific model if configured.
-
-    Returns ``None`` if no custom base_url is set. ``user_id`` enables
-    resolution of per-user BYOM records.
+def get_base_url_for_model(model_id: str) -> Optional[str]:
+    """
+    Get the custom base_url for a specific model if configured.
+    Returns None if no custom base_url is set.
     """
     registry = ModelRegistry.get_instance()
-    model = registry.get_model(model_id, user_id=user_id)
+    model = registry.get_model(model_id)
     if model:
         return model.base_url
-    return None
-
-
-def get_api_key_for_model(
-    model_id: str, user_id: Optional[str] = None
-) -> Optional[str]:
-    """Resolve the API key to use when invoking ``model_id``.
-
-    Priority:
-      1. The model record's own ``api_key`` (BYOM records and
-         ``openai_compatible`` YAMLs populate this).
-      2. The provider plugin's settings-based key.
-
-    ``user_id`` enables resolution of per-user BYOM records.
-    """
-    registry = ModelRegistry.get_instance()
-    model = registry.get_model(model_id, user_id=user_id)
-    if model is not None and model.api_key:
-        return model.api_key
-    if model is not None:
-        return get_api_key_for_provider(model.provider.value)
     return None

--- a/application/core/models/litellm.yaml
+++ b/application/core/models/litellm.yaml
@@ -1,0 +1,9 @@
+provider: litellm
+api_key_env: LITELLM_API_KEY
+models:
+  - id: openai/gpt-4o
+    name: GPT-4o (via LiteLLM)
+    token_limit: 128000
+  - id: anthropic/claude-sonnet-4-20250514
+    name: Claude Sonnet 4 (via LiteLLM)
+    token_limit: 200000

--- a/application/core/settings.py
+++ b/application/core/settings.py
@@ -99,7 +99,6 @@ class Settings(BaseSettings):
     HUGGINGFACE_API_KEY: Optional[str] = None
     OPEN_ROUTER_API_KEY: Optional[str] = None
     NOVITA_API_KEY: Optional[str] = None
-    LITELLM_API_KEY: Optional[str] = None  # litellm proxy key or provider key
 
     OPENAI_API_BASE: Optional[str] = None  # azure openai api base url
     OPENAI_API_VERSION: Optional[str] = None  # azure openai api version
@@ -201,7 +200,6 @@ class Settings(BaseSettings):
         "GROQ_API_KEY",
         "HUGGINGFACE_API_KEY",
         "NOVITA_API_KEY",
-        "LITELLM_API_KEY",
         "EMBEDDINGS_KEY",
         "FALLBACK_LLM_API_KEY",
         "QDRANT_API_KEY",

--- a/application/core/settings.py
+++ b/application/core/settings.py
@@ -99,6 +99,7 @@ class Settings(BaseSettings):
     HUGGINGFACE_API_KEY: Optional[str] = None
     OPEN_ROUTER_API_KEY: Optional[str] = None
     NOVITA_API_KEY: Optional[str] = None
+    LITELLM_API_KEY: Optional[str] = None  # litellm proxy key or provider key
 
     OPENAI_API_BASE: Optional[str] = None  # azure openai api base url
     OPENAI_API_VERSION: Optional[str] = None  # azure openai api version
@@ -200,6 +201,7 @@ class Settings(BaseSettings):
         "GROQ_API_KEY",
         "HUGGINGFACE_API_KEY",
         "NOVITA_API_KEY",
+        "LITELLM_API_KEY",
         "EMBEDDINGS_KEY",
         "FALLBACK_LLM_API_KEY",
         "QDRANT_API_KEY",

--- a/application/llm/litellm.py
+++ b/application/llm/litellm.py
@@ -8,8 +8,8 @@ Users configure ``LLM_PROVIDER=litellm`` and set ``LLM_NAME`` to any
 LiteLLM-supported model string (e.g. ``anthropic/claude-3-haiku``,
 ``azure/gpt-4o``, ``bedrock/anthropic.claude-v2``).  Provider-specific
 API keys are read from standard environment variables
-(``OPENAI_API_KEY``, ``ANTHROPIC_API_KEY``, etc.) or from the
-``LITELLM_API_KEY`` setting when using LiteLLM Proxy.
+(``OPENAI_API_KEY``, ``ANTHROPIC_API_KEY``, etc.) — LiteLLM picks
+them up automatically.
 """
 
 import json
@@ -25,12 +25,11 @@ class LiteLLM(BaseLLM):
     """LiteLLM provider — unified gateway to 100+ LLM providers.
 
     Args:
-        api_key: API key passed to ``litellm.completion``.  When using
-            LiteLLM Proxy this is the proxy key; otherwise the
-            provider-specific key (or ``None`` to let LiteLLM read
-            from environment variables).
+        api_key: API key forwarded to ``litellm.completion``.  Defaults
+            to ``settings.API_KEY``.  LiteLLM also reads provider-specific
+            keys from environment variables automatically.
         user_api_key: Optional user-provided API key override.
-        base_url: Optional base URL for LiteLLM Proxy.
+        base_url: Optional custom base URL.
     """
 
     def __init__(
@@ -42,7 +41,7 @@ class LiteLLM(BaseLLM):
         **kwargs,
     ) -> None:
         super().__init__(*args, **kwargs)
-        self.api_key = api_key or settings.LITELLM_API_KEY or settings.API_KEY
+        self.api_key = api_key or settings.API_KEY
         self.user_api_key = user_api_key
         self.litellm_base_url = base_url
 

--- a/application/llm/litellm.py
+++ b/application/llm/litellm.py
@@ -1,0 +1,389 @@
+"""LiteLLM provider for DocsGPT.
+
+Provides access to 100+ LLM providers (OpenAI, Anthropic, Google, Azure,
+Bedrock, Vertex, Cohere, etc.) through a single unified interface using
+LiteLLM as an AI gateway.
+
+Users configure ``LLM_PROVIDER=litellm`` and set ``LLM_NAME`` to any
+LiteLLM-supported model string (e.g. ``anthropic/claude-3-haiku``,
+``azure/gpt-4o``, ``bedrock/anthropic.claude-v2``).  Provider-specific
+API keys are read from standard environment variables
+(``OPENAI_API_KEY``, ``ANTHROPIC_API_KEY``, etc.) or from the
+``LITELLM_API_KEY`` setting when using LiteLLM Proxy.
+"""
+
+import json
+import logging
+
+from application.core.settings import settings
+from application.llm.base import BaseLLM
+
+logger = logging.getLogger(__name__)
+
+
+class LiteLLM(BaseLLM):
+    """LiteLLM provider — unified gateway to 100+ LLM providers.
+
+    Args:
+        api_key: API key passed to ``litellm.completion``.  When using
+            LiteLLM Proxy this is the proxy key; otherwise the
+            provider-specific key (or ``None`` to let LiteLLM read
+            from environment variables).
+        user_api_key: Optional user-provided API key override.
+        base_url: Optional base URL for LiteLLM Proxy.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        user_api_key: str | None = None,
+        base_url: str | None = None,
+        *args,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.api_key = api_key or settings.LITELLM_API_KEY or settings.API_KEY
+        self.user_api_key = user_api_key
+        self.litellm_base_url = base_url
+
+    def _clean_messages(self, messages: list[dict]) -> list[dict]:
+        """Normalize messages into OpenAI chat-completion format.
+
+        LiteLLM accepts OpenAI-format messages and translates them
+        for each provider internally, so this method mirrors the
+        cleaning logic used by the OpenAI provider.
+
+        Args:
+            messages: Raw message list from the pipeline.
+
+        Returns:
+            Cleaned list of message dicts.
+        """
+        cleaned: list[dict] = []
+        for message in messages:
+            role = message.get("role")
+            content = message.get("content")
+
+            if role == "model":
+                role = "assistant"
+
+            tool_calls = message.get("tool_calls")
+            if tool_calls and role == "assistant":
+                cleaned_tcs = []
+                for tc in tool_calls:
+                    func = tc.get("function", {})
+                    args = func.get("arguments", "{}")
+                    if isinstance(args, dict):
+                        args = json.dumps(self._remove_null_values(args))
+                    elif isinstance(args, str):
+                        try:
+                            parsed = json.loads(args)
+                            args = json.dumps(self._remove_null_values(parsed))
+                        except (json.JSONDecodeError, TypeError):
+                            pass
+                    cleaned_tcs.append(
+                        {
+                            "id": tc.get("id", ""),
+                            "type": "function",
+                            "function": {
+                                "name": func.get("name", ""),
+                                "arguments": args,
+                            },
+                        }
+                    )
+                cleaned.append(
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": cleaned_tcs,
+                    }
+                )
+                continue
+
+            tool_call_id = message.get("tool_call_id")
+            if role == "tool" and tool_call_id is not None:
+                cleaned.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call_id,
+                        "content": (
+                            content
+                            if isinstance(content, str)
+                            else json.dumps(content)
+                        ),
+                    }
+                )
+                continue
+
+            if role and content is not None:
+                if isinstance(content, str):
+                    cleaned.append({"role": role, "content": content})
+                elif isinstance(content, list):
+                    content_parts: list[dict] = []
+                    for item in content:
+                        if "function_call" in item:
+                            args = item["function_call"]["args"]
+                            if isinstance(args, str):
+                                try:
+                                    args = json.loads(args)
+                                except (json.JSONDecodeError, TypeError):
+                                    pass
+                            cleaned_args = self._remove_null_values(args)
+                            tool_call = {
+                                "id": item["function_call"]["call_id"],
+                                "type": "function",
+                                "function": {
+                                    "name": item["function_call"]["name"],
+                                    "arguments": json.dumps(cleaned_args),
+                                },
+                            }
+                            cleaned.append(
+                                {
+                                    "role": "assistant",
+                                    "content": None,
+                                    "tool_calls": [tool_call],
+                                }
+                            )
+                        elif "function_response" in item:
+                            cleaned.append(
+                                {
+                                    "role": "tool",
+                                    "tool_call_id": item["function_response"][
+                                        "call_id"
+                                    ],
+                                    "content": json.dumps(
+                                        item["function_response"]["response"][
+                                            "result"
+                                        ]
+                                    ),
+                                }
+                            )
+                        elif isinstance(item, dict):
+                            if (
+                                "type" in item
+                                and item["type"] == "text"
+                                and "text" in item
+                            ):
+                                content_parts.append(item)
+                            elif (
+                                "type" in item
+                                and item["type"] == "image_url"
+                                and "image_url" in item
+                            ):
+                                content_parts.append(item)
+                            elif "text" in item and "type" not in item:
+                                content_parts.append(
+                                    {"type": "text", "text": item["text"]}
+                                )
+                    if content_parts:
+                        cleaned.append({"role": role, "content": content_parts})
+                else:
+                    raise ValueError(f"Unexpected content type: {type(content)}")
+        return cleaned
+
+    @staticmethod
+    def _extract_reasoning_text(delta) -> str:
+        """Extract reasoning/thinking tokens from a stream delta chunk.
+
+        Args:
+            delta: A delta object from a streaming response chunk.
+
+        Returns:
+            Extracted reasoning text, or empty string.
+        """
+        if delta is None:
+            return ""
+        for key in (
+            "reasoning_content",
+            "reasoning",
+            "thinking",
+            "thinking_content",
+        ):
+            value = getattr(delta, key, None)
+            if value is None and isinstance(delta, dict):
+                value = delta.get(key)
+            if value and isinstance(value, str):
+                return value
+        return ""
+
+    def _build_completion_params(
+        self,
+        model: str,
+        messages: list[dict],
+        stream: bool,
+        tools: list[dict] | None = None,
+        **kwargs,
+    ) -> dict:
+        """Build the parameter dict for ``litellm.completion``.
+
+        Args:
+            model: LiteLLM model string.
+            messages: Cleaned message list.
+            stream: Whether to stream.
+            tools: Optional tool definitions.
+            **kwargs: Extra kwargs forwarded to LiteLLM.
+
+        Returns:
+            Dict of keyword arguments for ``litellm.completion``.
+        """
+        params: dict = {
+            "model": model,
+            "messages": messages,
+            "stream": stream,
+            "drop_params": True,
+            **kwargs,
+        }
+
+        if self.api_key:
+            params["api_key"] = self.api_key
+        if self.litellm_base_url:
+            params["api_base"] = self.litellm_base_url
+        if tools:
+            params["tools"] = tools
+
+        return params
+
+    def _raw_gen(
+        self,
+        baseself,
+        model: str,
+        messages: list[dict],
+        stream: bool = False,
+        tools: list[dict] | None = None,
+        **kwargs,
+    ):
+        """Generate a single completion via LiteLLM.
+
+        Args:
+            baseself: Reference passed by the decorator chain.
+            model: LiteLLM model string (e.g. ``anthropic/claude-3-haiku``).
+            messages: Chat messages.
+            stream: Must be ``False`` for non-streaming.
+            tools: Optional tool definitions.
+            **kwargs: Extra arguments forwarded to ``litellm.completion``.
+
+        Returns:
+            Content string, or a Choice object when tools are used.
+        """
+        import litellm
+
+        messages = self._clean_messages(messages)
+        logger.info(
+            "LiteLLM _raw_gen: model=%s, message_count=%d, tools=%s",
+            model,
+            len(messages),
+            bool(tools),
+        )
+
+        params = self._build_completion_params(
+            model, messages, stream=False, tools=tools, **kwargs
+        )
+        response = litellm.completion(**params)
+
+        if tools:
+            return response.choices[0]
+        return response.choices[0].message.content
+
+    def _raw_gen_stream(
+        self,
+        baseself,
+        model: str,
+        messages: list[dict],
+        stream: bool = True,
+        tools: list[dict] | None = None,
+        **kwargs,
+    ):
+        """Generate a streaming completion via LiteLLM.
+
+        Args:
+            baseself: Reference passed by the decorator chain.
+            model: LiteLLM model string.
+            messages: Chat messages.
+            stream: Must be ``True`` for streaming.
+            tools: Optional tool definitions.
+            **kwargs: Extra arguments forwarded to ``litellm.completion``.
+
+        Yields:
+            ``str`` for content tokens, ``dict`` for thinking/reasoning
+            tokens, or a Choice object for tool-call chunks.
+        """
+        import litellm
+
+        messages = self._clean_messages(messages)
+        logger.info(
+            "LiteLLM _raw_gen_stream: model=%s, message_count=%d, tools=%s",
+            model,
+            len(messages),
+            bool(tools),
+        )
+
+        params = self._build_completion_params(
+            model, messages, stream=True, tools=tools, **kwargs
+        )
+        response = litellm.completion(**params)
+
+        try:
+            for line in response:
+                if not getattr(line, "choices", None):
+                    continue
+
+                choice = line.choices[0]
+                delta = getattr(choice, "delta", None)
+
+                reasoning_text = self._extract_reasoning_text(delta)
+                if reasoning_text:
+                    yield {"type": "thought", "thought": reasoning_text}
+
+                content = getattr(delta, "content", None)
+                if isinstance(content, str) and content:
+                    yield content
+                    continue
+
+                has_tool_calls = bool(getattr(delta, "tool_calls", None))
+                finish_reason = getattr(choice, "finish_reason", None)
+
+                if has_tool_calls or finish_reason == "tool_calls":
+                    yield choice
+        finally:
+            if hasattr(response, "close"):
+                response.close()
+
+    def _supports_tools(self) -> bool:
+        """LiteLLM supports function calling for providers that support it."""
+        return True
+
+    def _supports_structured_output(self) -> bool:
+        """LiteLLM supports structured output for providers that support it."""
+        return True
+
+    def prepare_structured_output_format(
+        self, json_schema: dict | None
+    ) -> dict | None:
+        """Prepare structured output format using OpenAI's json_schema spec.
+
+        LiteLLM translates OpenAI-format ``response_format`` to each
+        provider's native format via ``drop_params=True``.
+
+        Args:
+            json_schema: JSON schema dict for the expected response.
+
+        Returns:
+            OpenAI-format ``response_format`` dict, or ``None``.
+        """
+        if not json_schema:
+            return None
+        try:
+            return {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": json_schema.get("name", "response"),
+                    "description": json_schema.get(
+                        "description", "Structured response"
+                    ),
+                    "schema": json_schema,
+                    "strict": True,
+                },
+            }
+        except Exception as e:
+            logger.error("Error preparing structured output format: %s", e)
+            return None

--- a/application/llm/llm_creator.py
+++ b/application/llm/llm_creator.py
@@ -1,11 +1,36 @@
 import logging
 
-from application.llm.providers import PROVIDERS_BY_NAME
+from application.llm.anthropic import AnthropicLLM
+from application.llm.docsgpt_provider import DocsGPTAPILLM
+from application.llm.google_ai import GoogleLLM
+from application.llm.groq import GroqLLM
+from application.llm.litellm import LiteLLM
+from application.llm.llama_cpp import LlamaCpp
+from application.llm.novita import NovitaLLM
+from application.llm.openai import AzureOpenAILLM, OpenAILLM
+from application.llm.premai import PremAILLM
+from application.llm.sagemaker import SagemakerAPILLM
+from application.llm.open_router import OpenRouterLLM
 
 logger = logging.getLogger(__name__)
 
 
 class LLMCreator:
+    llms = {
+        "openai": OpenAILLM,
+        "azure_openai": AzureOpenAILLM,
+        "sagemaker": SagemakerAPILLM,
+        "llama.cpp": LlamaCpp,
+        "anthropic": AnthropicLLM,
+        "docsgpt": DocsGPTAPILLM,
+        "premai": PremAILLM,
+        "groq": GroqLLM,
+        "google": GoogleLLM,
+        "novita": NovitaLLM,
+        "openrouter": OpenRouterLLM,
+        "litellm": LiteLLM,
+    }
+
     @classmethod
     def create_llm(
         cls,
@@ -16,111 +41,28 @@ class LLMCreator:
         model_id=None,
         agent_id=None,
         backup_models=None,
-        model_user_id=None,
         *args,
         **kwargs,
     ):
-        """Construct an LLM for the given provider ``type``.
+        from application.core.model_utils import get_base_url_for_model
 
-        ``model_user_id`` is the BYOM-resolution scope. Defaults to
-        ``decoded_token['sub']`` (the caller). Pass it explicitly when
-        the model record belongs to a *different* user — most notably
-        for shared-agent dispatch, where the agent's stored
-        ``default_model_id`` is the owner's BYOM UUID but
-        ``decoded_token`` represents the caller.
-        """
-        from application.core.model_registry import ModelRegistry
-        from application.security.safe_url import (
-            UnsafeUserUrlError,
-            pinned_httpx_client,
-            validate_user_base_url,
-        )
-
-        plugin = PROVIDERS_BY_NAME.get(type.lower())
-        if plugin is None or plugin.llm_class is None:
+        llm_class = cls.llms.get(type.lower())
+        if not llm_class:
             raise ValueError(f"No LLM class found for type {type}")
 
-        # Prefer per-model endpoint config from the registry. This is what
-        # makes openai_compatible AND end-user BYOM work without changing
-        # every call site: if the registered AvailableModel carries its
-        # own api_key / base_url, they win over whatever the caller
-        # resolved via the provider plugin.
-        #
-        # End-user BYOM lookups need the user_id from decoded_token to
-        # find the user's per-user models layer (built-in models resolve
-        # without it, so this stays back-compat).
+        # Extract base_url from model configuration if model_id is provided
         base_url = None
-        upstream_model_id = model_id
-        capabilities = None
         if model_id:
-            user_id = model_user_id
-            if user_id is None:
-                user_id = (
-                    (decoded_token or {}).get("sub") if decoded_token else None
-                )
-            model = ModelRegistry.get_instance().get_model(model_id, user_id=user_id)
-            if model is not None:
-                # Forward registry caps so the LLM enforces them at
-                # dispatch (built-in classes hard-code True otherwise).
-                capabilities = getattr(model, "capabilities", None)
-                # SECURITY: refuse user-source dispatch without its own
-                # api_key (would leak settings.API_KEY to base_url).
-                if (
-                    getattr(model, "source", "builtin") == "user"
-                    and not model.api_key
-                ):
-                    raise ValueError(
-                        f"Custom model {model_id!r} has no usable API key "
-                        "(decryption may have failed). Re-save the model "
-                        "in settings to dispatch it."
-                    )
-                if model.api_key:
-                    api_key = model.api_key
-                if model.base_url:
-                    base_url = model.base_url
-                # For BYOM the registry id is a UUID; the upstream API
-                # call needs the user's typed model name instead.
-                if model.upstream_model_id:
-                    upstream_model_id = model.upstream_model_id
+            base_url = get_base_url_for_model(model_id)
 
-                # SECURITY: re-validate at dispatch (defense in depth
-                # for pre-guard rows / YAML-supplied entries). The
-                # pinned httpx.Client below is what actually closes the
-                # DNS-rebinding TOCTOU window.
-                if base_url and getattr(model, "source", "builtin") == "user":
-                    try:
-                        validate_user_base_url(base_url)
-                    except UnsafeUserUrlError as e:
-                        raise ValueError(
-                            f"Refusing to dispatch model {model_id!r}: {e}"
-                        ) from e
-                    # Pinned httpx.Client: resolves once, validates, and
-                    # binds the SDK's outbound socket to the validated IP
-                    # (preserves Host / SNI). Future BYOM providers must
-                    # opt in explicitly — only openai_compatible takes
-                    # http_client today.
-                    if plugin.name == "openai_compatible":
-                        try:
-                            kwargs["http_client"] = pinned_httpx_client(
-                                base_url
-                            )
-                        except UnsafeUserUrlError as e:
-                            raise ValueError(
-                                f"Refusing to dispatch model {model_id!r}: {e}"
-                            ) from e
-
-        # Forward model_user_id so backup/fallback resolves under the
-        # owner's scope on shared-agent dispatch.
-        return plugin.llm_class(
+        return llm_class(
             api_key,
             user_api_key,
             decoded_token=decoded_token,
-            model_id=upstream_model_id,
+            model_id=model_id,
             agent_id=agent_id,
             base_url=base_url,
             backup_models=backup_models,
-            model_user_id=model_user_id,
-            capabilities=capabilities,
             *args,
             **kwargs,
         )

--- a/application/llm/providers/__init__.py
+++ b/application/llm/providers/__init__.py
@@ -17,6 +17,7 @@ from application.llm.providers.docsgpt import DocsGPTProvider
 from application.llm.providers.google import GoogleProvider
 from application.llm.providers.groq import GroqProvider
 from application.llm.providers.huggingface import HuggingFaceProvider
+from application.llm.providers.litellm import LiteLLMProvider
 from application.llm.providers.llama_cpp import LlamaCppProvider
 from application.llm.providers.novita import NovitaProvider
 from application.llm.providers.openai import OpenAIProvider
@@ -41,6 +42,7 @@ ALL_PROVIDERS: List[Provider] = [
     OpenRouterProvider(),
     NovitaProvider(),
     HuggingFaceProvider(),
+    LiteLLMProvider(),
     LlamaCppProvider(),
     PremAIProvider(),
     SagemakerProvider(),

--- a/application/llm/providers/litellm.py
+++ b/application/llm/providers/litellm.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from application.llm.litellm import LiteLLM
+from application.llm.providers._apikey_or_llm_name import (
+    filter_models_by_llm_name,
+    get_api_key,
+)
+from application.llm.providers.base import Provider
+
+
+class LiteLLMProvider(Provider):
+    name = "litellm"
+    llm_class = LiteLLM
+
+    def get_api_key(self, settings) -> Optional[str]:
+        return get_api_key(settings, self.name, settings.LITELLM_API_KEY)
+
+    def filter_yaml_models(self, settings, models):
+        return filter_models_by_llm_name(
+            settings, self.name, settings.LITELLM_API_KEY, models
+        )

--- a/application/requirements.txt
+++ b/application/requirements.txt
@@ -34,6 +34,7 @@ joblib==1.5.3
 jsonpatch==1.33
 jsonpointer==3.1.1
 kombu==5.6.2
+litellm>=1.60.0,<2.0.0
 langchain==1.2.3
 langchain-community==0.4.1
 langchain-core==1.2.29

--- a/tests/llm/test_litellm.py
+++ b/tests/llm/test_litellm.py
@@ -85,8 +85,7 @@ class _Response:
 def llm():
     """Return a LiteLLM instance with settings stubbed."""
     with mock.patch("application.llm.litellm.settings") as mock_settings:
-        mock_settings.LITELLM_API_KEY = "test-key"
-        mock_settings.API_KEY = None
+        mock_settings.API_KEY = "test-key"
         return LiteLLM(api_key="test-key")
 
 

--- a/tests/llm/test_litellm.py
+++ b/tests/llm/test_litellm.py
@@ -1,0 +1,301 @@
+"""Tests for the LiteLLM provider."""
+
+import types as builtin_types
+from unittest import mock
+
+import pytest
+
+from application.llm.litellm import LiteLLM
+
+
+# ---------------------------------------------------------------------------
+# Fake response helpers (mirrors test_openai_llm.py style)
+# ---------------------------------------------------------------------------
+
+
+class _Msg:
+    def __init__(self, content=None, tool_calls=None):
+        self.content = content
+        self.tool_calls = tool_calls
+
+
+class _Delta:
+    def __init__(self, content=None, reasoning_content=None, tool_calls=None):
+        self.content = content
+        self.reasoning_content = reasoning_content
+        self.tool_calls = tool_calls
+
+
+class _Choice:
+    def __init__(
+        self,
+        content=None,
+        delta=None,
+        reasoning_content=None,
+        tool_calls=None,
+        finish_reason="stop",
+    ):
+        self.message = _Msg(content=content)
+        self.delta = _Delta(
+            content=delta,
+            reasoning_content=reasoning_content,
+            tool_calls=tool_calls,
+        )
+        self.finish_reason = finish_reason
+
+
+class _StreamLine:
+    def __init__(self, deltas):
+        choices = []
+        for d in deltas:
+            if isinstance(d, dict):
+                choices.append(
+                    _Choice(
+                        delta=d.get("content"),
+                        reasoning_content=d.get("reasoning_content"),
+                        tool_calls=d.get("tool_calls"),
+                        finish_reason=d.get("finish_reason", "stop"),
+                    )
+                )
+            else:
+                choices.append(_Choice(delta=d))
+        self.choices = choices
+
+
+class _Response:
+    def __init__(self, choices=None, lines=None):
+        self._choices = choices or []
+        self._lines = lines or []
+
+    @property
+    def choices(self):
+        return self._choices
+
+    def __iter__(self):
+        for line in self._lines:
+            yield line
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def llm():
+    """Return a LiteLLM instance with settings stubbed."""
+    with mock.patch("application.llm.litellm.settings") as mock_settings:
+        mock_settings.LITELLM_API_KEY = "test-key"
+        mock_settings.API_KEY = None
+        return LiteLLM(api_key="test-key")
+
+
+# ---------------------------------------------------------------------------
+# _raw_gen tests
+# ---------------------------------------------------------------------------
+
+
+class TestRawGen:
+    def test_basic_completion(self, llm):
+        """Non-streaming call returns content string."""
+        fake_response = _Response(
+            choices=[_Choice(content="hello from litellm")]
+        )
+        import sys
+
+        fake_mod = builtin_types.ModuleType("litellm")
+        fake_mod.completion = mock.MagicMock(return_value=fake_response)
+        sys.modules["litellm"] = fake_mod
+
+        try:
+            result = llm._raw_gen(
+                llm,
+                model="anthropic/claude-3-haiku",
+                messages=[{"role": "user", "content": "hi"}],
+                stream=False,
+            )
+            assert result == "hello from litellm"
+
+            call_kwargs = fake_mod.completion.call_args[1]
+            assert call_kwargs["model"] == "anthropic/claude-3-haiku"
+            assert call_kwargs["drop_params"] is True
+            assert call_kwargs["api_key"] == "test-key"
+            assert call_kwargs["stream"] is False
+        finally:
+            del sys.modules["litellm"]
+
+    def test_tool_call_returns_choice(self, llm):
+        """When tools are provided, returns the Choice object."""
+        fake_choice = _Choice(content=None, tool_calls=[{"id": "tc1"}])
+        fake_response = _Response(choices=[fake_choice])
+
+        import sys
+
+        fake_mod = builtin_types.ModuleType("litellm")
+        fake_mod.completion = mock.MagicMock(return_value=fake_response)
+        sys.modules["litellm"] = fake_mod
+
+        try:
+            result = llm._raw_gen(
+                llm,
+                model="openai/gpt-4o",
+                messages=[{"role": "user", "content": "use tool"}],
+                stream=False,
+                tools=[{"type": "function", "function": {"name": "test"}}],
+            )
+            assert result is fake_choice
+        finally:
+            del sys.modules["litellm"]
+
+
+# ---------------------------------------------------------------------------
+# _raw_gen_stream tests
+# ---------------------------------------------------------------------------
+
+
+class TestRawGenStream:
+    def test_stream_yields_content(self, llm):
+        """Streaming yields content strings."""
+        fake_response = _Response(
+            lines=[
+                _StreamLine(["part1"]),
+                _StreamLine(["part2"]),
+            ]
+        )
+
+        import sys
+
+        fake_mod = builtin_types.ModuleType("litellm")
+        fake_mod.completion = mock.MagicMock(return_value=fake_response)
+        sys.modules["litellm"] = fake_mod
+
+        try:
+            chunks = list(
+                llm._raw_gen_stream(
+                    llm,
+                    model="anthropic/claude-3-haiku",
+                    messages=[{"role": "user", "content": "hi"}],
+                    stream=True,
+                )
+            )
+            assert chunks == ["part1", "part2"]
+        finally:
+            del sys.modules["litellm"]
+
+    def test_stream_yields_reasoning(self, llm):
+        """Streaming yields reasoning tokens as dicts."""
+        fake_response = _Response(
+            lines=[
+                _StreamLine(
+                    [{"reasoning_content": "thinking...", "content": None}]
+                ),
+                _StreamLine(["answer"]),
+            ]
+        )
+
+        import sys
+
+        fake_mod = builtin_types.ModuleType("litellm")
+        fake_mod.completion = mock.MagicMock(return_value=fake_response)
+        sys.modules["litellm"] = fake_mod
+
+        try:
+            chunks = list(
+                llm._raw_gen_stream(
+                    llm,
+                    model="openai/o3-mini",
+                    messages=[{"role": "user", "content": "think"}],
+                    stream=True,
+                )
+            )
+            assert chunks[0] == {"type": "thought", "thought": "thinking..."}
+            assert chunks[1] == "answer"
+        finally:
+            del sys.modules["litellm"]
+
+
+# ---------------------------------------------------------------------------
+# drop_params tests
+# ---------------------------------------------------------------------------
+
+
+class TestDropParams:
+    def test_drop_params_default_true(self, llm):
+        """drop_params=True is always passed by default."""
+        fake_response = _Response(
+            choices=[_Choice(content="ok")]
+        )
+
+        import sys
+
+        fake_mod = builtin_types.ModuleType("litellm")
+        fake_mod.completion = mock.MagicMock(return_value=fake_response)
+        sys.modules["litellm"] = fake_mod
+
+        try:
+            llm._raw_gen(
+                llm,
+                model="openai/gpt-4o",
+                messages=[{"role": "user", "content": "test"}],
+            )
+            call_kwargs = fake_mod.completion.call_args[1]
+            assert call_kwargs["drop_params"] is True
+        finally:
+            del sys.modules["litellm"]
+
+
+# ---------------------------------------------------------------------------
+# Message cleaning tests
+# ---------------------------------------------------------------------------
+
+
+class TestCleanMessages:
+    def test_model_role_becomes_assistant(self, llm):
+        """'model' role is normalized to 'assistant'."""
+        result = llm._clean_messages(
+            [{"role": "model", "content": "hi"}]
+        )
+        assert result[0]["role"] == "assistant"
+
+    def test_tool_message_passthrough(self, llm):
+        """Tool messages with tool_call_id are passed through."""
+        result = llm._clean_messages(
+            [
+                {
+                    "role": "tool",
+                    "tool_call_id": "tc1",
+                    "content": '{"result": "ok"}',
+                }
+            ]
+        )
+        assert result[0]["role"] == "tool"
+        assert result[0]["tool_call_id"] == "tc1"
+
+    def test_base_url_forwarded(self):
+        """base_url is forwarded as api_base to litellm."""
+        with mock.patch("application.llm.litellm.settings") as mock_settings:
+            mock_settings.LITELLM_API_KEY = None
+            mock_settings.API_KEY = None
+            inst = LiteLLM(
+                api_key="key",
+                base_url="http://localhost:4000",
+            )
+            params = inst._build_completion_params(
+                model="openai/gpt-4o",
+                messages=[{"role": "user", "content": "hi"}],
+                stream=False,
+            )
+            assert params["api_base"] == "http://localhost:4000"
+
+
+# ---------------------------------------------------------------------------
+# supports_* tests
+# ---------------------------------------------------------------------------
+
+
+class TestSupports:
+    def test_supports_tools(self, llm):
+        assert llm._supports_tools() is True
+
+    def test_supports_structured_output(self, llm):
+        assert llm._supports_structured_output() is True


### PR DESCRIPTION
  - **What kind of change does this PR introduce?** Feature adds LiteLLM as a new LLM provider                                                                                                                     
                                                                                                                                                                                                                     
  - **Why was this change needed?** DocsGPT supports individual LLM providers (OpenAI, Anthropic, Google, Groq, etc.) each with separate integration code. LiteLLM provides a unified interface to 100+ LLM providers
   through a single `completion()` call. Users switch providers by changing a model string. This was requested across PRs #305, #310, #394, #572.
                  
  - **Other information**: See sections below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  ---                                                                                                                                                                                                                
                  
  ## What Changed                                                                                                                                                                                                    
   
  | File | Change |                                                                                                                                                                                                  
  |---|---|       
  | `application/llm/litellm.py` | New `LiteLLM` provider extending `BaseLLM` non-streaming, streaming, tool calling, structured output, reasoning tokens |
  | `application/llm/llm_creator.py` | Registered `"litellm": LiteLLM` in `LLMCreator.llms` |                                                                                                                        
  | `application/core/model_settings.py` | Added `ModelProvider.LITELLM` enum + `_add_litellm_models()` for dynamic model registration from `LLM_NAME` |                                                             
  | `application/core/model_utils.py` | Added `"litellm"` to `provider_key_map` |                                                                                                                                    
  | `application/requirements.txt` | Added `litellm>=1.60.0,<2.0.0` |                                                                                                                                                
  | `tests/llm/test_litellm.py` | 10 unit tests |                                                                                                                                                                    
                  
  ---                                                                                                                                                                                                                
                  
  ## Usage                                                                                                                                                                                                           
   
  ### Quick Start                                                                                                                                                                                                    
                  
  ```bash
  # 1. Set LiteLLM as the provider
  export LLM_PROVIDER=litellm

  # 2. Set the model using any LiteLLM-supported model string
  export LLM_NAME=anthropic/claude-3-haiku
                                                                                                                                                                                                                     
  # 3. Set the provider's API key (LiteLLM reads standard env vars automatically)
  export ANTHROPIC_API_KEY=sk-ant-...                                                                                                                                                                                
                  
  Switching Providers

  # OpenAI
  export LLM_NAME=openai/gpt-4o                                                                                                                                                                                      
  export OPENAI_API_KEY=sk-...
                                                                                                                                                                                                                     
  # Azure OpenAI  
  export LLM_NAME=azure/gpt-4o
  export AZURE_API_KEY=...
  export AZURE_API_BASE=https://your-resource.openai.azure.com
                                                                                                                                                                                                                     
  # AWS Bedrock
  export LLM_NAME=bedrock/anthropic.claude-v2                                                                                                                                                                        
  export AWS_ACCESS_KEY_ID=...
  export AWS_SECRET_ACCESS_KEY=...
  export AWS_REGION_NAME=us-east-1
                                                                                                                                                                                                                     
  # Google Vertex AI
  export LLM_NAME=vertex_ai/gemini-pro                                                                                                                                                                               
  export VERTEXAI_PROJECT=your-project
  export VERTEXAI_LOCATION=us-central1

  # Groq                                                                                                                                                                                                             
  export LLM_NAME=groq/llama3-70b-8192
  export GROQ_API_KEY=gsk_...                                                                                                                                                                                        
                  
  # Local Ollama
  export LLM_NAME=ollama/llama3

  Any of the https://docs.litellm.ai/docs/providers works as LLM_NAME.                                                                                                                                               
   
  Python Usage (Programmatic)                                                                                                                                                                                        
                  
  from application.llm.llm_creator import LLMCreator

  llm = LLMCreator.create_llm(                                                                                                                                                                                       
      type="litellm",
      api_key=None,  # reads from env vars automatically                                                                                                                                                             
      user_api_key=None,
      decoded_token=None,
  )

  # Non-streaming
  response = llm.gen(
      model="anthropic/claude-3-haiku",                                                                                                                                                                              
      messages=[{"role": "user", "content": "What is DocsGPT?"}],
  )                                                                                                                                                                                                                  
  print(response) 

  # Streaming
  for chunk in llm.gen_stream(
      model="anthropic/claude-3-haiku",                                                                                                                                                                              
      messages=[{"role": "user", "content": "Explain RAG in 3 sentences."}],
  ):                                                                                                                                                                                                                 
      print(chunk, end="", flush=True)
```
  ---                                                                                                                                                                                                                
  Testing
                                                                                                                                                                                                                     
  Unit Tests (10/10 Passing)
```
  tests/llm/test_litellm.py::TestRawGen::test_basic_completion PASSED
  tests/llm/test_litellm.py::TestRawGen::test_tool_call_returns_choice PASSED
  tests/llm/test_litellm.py::TestRawGenStream::test_stream_yields_content PASSED                                                                                                                                     
  tests/llm/test_litellm.py::TestRawGenStream::test_stream_yields_reasoning PASSED
  tests/llm/test_litellm.py::TestDropParams::test_drop_params_default_true PASSED                                                                                                                                    
  tests/llm/test_litellm.py::TestCleanMessages::test_model_role_becomes_assistant PASSED
  tests/llm/test_litellm.py::TestCleanMessages::test_tool_message_passthrough PASSED                                                                                                                                 
  tests/llm/test_litellm.py::TestCleanMessages::test_base_url_forwarded PASSED
  tests/llm/test_litellm.py::TestSupports::test_supports_tools PASSED                                                                                                                                                
  tests/llm/test_litellm.py::TestSupports::test_supports_structured_output PASSED
  ======================== 10 passed in 0.16s ========================
```
  # Live Tests (Azure AI Foundry → Claude Sonnet via LiteLLM)

  Model: azure_ai/claude-sonnet-4-6

  Non-streaming _raw_gen      → "4"                                                                                                                                                                                  
  Streaming _raw_gen_stream   → "1, 2, 3, 4, 5"
  Full pipeline gen()         → "OK"                                                                                                                                                                                 
  Full pipeline gen_stream()  → "Hello! 👋 How are you doing"                                                                                                                                                                 
   
  ---                                                                                                                                                                                                                
  Risk / Compatibility
                      
  - Additive only, no existing provider code touched
  - drop_params=True set by default so provider-unsupported kwargs are silently dropped                                                                                                                              
  - LiteLLM lazily imported inside function bodies.
