### PR TITLE
fix(security): require authentication on /api/delete_by_ids (CWE-862)

### DIFF
--- a/application/api/user/sources/routes.py
+++ b/application/api/user/sources/routes.py
@@ -161,6 +161,9 @@ class DeleteByIds(Resource):
         params={"path": "Comma-separated list of IDs"},
     )
     def get(self):
+        decoded_token = request.decoded_token
+        if not decoded_token:
+            return make_response(jsonify({"success": False}), 401)
         ids = request.args.get("path")
         if not ids:
             return make_response(

--- a/tests/api/user/sources/test_source_routes.py
+++ b/tests/api/user/sources/test_source_routes.py
@@ -368,10 +368,22 @@ class TestPaginatedSources:
 @pytest.mark.unit
 class TestDeleteByIds:
 
+    def test_returns_401_unauthenticated(self, app):
+        from application.api.user.sources.routes import DeleteByIds
+
+        with app.test_request_context("/api/delete_by_ids"):
+            from flask import request
+            request.decoded_token = None
+            response = DeleteByIds().get()
+
+        assert _status(response) == 401
+
     def test_returns_400_when_path_missing(self, app):
         from application.api.user.sources.routes import DeleteByIds
 
         with app.test_request_context("/api/delete_by_ids"):
+            from flask import request
+            request.decoded_token = {"sub": "u1"}
             response = DeleteByIds().get()
 
         assert _status(response) == 400
@@ -388,6 +400,8 @@ class TestDeleteByIds:
             mock_collection,
         ):
             with app.test_request_context("/api/delete_by_ids?path=id1,id2"):
+                from flask import request
+                request.decoded_token = {"sub": "u1"}
                 response = DeleteByIds().get()
 
         assert _status(response) == 200
@@ -405,6 +419,8 @@ class TestDeleteByIds:
             mock_collection,
         ):
             with app.test_request_context("/api/delete_by_ids?path=id1"):
+                from flask import request
+                request.decoded_token = {"sub": "u1"}
                 response = DeleteByIds().get()
 
         assert _status(response) == 400
@@ -420,6 +436,8 @@ class TestDeleteByIds:
             mock_collection,
         ):
             with app.test_request_context("/api/delete_by_ids?path=id1"):
+                from flask import request
+                request.decoded_token = {"sub": "u1"}
                 response = DeleteByIds().get()
 
         assert _status(response) == 400

--- a/tests/test_cwe862_delete_by_ids_auth.py
+++ b/tests/test_cwe862_delete_by_ids_auth.py
@@ -1,0 +1,88 @@
+"""
+PoC / regression test for CWE-862: Missing authentication on /api/delete_by_ids.
+
+The DeleteByIds endpoint at /api/delete_by_ids does not check request.decoded_token,
+allowing any unauthenticated user to delete vector-store indexes belonging to any user.
+
+This test verifies that:
+1. An unauthenticated request (no token) to /api/delete_by_ids returns 401.
+2. An authenticated request is allowed to proceed (returns 200 or 400 depending
+   on whether the IDs exist — but NOT 401).
+"""
+
+import os
+import sys
+
+import pytest
+
+# Ensure the application root is importable
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+
+@pytest.fixture()
+def app(monkeypatch):
+    """Create a minimal Flask app with the sources blueprint registered."""
+    # Patch settings BEFORE importing app machinery
+    from application.core.settings import settings
+
+    monkeypatch.setattr(settings, "AUTH_TYPE", "simple_jwt")
+    monkeypatch.setattr(settings, "JWT_SECRET_KEY", "test-secret-key")
+
+    # Use mongomock so we don't need a real MongoDB
+    import mongomock
+
+    mock_client = mongomock.MongoClient()
+    mock_db = mock_client[settings.MONGO_DB_NAME]
+
+    monkeypatch.setattr(
+        "application.api.user.base.sources_collection", mock_db["sources"]
+    )
+
+    from application.app import app as flask_app
+
+    flask_app.config["TESTING"] = True
+    yield flask_app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture()
+def auth_header(app):
+    """Return a valid Authorization header."""
+    from jose import jwt
+    from application.core.settings import settings
+
+    token = jwt.encode({"sub": "test-user"}, settings.JWT_SECRET_KEY, algorithm="HS256")
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestDeleteByIdsAuth:
+    """Verify that /api/delete_by_ids requires authentication."""
+
+    def test_unauthenticated_request_returns_401(self, client):
+        """An unauthenticated request MUST be rejected with 401."""
+        resp = client.get("/api/delete_by_ids?path=some-id-1,some-id-2")
+        assert resp.status_code == 401, (
+            f"Expected 401 for unauthenticated /api/delete_by_ids, got {resp.status_code}. "
+            "Endpoint is missing authentication check (CWE-862)."
+        )
+
+    def test_authenticated_request_is_allowed(self, client, auth_header):
+        """An authenticated request should NOT get 401 (may get 400 if IDs don't exist)."""
+        resp = client.get(
+            "/api/delete_by_ids?path=nonexistent-id", headers=auth_header
+        )
+        # 200 or 400 are acceptable — the point is it should NOT be 401
+        assert resp.status_code != 401, (
+            f"Authenticated request got 401; auth check may be broken."
+        )
+
+    def test_missing_path_param_returns_400(self, client, auth_header):
+        """Missing 'path' parameter should return 400, not allow operation."""
+        resp = client.get("/api/delete_by_ids", headers=auth_header)
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary

The `/api/delete_by_ids` endpoint (`DeleteByIds.get` in `application/api/user/sources/routes.py`) does not check the request's authentication token before deleting vector-store indexes. On a multi-user deployment (`AUTH_TYPE=simple_jwt` or `session_jwt`), any unauthenticated network caller who knows or guesses a source/index ID can delete it.

- **CWE:** CWE-862 (Missing Authorization)
- **File / function:** `application/api/user/sources/routes.py` → `DeleteByIds.get`
- **Route:** `GET /api/delete_by_ids?path=<id1>,<id2>,...`
- **Severity:** High on multi-user deployments; no impact on `AUTH_TYPE=None` single-user installs.

## Data flow

1. Request hits `DeleteByIds.get`.
2. `ids = request.args.get("path")` is parsed and split.
3. `sources_collection.delete_index(ids=ids)` is invoked, which proxies to the configured vector store backend (faiss / qdrant / milvus / pgvector / mongodb / elasticsearch / lancedb) and removes the index by raw ID.
4. No `request.decoded_token` check exists between (1) and (3), even though the global `@app.before_request` in `application/app.py` only *populates* `decoded_token = None` for unauthenticated requests under JWT auth modes — it does not reject them. Per-route checks are required, and every neighboring sensitive route (`DeleteOldIndexes`, `ManageSync`, `SyncSource`) already has one. `DeleteByIds` was the lone outlier.

## Fix

Add the same standard guard already used by sibling endpoints in the same file:

```python
def get(self):
    decoded_token = request.decoded_token
    if not decoded_token:
        return make_response(jsonify({"success": False}), 401)
    ...
```

Three lines, matches the existing pattern exactly, and is a no-op when `AUTH_TYPE=None` (the auth layer returns a synthetic `{"sub": "local"}` token in that mode, so `decoded_token` is truthy and execution continues unchanged).

## Tests

Added `tests/test_cwe862_delete_by_ids_auth.py` (regression PoC) and extended `tests/api/user/sources/test_source_routes.py`:

- `test_returns_401_unauthenticated` — request with `decoded_token = None` → 401.
- `test_unauthenticated_request_returns_401` — full Flask client GET with no `Authorization` header → 401.
- `test_authenticated_request_is_allowed` — JWT-bearing request is not blocked at the auth layer.
- Existing `TestDeleteByIds` cases (200 success, 400 on missing/invalid path) updated to set `request.decoded_token` so they continue to pass after the new check.

All updated/new test cases pass locally.

## Security analysis

- **Exploitability:** Pre-fix, `curl 'https://target/api/delete_by_ids?path=<id>'` with no token destroys vector-store data on any deployment running `AUTH_TYPE=simple_jwt` or `session_jwt`. The only preconditions are network reachability and a known/guessed source ID.
- **Impact:** Permanent destruction of indexed documents in the configured vector store; affected users lose retrieval over those sources.
- **Mitigation provided:** The fix enforces token presence, blocking all unauthenticated callers and aligning the route with the rest of the sources blueprint.

### Adversarial review

Before submitting, we tried to disprove this. The global `before_request` hook looked like it might already gate the route, but inspection of `application/app.py` shows it only *sets* `request.decoded_token = None` on auth failure under JWT modes and lets the request continue — sibling routes in this very file rely on per-handler `if not decoded_token: 401` guards for that reason. We also checked whether `delete_index` itself enforces ownership: it does not (across any backend it just deletes by raw ID), so there is no defense-in-depth that saves the unauthenticated case. Finally, single-user installs (`AUTH_TYPE=None`) are unaffected because `handle_auth` returns a synthetic local token, so the new check is a no-op there.

Note: a separate IDOR remains where authenticated users can delete *other* users' indexes because `delete_index` does not filter by owner. That is out of scope for this PR (different CWE, larger change touching every backend); this PR addresses the missing-authentication issue only.

cc @lewiswigmore
