### PR TITLE
fix: update message and rename conversation triggers

### DIFF
--- a/frontend/src/agents/workflow/WorkflowBuilder.tsx
+++ b/frontend/src/agents/workflow/WorkflowBuilder.tsx
@@ -813,7 +813,11 @@ function WorkflowBuilderInner() {
         const response = await userService.getWorkflow(workflowId, token);
         if (!response.ok) throw new Error('Failed to fetch workflow');
         const responseData = await response.json();
-        const { workflow, nodes: apiNodes, edges: apiEdges } = responseData.data;
+        const {
+          workflow,
+          nodes: apiNodes,
+          edges: apiEdges,
+        } = responseData.data;
         const nextWorkflowName = workflow.name;
         const nextWorkflowDescription = workflow.description || '';
         const mappedNodes = apiNodes.map((n: WorkflowNode) => {
@@ -1472,7 +1476,9 @@ function WorkflowBuilderInner() {
                           {t('agents.form.advanced.systemPromptOverride')}
                         </label>
                         <p className="mt-0.5 text-[11px] text-gray-500 dark:text-gray-400">
-                          {t('agents.form.advanced.systemPromptOverrideDescription')}
+                          {t(
+                            'agents.form.advanced.systemPromptOverrideDescription',
+                          )}
                         </p>
                       </div>
                       <button

--- a/frontend/src/conversation/Conversation.tsx
+++ b/frontend/src/conversation/Conversation.tsx
@@ -236,7 +236,7 @@ export default function Conversation() {
           isSplitArtifactOpen ? 'w-[60%] px-6' : 'w-full'
         }`}
       >
-        <div className="relative min-h-0 flex-1 ">
+        <div className="relative min-h-0 flex-1">
           <ConversationMessages
             handleQuestion={handleQuestion}
             handleQuestionSubmission={handleQuestionSubmission}

--- a/frontend/src/conversation/ConversationBubble.tsx
+++ b/frontend/src/conversation/ConversationBubble.tsx
@@ -132,7 +132,7 @@ const ConversationBubble = forwardRef<
   }, [message]);
 
   const handleEditClick = () => {
-    if (!editInputBox.trim() || editInputBox.trim() === message.trim()) return;
+    if (!editInputBox.trim() || editInputBox.trim() === (message ?? '').trim()) return;
     setIsEditClicked(false);
     handleUpdatedQuestionSubmission?.(editInputBox, true, questionNumber);
   };
@@ -245,7 +245,7 @@ const ConversationBubble = forwardRef<
                 <button
                   className="bg-primary not-disabled:hover:bg-primary/90 not-disabled:dark:hover:bg-primary/90 rounded-full px-4 py-2 text-sm font-medium text-white transition-colors disabled:bg-primary/30 disabled:cursor-not-allowed"
                   onClick={handleEditClick}
-                  disabled={!editInputBox.trim() || editInputBox.trim() === message.trim()}
+                  disabled={!editInputBox.trim() || editInputBox.trim() === (message  ?? '').trim()}
                 >
                   {t('conversation.edit.update')}
                 </button>

--- a/frontend/src/conversation/ConversationBubble.tsx
+++ b/frontend/src/conversation/ConversationBubble.tsx
@@ -132,7 +132,8 @@ const ConversationBubble = forwardRef<
   }, [message]);
 
   const handleEditClick = () => {
-    if (!editInputBox.trim() || editInputBox.trim() === (message ?? '').trim()) return;
+    if (!editInputBox.trim() || editInputBox.trim() === (message ?? '').trim())
+      return;
     setIsEditClicked(false);
     handleUpdatedQuestionSubmission?.(editInputBox, true, questionNumber);
   };
@@ -243,9 +244,12 @@ const ConversationBubble = forwardRef<
                   {t('conversation.edit.cancel')}
                 </button>
                 <button
-                  className="bg-primary not-disabled:hover:bg-primary/90 not-disabled:dark:hover:bg-primary/90 rounded-full px-4 py-2 text-sm font-medium text-white transition-colors disabled:bg-primary/30 disabled:cursor-not-allowed"
+                  className="bg-primary not-disabled:hover:bg-primary/90 not-disabled:dark:hover:bg-primary/90 disabled:bg-primary/30 rounded-full px-4 py-2 text-sm font-medium text-white transition-colors disabled:cursor-not-allowed"
                   onClick={handleEditClick}
-                  disabled={!editInputBox.trim() || editInputBox.trim() === (message  ?? '').trim()}
+                  disabled={
+                    !editInputBox.trim() ||
+                    editInputBox.trim() === (message ?? '').trim()
+                  }
                 >
                   {t('conversation.edit.update')}
                 </button>

--- a/frontend/src/conversation/ConversationBubble.tsx
+++ b/frontend/src/conversation/ConversationBubble.tsx
@@ -132,7 +132,7 @@ const ConversationBubble = forwardRef<
   }, [message]);
 
   const handleEditClick = () => {
-    if (!editInputBox.trim() || editInputBox.trim() === message) return;
+    if (!editInputBox.trim() || editInputBox.trim() === message.trim()) return;
     setIsEditClicked(false);
     handleUpdatedQuestionSubmission?.(editInputBox, true, questionNumber);
   };
@@ -245,7 +245,7 @@ const ConversationBubble = forwardRef<
                 <button
                   className="bg-primary not-disabled:hover:bg-primary/90 not-disabled:dark:hover:bg-primary/90 rounded-full px-4 py-2 text-sm font-medium text-white transition-colors disabled:bg-primary/30 disabled:cursor-not-allowed"
                   onClick={handleEditClick}
-                  disabled={!editInputBox.trim() || editInputBox.trim() === message}
+                  disabled={!editInputBox.trim() || editInputBox.trim() === message.trim()}
                 >
                   {t('conversation.edit.update')}
                 </button>

--- a/frontend/src/conversation/ConversationBubble.tsx
+++ b/frontend/src/conversation/ConversationBubble.tsx
@@ -132,6 +132,7 @@ const ConversationBubble = forwardRef<
   }, [message]);
 
   const handleEditClick = () => {
+    if (!editInputBox.trim() || editInputBox.trim() === message) return;
     setIsEditClicked(false);
     handleUpdatedQuestionSubmission?.(editInputBox, true, questionNumber);
   };
@@ -242,8 +243,9 @@ const ConversationBubble = forwardRef<
                   {t('conversation.edit.cancel')}
                 </button>
                 <button
-                  className="bg-primary hover:bg-primary/90 dark:hover:bg-primary/90 rounded-full px-4 py-2 text-sm font-medium text-white transition-colors"
+                  className="bg-primary not-disabled:hover:bg-primary/90 not-disabled:dark:hover:bg-primary/90 rounded-full px-4 py-2 text-sm font-medium text-white transition-colors disabled:bg-primary/30 disabled:cursor-not-allowed"
                   onClick={handleEditClick}
+                  disabled={!editInputBox.trim() || editInputBox.trim() === message}
                 >
                   {t('conversation.edit.update')}
                 </button>

--- a/frontend/src/conversation/ConversationTile.tsx
+++ b/frontend/src/conversation/ConversationTile.tsx
@@ -64,7 +64,10 @@ export default function ConversationTile({
   }
 
   function handleSaveConversation(changedConversation: ConversationProps) {
-    if (changedConversation.name.trim().length && changedConversation.name.trim() !== conversation.name.trim()) {
+    if (
+      changedConversation.name.trim().length &&
+      changedConversation.name.trim() !== conversation.name.trim()
+    ) {
       onSave(changedConversation);
       setIsEdit(false);
     } else {

--- a/frontend/src/conversation/ConversationTile.tsx
+++ b/frontend/src/conversation/ConversationTile.tsx
@@ -64,7 +64,7 @@ export default function ConversationTile({
   }
 
   function handleSaveConversation(changedConversation: ConversationProps) {
-    if (changedConversation.name.trim().length) {
+    if (changedConversation.name.trim().length && changedConversation.name.trim() !== conversation.name) {
       onSave(changedConversation);
       setIsEdit(false);
     } else {

--- a/frontend/src/conversation/ConversationTile.tsx
+++ b/frontend/src/conversation/ConversationTile.tsx
@@ -64,7 +64,7 @@ export default function ConversationTile({
   }
 
   function handleSaveConversation(changedConversation: ConversationProps) {
-    if (changedConversation.name.trim().length && changedConversation.name.trim() !== conversation.name) {
+    if (changedConversation.name.trim().length && changedConversation.name.trim() !== conversation.name.trim()) {
       onSave(changedConversation);
       setIsEdit(false);
     } else {


### PR DESCRIPTION

This PR fixes: #2369 
- Prevents submitting an message if the input is empty or unchanged from the original message 
- Disables the "Update" button and updates its styles when the edit input is empty or unchanged
- Prevents saving a conversation if the name is empty or unchanged 

## Tested the changes, Videos:
https://github.com/user-attachments/assets/2667f5b9-722f-4c0e-be8d-f6bec1f47356

https://github.com/user-attachments/assets/86f02c62-c225-4259-a0dc-65f3743975b1

