### PR TITLE
feat: add Oracle vector store integration (#981)

### DIFF
--- a/application/core/settings.py
+++ b/application/core/settings.py
@@ -61,7 +61,7 @@ class Settings(BaseSettings):
     PARSE_IMAGE_REMOTE: bool = False
     DOCLING_OCR_ENABLED: bool = False  # Enable OCR for docling parsers (PDF, images)
     DOCLING_OCR_ATTACHMENTS_ENABLED: bool = False  # Enable OCR for docling when parsing attachments
-    VECTOR_STORE: str = "faiss"  #  "faiss" or "elasticsearch" or "qdrant" or "milvus" or "lancedb" or "pgvector"
+    VECTOR_STORE: str = "faiss"  #  "faiss" or "elasticsearch" or "qdrant" or "milvus" or "lancedb" or "pgvector" or "oracle"
     RETRIEVERS_ENABLED: list = ["classic_rag"]
     AGENT_NAME: str = "classic"
     FALLBACK_LLM_PROVIDER: Optional[str] = None  # provider for fallback llm
@@ -156,6 +156,12 @@ class Settings(BaseSettings):
     # LanceDB vectorstore config
     LANCEDB_PATH: str = "./data/lancedb"  # Path where LanceDB stores its local data
     LANCEDB_TABLE_NAME: Optional[str] = "docsgpts"  # Name of the table to use for storing vectors
+
+    # Oracle Database 23ai vectorstore config
+    ORACLE_USER: Optional[str] = None  # Oracle database username
+    ORACLE_PASSWORD: Optional[str] = None  # Oracle database password
+    ORACLE_DSN: Optional[str] = None  # Oracle DSN / Easy Connect string (e.g., "host:port/service_name")
+    ORACLE_CONNECTION_STRING: Optional[str] = None  # Full Oracle connection string (user/password@dsn)
 
     FLASK_DEBUG_MODE: bool = False
     STORAGE_TYPE: str = "local"  # local or s3

--- a/application/vectorstore/oracle.py
+++ b/application/vectorstore/oracle.py
@@ -1,0 +1,479 @@
+"""Oracle Database 23ai Vector Store for DocsGPT.
+
+Supports Oracle Database 23ai's native VECTOR data type and vector similarity
+search via the ``oracledb`` Python driver.
+
+Requires:
+    - Oracle Database 23ai (or later) with VECTOR datatype support.
+    - ``oracledb`` package (``pip install oracledb``).
+    - A database user with privileges to create tables and vector indexes.
+"""
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+from application.core.settings import settings
+from application.vectorstore.base import BaseVectorStore
+from application.vectorstore.document_class import Document
+
+
+logger = logging.getLogger(__name__)
+
+
+class OracleVectorStore(BaseVectorStore):
+    """Oracle Database 23ai vector store.
+
+    Stores document embeddings in an Oracle table using the native ``VECTOR``
+    column type and performs similarity search with ``VECTOR_DISTANCE()``.
+    """
+
+    def __init__(
+        self,
+        source_id: str = "",
+        embeddings_key: str = "embeddings",
+        table_name: str = "docsgpt_documents",
+        vector_column: str = "embedding",
+        text_column: str = "text",
+        metadata_column: str = "metadata",
+        user: Optional[str] = None,
+        password: Optional[str] = None,
+        dsn: Optional[str] = None,
+        connection_string: Optional[str] = None,
+    ):
+        """Initialize the Oracle vector store.
+
+        Args:
+            source_id: Unique identifier for the document source.
+            embeddings_key: Key/label for the embedding model.
+            table_name: Name of the Oracle table to store vectors in.
+            vector_column: Name of the VECTOR column.
+            text_column: Name of the text content column.
+            metadata_column: Name of the JSON metadata column.
+            user: Oracle database username (overrides ``ORACLE_USER``).
+            password: Oracle database password (overrides ``ORACLE_PASSWORD``).
+            dsn: Oracle DSN / Easy Connect string (overrides ``ORACLE_DSN``).
+            connection_string: Full ``oracledb.connect()`` connection string
+                (overrides individual user/password/dsn). Format:
+                ``user/password@dsn``
+        """
+        super().__init__()
+
+        self._source_id = str(source_id).replace("application/indexes/", "").rstrip("/")
+        self._embeddings_key = embeddings_key
+        self._table_name = table_name
+        self._vector_column = vector_column
+        self._text_column = text_column
+        self._metadata_column = metadata_column
+        self._embedding = self._get_embeddings(settings.EMBEDDINGS_NAME, embeddings_key)
+
+        # Resolve connection parameters: explicit args > settings > env
+        self._user = user or getattr(settings, "ORACLE_USER", None)
+        self._password = password or getattr(settings, "ORACLE_PASSWORD", None)
+        self._dsn = dsn or getattr(settings, "ORACLE_DSN", None)
+
+        # A full connection string (user/password@dsn) takes precedence
+        self._connection_string = connection_string or getattr(
+            settings, "ORACLE_CONNECTION_STRING", None
+        )
+
+        if not any([self._connection_string, (self._user and self._password and self._dsn)]):
+            raise ValueError(
+                "Oracle connection parameters are required. "
+                "Set ORACLE_USER, ORACLE_PASSWORD, and ORACLE_DSN in settings, "
+                "or set ORACLE_CONNECTION_STRING, "
+                "or pass connection_string/user/password/dsn parameters."
+            )
+
+        try:
+            import oracledb
+        except ImportError:
+            raise ImportError(
+                "Could not import the oracledb Python driver. "
+                "Please install it with `pip install oracledb`."
+            )
+
+        self._oracledb = oracledb
+        self._connection: Optional[Any] = None
+        self._ensure_table_exists()
+
+    # ------------------------------------------------------------------
+    # Connection management
+    # ------------------------------------------------------------------
+
+    def _get_connection(self):
+        """Get or create a database connection."""
+        if self._connection is None:
+            self._connection = self._connect()
+        else:
+            try:
+                # Lightweight round-trip check; cursor open implies connected.
+                with self._connection.cursor():
+                    pass
+            except Exception:
+                # Connection is stale — reconnect.
+                logger.info("Oracle connection stale, reconnecting.")
+                self._close_connection()
+                self._connection = self._connect()
+        return self._connection
+
+    def _connect(self):
+        """Create a new Oracle database connection."""
+        if self._connection_string:
+            logger.debug("Connecting to Oracle via connection string.")
+            return self._oracledb.connect(self._connection_string)
+
+        logger.debug(
+            "Connecting to Oracle with user=%s, dsn=%s", self._user, self._dsn
+        )
+        return self._oracledb.connect(user=self._user, password=self._password, dsn=self._dsn)
+
+    def _close_connection(self):
+        """Close the current connection if open."""
+        if self._connection is not None:
+            try:
+                self._connection.close()
+            except Exception:
+                pass
+            self._connection = None
+
+    # ------------------------------------------------------------------
+    # Schema management
+    # ------------------------------------------------------------------
+
+    def _ensure_table_exists(self):
+        """Create the table and vector index if they don't already exist."""
+        conn = self._get_connection()
+        cursor = conn.cursor()
+
+        try:
+            embedding_dim = getattr(self._embedding, "dimension", 768)
+
+            # Create the documents table with a VECTOR column.
+            # Oracle 23ai supports VECTOR(n, FLOAT64) as a native column type.
+            create_table_sql = f"""
+            CREATE TABLE {self._table_name} (
+                id NUMBER GENERATED BY DEFAULT AS IDENTITY PRIMARY KEY,
+                {self._text_column} CLOB NOT NULL,
+                {self._vector_column} VECTOR({embedding_dim}, FLOAT64),
+                {self._metadata_column} CLOB,
+                source_id VARCHAR2(1000) NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+            cursor.execute(create_table_sql)
+            conn.commit()
+            logger.info("Created table %s.", self._table_name)
+
+        except Exception as exc:
+            # ORA-00955: name is already used by an existing object
+            # (table already exists) — this is expected on re-init.
+            conn.rollback()
+            if "ORA-00955" not in str(exc):
+                logger.warning("Table may already exist: %s", exc)
+
+        try:
+            # Create an HNSW vector index for approximate nearest neighbour search.
+            # Oracle 23ai supports: VECTOR INDEX … ORGANIZATION NEIGHBOR PARTITIONS
+            # with DISTANCE COSINE and TARGET ACCURACY.
+            index_name = f"{self._table_name}_{self._vector_column}_idx"
+            # Oracle object names are capped at 30 bytes by default; truncate if needed.
+            index_name = index_name[:30]
+
+            create_index_sql = f"""
+            CREATE VECTOR INDEX {index_name}
+            ON {self._table_name}({self._vector_column})
+            ORGANIZATION NEIGHBOR PARTITIONS
+            DISTANCE COSINE
+            WITH TARGET ACCURACY 95
+            """
+            cursor.execute(create_index_sql)
+            conn.commit()
+            logger.info("Created vector index %s.", index_name)
+
+        except Exception as exc:
+            conn.rollback()
+            if "ORA-00955" not in str(exc):
+                logger.warning("Vector index may already exist: %s", exc)
+
+        try:
+            # B-tree index on source_id for efficient filtering.
+            source_idx_name = f"{self._table_name}_src_idx"[:30]
+            cursor.execute(
+                f"CREATE INDEX {source_idx_name} ON {self._table_name}(source_id)"
+            )
+            conn.commit()
+
+        except Exception as exc:
+            conn.rollback()
+            if "ORA-00955" not in str(exc):
+                logger.warning("source_id index may already exist: %s", exc)
+
+        finally:
+            cursor.close()
+
+    # ------------------------------------------------------------------
+    # Public API  (required by BaseVectorStore)
+    # ------------------------------------------------------------------
+
+    def search(self, question: str, k: int = 2, *args, **kwargs) -> List[Document]:
+        """Search for the *k* most similar documents using cosine distance."""
+        query_vector = self._embedding.embed_query(question)
+
+        conn = self._get_connection()
+        cursor = conn.cursor()
+
+        try:
+            # Oracle uses VECTOR_DISTANCE() for similarity and
+            # FETCH FIRST … ROWS ONLY instead of LIMIT.
+            search_sql = f"""
+            SELECT {self._text_column}, {self._metadata_column},
+                   VECTOR_DISTANCE({self._vector_column}, :qv, COSINE) AS distance
+            FROM {self._table_name}
+            WHERE source_id = :sid
+            ORDER BY VECTOR_DISTANCE({self._vector_column}, :qv2, COSINE)
+            FETCH FIRST :k ROWS ONLY
+            """
+            cursor.execute(
+                search_sql,
+                qv=self._encode_vector(query_vector),
+                sid=self._source_id,
+                qv2=self._encode_vector(query_vector),
+                k=k,
+            )
+            results = cursor.fetchall()
+
+            documents = []
+            for row in results:
+                text = row[0]
+                metadata_raw = row[1]
+                metadata = self._decode_metadata(metadata_raw)
+                documents.append(Document(page_content=text, metadata=metadata))
+
+            return documents
+
+        except Exception as e:
+            logger.error("Error searching documents: %s", e, exc_info=True)
+            return []
+        finally:
+            cursor.close()
+
+    def add_texts(
+        self,
+        texts: List[str],
+        metadatas: Optional[List[Dict[str, Any]]] = None,
+        *args,
+        **kwargs,
+    ) -> List[str]:
+        """Add a list of texts with their embeddings to the store.
+
+        Returns a list of inserted row IDs as strings.
+        """
+        if not texts:
+            return []
+
+        embeddings = self._embedding.embed_documents(texts)
+        metadatas = metadatas or [{}] * len(texts)
+
+        conn = self._get_connection()
+        cursor = conn.cursor()
+
+        # Oracle's RETURNING … INTO needs an OUT bind variable.
+        # We use a PL/SQL block or the simpler rowid approach.
+        # Here we use INSERT … RETURNING id INTO :rid with a bind variable.
+        insert_sql = f"""
+        INSERT INTO {self._table_name}
+            ({self._text_column}, {self._vector_column}, {self._metadata_column}, source_id)
+        VALUES (:txt, :vec, :meta, :sid)
+        RETURNING id INTO :rid
+        """
+
+        inserted_ids = []
+        try:
+            for text, embedding, metadata in zip(texts, embeddings, metadatas):
+                row_id = cursor.var(self._oracledb.NUMBER)
+                cursor.execute(
+                    insert_sql,
+                    txt=text,
+                    vec=self._encode_vector(embedding),
+                    meta=self._encode_metadata(metadata),
+                    sid=self._source_id,
+                    rid=row_id,
+                )
+                inserted_ids.append(str(row_id.getvalue()[0]))
+
+            conn.commit()
+            return inserted_ids
+
+        except Exception as e:
+            conn.rollback()
+            logger.error("Error adding texts: %s", e)
+            raise
+        finally:
+            cursor.close()
+
+    def delete_index(self, *args, **kwargs):
+        """Delete all documents for the current *source_id*."""
+        conn = self._get_connection()
+        cursor = conn.cursor()
+
+        try:
+            cursor.execute(
+                f"DELETE FROM {self._table_name} WHERE source_id = :sid",
+                sid=self._source_id,
+            )
+            conn.commit()
+        except Exception as e:
+            conn.rollback()
+            logger.error("Error deleting index: %s", e)
+            raise
+        finally:
+            cursor.close()
+
+    def save_local(self, *args, **kwargs):
+        """No-op — data is already persisted in Oracle Database."""
+        pass
+
+    def get_chunks(self) -> List[Dict[str, Any]]:
+        """Return all chunks for the current *source_id*."""
+        conn = self._get_connection()
+        cursor = conn.cursor()
+
+        try:
+            cursor.execute(
+                f"SELECT id, {self._text_column}, {self._metadata_column} "
+                f"FROM {self._table_name} "
+                f"WHERE source_id = :sid "
+                f"ORDER BY id",
+                sid=self._source_id,
+            )
+            results = cursor.fetchall()
+
+            chunks = []
+            for doc_id, text, metadata_raw in results:
+                chunks.append({
+                    "doc_id": str(doc_id),
+                    "text": text,
+                    "metadata": self._decode_metadata(metadata_raw),
+                })
+            return chunks
+
+        except Exception as e:
+            logger.error("Error getting chunks: %s", e)
+            return []
+        finally:
+            cursor.close()
+
+    def add_chunk(
+        self, text: str, metadata: Optional[Dict[str, Any]] = None
+    ) -> str:
+        """Add a single chunk and return its row ID."""
+        metadata = metadata or {}
+        final_metadata = metadata.copy()
+        final_metadata["source_id"] = self._source_id
+
+        embeddings = self._embedding.embed_documents([text])
+        if not embeddings:
+            raise ValueError("Could not generate embedding for chunk")
+
+        conn = self._get_connection()
+        cursor = conn.cursor()
+
+        insert_sql = f"""
+        INSERT INTO {self._table_name}
+            ({self._text_column}, {self._vector_column}, {self._metadata_column}, source_id)
+        VALUES (:txt, :vec, :meta, :sid)
+        RETURNING id INTO :rid
+        """
+
+        try:
+            row_id = cursor.var(self._oracledb.NUMBER)
+            cursor.execute(
+                insert_sql,
+                txt=text,
+                vec=self._encode_vector(embeddings[0]),
+                meta=self._encode_metadata(final_metadata),
+                sid=self._source_id,
+                rid=row_id,
+            )
+            conn.commit()
+            return str(row_id.getvalue()[0])
+
+        except Exception as e:
+            conn.rollback()
+            logger.error("Error adding chunk: %s", e)
+            raise
+        finally:
+            cursor.close()
+
+    def delete_chunk(self, chunk_id: str) -> bool:
+        """Delete a single chunk by its row ID.
+
+        Returns ``True`` if a row was deleted, ``False`` otherwise.
+        """
+        conn = self._get_connection()
+        cursor = conn.cursor()
+
+        try:
+            cursor.execute(
+                f"DELETE FROM {self._table_name} WHERE id = :cid AND source_id = :sid",
+                cid=int(chunk_id),
+                sid=self._source_id,
+            )
+            deleted_count = cursor.rowcount
+            conn.commit()
+            return deleted_count > 0
+
+        except Exception as e:
+            conn.rollback()
+            logger.error("Error deleting chunk: %s", e)
+            return False
+        finally:
+            cursor.close()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _encode_vector(vector: List[float]) -> str:
+        """Format a Python float list as an Oracle VECTOR literal string.
+
+        Oracle accepts the format ``'[1.5, 2.3, -0.7]'`` for vector bind
+        parameters when passed as a string. The oracledb driver may also
+        accept a list-of-floats directly in some versions; the string
+        representation is the most portable approach.
+        """
+        return "[" + ", ".join(str(v) for v in vector) + "]"
+
+    @staticmethod
+    def _encode_metadata(metadata: dict) -> Optional[str]:
+        """Serialize metadata dict to a JSON string for the CLOB column."""
+        if not metadata:
+            return None
+        return json.dumps(metadata)
+
+    @staticmethod
+    def _decode_metadata(metadata_raw: Any) -> dict:
+        """Deserialize the CLOB metadata column back to a dict."""
+        if metadata_raw is None:
+            return {}
+        if isinstance(metadata_raw, dict):
+            return metadata_raw
+        if isinstance(metadata_raw, str):
+            try:
+                return json.loads(metadata_raw)
+            except (json.JSONDecodeError, TypeError):
+                return {}
+        # CLOB objects from oracledb may need .read()
+        if hasattr(metadata_raw, "read"):
+            try:
+                return json.loads(metadata_raw.read())
+            except (json.JSONDecodeError, TypeError):
+                return {}
+        return {}
+
+    def __del__(self):
+        """Close the database connection when the object is garbage-collected."""
+        if hasattr(self, "_connection"):
+            self._close_connection()

--- a/application/vectorstore/vector_creator.py
+++ b/application/vectorstore/vector_creator.py
@@ -4,6 +4,7 @@ from application.vectorstore.milvus import MilvusStore
 from application.vectorstore.mongodb import MongoDBVectorStore
 from application.vectorstore.qdrant import QdrantStore
 from application.vectorstore.pgvector import PGVectorStore
+from application.vectorstore.oracle import OracleVectorStore
 
 
 class VectorCreator:
@@ -13,7 +14,8 @@ class VectorCreator:
         "mongodb": MongoDBVectorStore,
         "qdrant": QdrantStore,
         "milvus": MilvusStore,
-        "pgvector": PGVectorStore
+        "pgvector": PGVectorStore,
+        "oracle": OracleVectorStore,
     }
 
     @classmethod

--- a/tests/vectorstore/test_oracle.py
+++ b/tests/vectorstore/test_oracle.py
@@ -1,0 +1,474 @@
+"""Unit tests for OracleVectorStore.
+
+Follows the same mocking pattern as ``test_pgvector.py`` so that all
+external dependencies (oracledb, settings) are replaced by MagicMock
+objects.  No real Oracle database is required.
+"""
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+
+def _make_store(
+    source_id="test-source",
+    embeddings_key="key",
+    user="test_user",
+    password="test_pass",
+    dsn="localhost:1521/xepdb1",
+):
+    """Helper to create an OracleVectorStore with all external deps mocked."""
+    with patch(
+        "application.vectorstore.base.BaseVectorStore._get_embeddings"
+    ) as mock_get_emb, patch(
+        "application.vectorstore.oracle.settings"
+    ) as mock_settings, patch.dict(
+        "sys.modules",
+        {
+            "oracledb": MagicMock(),
+        },
+    ):
+        mock_emb = Mock()
+        mock_emb.embed_query = Mock(return_value=[0.1, 0.2, 0.3])
+        mock_emb.embed_documents = Mock(return_value=[[0.1, 0.2, 0.3]])
+        mock_emb.dimension = 768
+        mock_get_emb.return_value = mock_emb
+        mock_settings.EMBEDDINGS_NAME = "test_model"
+        mock_settings.ORACLE_USER = user
+        mock_settings.ORACLE_PASSWORD = password
+        mock_settings.ORACLE_DSN = dsn
+        mock_settings.ORACLE_CONNECTION_STRING = None
+
+        from application.vectorstore.oracle import OracleVectorStore
+
+        # Patch _ensure_table_exists to avoid DB calls during init
+        with patch.object(OracleVectorStore, "_ensure_table_exists"):
+            store = OracleVectorStore(
+                source_id=source_id,
+                embeddings_key=embeddings_key,
+            )
+        # Provide a mock connection
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        store._connection = mock_conn
+
+        return store, mock_conn, mock_cursor, mock_emb
+
+
+def _make_store_with_connection_string(
+    source_id="test-source",
+    embeddings_key="key",
+    connection_string="test_user/test_pass@localhost:1521/xepdb1",
+):
+    """Helper using ORACLE_CONNECTION_STRING instead of individual params."""
+    with patch(
+        "application.vectorstore.base.BaseVectorStore._get_embeddings"
+    ) as mock_get_emb, patch(
+        "application.vectorstore.oracle.settings"
+    ) as mock_settings, patch.dict(
+        "sys.modules",
+        {
+            "oracledb": MagicMock(),
+        },
+    ):
+        mock_emb = Mock()
+        mock_emb.embed_query = Mock(return_value=[0.1, 0.2, 0.3])
+        mock_emb.embed_documents = Mock(return_value=[[0.1, 0.2, 0.3]])
+        mock_emb.dimension = 768
+        mock_get_emb.return_value = mock_emb
+        mock_settings.EMBEDDINGS_NAME = "test_model"
+        mock_settings.ORACLE_USER = None
+        mock_settings.ORACLE_PASSWORD = None
+        mock_settings.ORACLE_DSN = None
+        mock_settings.ORACLE_CONNECTION_STRING = connection_string
+
+        from application.vectorstore.oracle import OracleVectorStore
+
+        with patch.object(OracleVectorStore, "_ensure_table_exists"):
+            store = OracleVectorStore(
+                source_id=source_id,
+                embeddings_key=embeddings_key,
+            )
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        store._connection = mock_conn
+
+        return store, mock_conn, mock_cursor, mock_emb
+
+
+# ---------------------------------------------------------------------------
+# Init tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOracleVectorStoreInit:
+    def test_source_id_cleaned(self):
+        store, _, _, _ = _make_store(source_id="application/indexes/abc123/")
+        assert store._source_id == "abc123"
+
+    def test_missing_connection_params_raises(self):
+        with patch(
+            "application.vectorstore.base.BaseVectorStore._get_embeddings"
+        ) as mock_get_emb, patch(
+            "application.vectorstore.oracle.settings"
+        ) as mock_settings, patch.dict(
+            "sys.modules",
+            {
+                "oracledb": MagicMock(),
+            },
+        ):
+            mock_get_emb.return_value = Mock(dimension=768)
+            mock_settings.EMBEDDINGS_NAME = "test_model"
+            mock_settings.ORACLE_USER = None
+            mock_settings.ORACLE_PASSWORD = None
+            mock_settings.ORACLE_DSN = None
+            mock_settings.ORACLE_CONNECTION_STRING = None
+
+            from application.vectorstore.oracle import OracleVectorStore
+
+            with pytest.raises(ValueError, match="connection parameters are required"):
+                OracleVectorStore(source_id="test", embeddings_key="key")
+
+    def test_init_with_connection_string(self):
+        """Initialisation via full connection string should succeed."""
+        store, _, _, _ = _make_store_with_connection_string()
+        assert store._source_id == "test-source"
+
+
+# ---------------------------------------------------------------------------
+# Search tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOracleVectorStoreSearch:
+    def test_search_returns_documents(self):
+        store, mock_conn, mock_cursor, mock_emb = _make_store()
+        mock_cursor.fetchall.return_value = [
+            ("hello world", '{"source": "test.txt"}', 0.1),
+            ("foo bar", '{"source": "test2.txt"}', 0.2),
+        ]
+
+        results = store.search("query", k=2)
+
+        mock_emb.embed_query.assert_called_once_with("query")
+        assert len(results) == 2
+        assert results[0].page_content == "hello world"
+        assert results[0].metadata == {"source": "test.txt"}
+
+    def test_search_returns_empty_on_error(self):
+        store, mock_conn, mock_cursor, _ = _make_store()
+        mock_cursor.execute.side_effect = Exception("connection lost")
+
+        results = store.search("query")
+        assert results == []
+
+    def test_search_handles_null_metadata(self):
+        store, _, mock_cursor, _ = _make_store()
+        mock_cursor.fetchall.return_value = [("text", None, 0.5)]
+
+        results = store.search("query")
+        assert len(results) == 1
+        assert results[0].metadata == {}
+
+    def test_search_uses_cosine_distance(self):
+        store, _, mock_cursor, _ = _make_store()
+        mock_cursor.fetchall.return_value = [("text", None, 0.5)]
+
+        store.search("query")
+
+        sql = mock_cursor.execute.call_args[0][0]
+        assert "VECTOR_DISTANCE" in sql
+        assert "COSINE" in sql
+        assert "FETCH FIRST" in sql
+
+
+# ---------------------------------------------------------------------------
+# add_texts tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOracleVectorStoreAddTexts:
+    def test_add_texts_inserts_and_returns_ids(self):
+        store, mock_conn, mock_cursor, mock_emb = _make_store()
+        mock_emb.embed_documents.return_value = [[0.1, 0.2], [0.3, 0.4]]
+
+        # Simulate RETURNING id … INTO :rid
+        def _side_effect(sql, **kwargs):
+            rid_var = kwargs.get("rid")
+            if rid_var is not None:
+                # The mock oracledb cursor var returns (value,) via getvalue()
+                call_idx = mock_cursor.execute.call_count
+                rid_var.getvalue.return_value = (call_idx,)
+            return MagicMock()
+
+        mock_cursor.execute.side_effect = _side_effect
+        mock_cursor.var = MagicMock(return_value=MagicMock())
+
+        ids = store.add_texts(["text1", "text2"], [{"a": 1}, {"b": 2}])
+
+        assert len(ids) == 2
+        assert mock_cursor.execute.call_count == 2
+        mock_conn.commit.assert_called_once()
+
+    def test_add_texts_empty_returns_empty(self):
+        store, _, _, _ = _make_store()
+        assert store.add_texts([]) == []
+
+    def test_add_texts_default_metadatas(self):
+        store, mock_conn, mock_cursor, mock_emb = _make_store()
+        mock_emb.embed_documents.return_value = [[0.1, 0.2]]
+        mock_cursor.var = MagicMock(return_value=MagicMock())
+
+        ids = store.add_texts(["text1"])
+        assert len(ids) == 1
+
+    def test_add_texts_rolls_back_on_error(self):
+        store, mock_conn, mock_cursor, mock_emb = _make_store()
+        mock_emb.embed_documents.return_value = [[0.1]]
+        mock_cursor.execute.side_effect = Exception("insert failed")
+
+        with pytest.raises(Exception, match="insert failed"):
+            store.add_texts(["text1"])
+
+        mock_conn.rollback.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# delete_index tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOracleVectorStoreDeleteIndex:
+    def test_delete_index_deletes_by_source_id(self):
+        store, mock_conn, mock_cursor, _ = _make_store(source_id="src123")
+
+        store.delete_index()
+
+        mock_cursor.execute.assert_called_once()
+        sql = mock_cursor.execute.call_args[0][0]
+        assert "DELETE FROM" in sql
+        assert mock_cursor.execute.call_args[1]["sid"] == "src123"
+        mock_conn.commit.assert_called_once()
+
+    def test_delete_index_rolls_back_on_error(self):
+        store, mock_conn, mock_cursor, _ = _make_store()
+        mock_cursor.execute.side_effect = Exception("fail")
+
+        with pytest.raises(Exception):
+            store.delete_index()
+
+        mock_conn.rollback.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# save_local tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOracleVectorStoreSaveLocal:
+    def test_save_local_is_noop(self):
+        store, _, _, _ = _make_store()
+        assert store.save_local() is None
+
+
+# ---------------------------------------------------------------------------
+# get_chunks tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOracleVectorStoreGetChunks:
+    def test_get_chunks(self):
+        store, _, mock_cursor, _ = _make_store()
+        mock_cursor.fetchall.return_value = [
+            (1, "text1", '{"key": "val"}'),
+            (2, "text2", None),
+        ]
+
+        chunks = store.get_chunks()
+        assert len(chunks) == 2
+        assert chunks[0] == {"doc_id": "1", "text": "text1", "metadata": {"key": "val"}}
+        assert chunks[1] == {"doc_id": "2", "text": "text2", "metadata": {}}
+
+    def test_get_chunks_returns_empty_on_error(self):
+        store, _, mock_cursor, _ = _make_store()
+        mock_cursor.execute.side_effect = Exception("fail")
+
+        assert store.get_chunks() == []
+
+
+# ---------------------------------------------------------------------------
+# add_chunk tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOracleVectorStoreAddChunk:
+    def test_add_chunk(self):
+        store, mock_conn, mock_cursor, mock_emb = _make_store(source_id="src1")
+        mock_emb.embed_documents.return_value = [[0.1, 0.2]]
+        mock_cursor.var = MagicMock(return_value=MagicMock())
+
+        chunk_id = store.add_chunk("hello", metadata={"key": "val"})
+
+        assert chunk_id is not None
+        mock_conn.commit.assert_called_once()
+
+    def test_add_chunk_raises_on_empty_embedding(self):
+        store, _, _, mock_emb = _make_store()
+        mock_emb.embed_documents.return_value = []
+
+        with pytest.raises(ValueError, match="Could not generate embedding"):
+            store.add_chunk("text")
+
+    def test_add_chunk_includes_source_id_in_metadata(self):
+        store, mock_conn, mock_cursor, mock_emb = _make_store(source_id="src1")
+        mock_emb.embed_documents.return_value = [[0.1, 0.2]]
+        mock_cursor.var = MagicMock(return_value=MagicMock())
+
+        store.add_chunk("hello", metadata={"key": "val"})
+
+        # Verify source_id is passed as a bind parameter to the INSERT.
+        insert_call = mock_cursor.execute.call_args
+        params = insert_call[1]
+        assert params["sid"] == "src1"
+
+
+# ---------------------------------------------------------------------------
+# delete_chunk tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOracleVectorStoreDeleteChunk:
+    def test_delete_chunk_success(self):
+        store, mock_conn, mock_cursor, _ = _make_store()
+        mock_cursor.rowcount = 1
+
+        result = store.delete_chunk("42")
+        assert result is True
+        mock_conn.commit.assert_called_once()
+
+    def test_delete_chunk_not_found(self):
+        store, mock_conn, mock_cursor, _ = _make_store()
+        mock_cursor.rowcount = 0
+
+        result = store.delete_chunk("999")
+        assert result is False
+
+    def test_delete_chunk_returns_false_on_error(self):
+        store, _, mock_cursor, _ = _make_store()
+        mock_cursor.execute.side_effect = Exception("fail")
+
+        result = store.delete_chunk("42")
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Connection management tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOracleVectorStoreConnection:
+    def test_get_connection_creates_new(self):
+        store, mock_conn, _, _ = _make_store()
+        store._connection = None  # Force creation
+
+        mock_oracledb = MagicMock()
+        new_conn = MagicMock()
+        mock_oracledb.connect.return_value = new_conn
+        store._oracledb = mock_oracledb
+
+        conn = store._get_connection()
+        mock_oracledb.connect.assert_called_once()
+        assert conn is new_conn
+
+    def test_get_connection_reuses_existing(self):
+        store, mock_conn, _, _ = _make_store()
+        # Connection is already set by _make_store
+        conn = store._get_connection()
+        assert conn is mock_conn
+
+    def test_get_connection_reconnects_on_failure(self):
+        store, mock_conn, mock_cursor, _ = _make_store()
+        # Make the existing connection throw on cursor()
+        mock_conn.cursor.side_effect = Exception("ORA-03135: connection lost")
+
+        mock_oracledb = MagicMock()
+        new_conn = MagicMock()
+        mock_oracledb.connect.return_value = new_conn
+        store._oracledb = mock_oracledb
+
+        conn = store._get_connection()
+        # Should have tried reconnecting
+        mock_oracledb.connect.assert_called_once()
+        assert conn is new_conn
+
+    def test_ensure_table_exists(self):
+        store, mock_conn, mock_cursor, _ = _make_store()
+        # Reset mock_connection to simulate first call
+        store._ensure_table_exists()
+
+        # Should have executed CREATE TABLE and index DDL statements
+        assert mock_cursor.execute.call_count >= 3
+        mock_conn.commit.assert_called()
+
+    def test_del_closes_connection(self):
+        store, mock_conn, _, _ = _make_store()
+
+        store.__del__()
+        mock_conn.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Helper / encoding tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestOracleVectorStoreHelpers:
+    def test_encode_vector(self):
+        from application.vectorstore.oracle import OracleVectorStore as OVS
+
+        result = OVS._encode_vector([1.5, -2.3, 0.0])
+        assert result == "[1.5, -2.3, 0.0]"
+
+    def test_encode_metadata_none(self):
+        from application.vectorstore.oracle import OracleVectorStore as OVS
+
+        assert OVS._encode_metadata(None) is None
+        assert OVS._encode_metadata({}) is None
+
+    def test_encode_metadata_dict(self):
+        from application.vectorstore.oracle import OracleVectorStore as OVS
+
+        result = OVS._encode_metadata({"key": "val"})
+        assert result == '{"key": "val"}'
+
+    def test_decode_metadata_none(self):
+        from application.vectorstore.oracle import OracleVectorStore as OVS
+
+        assert OVS._decode_metadata(None) == {}
+
+    def test_decode_metadata_string(self):
+        from application.vectorstore.oracle import OracleVectorStore as OVS
+
+        assert OVS._decode_metadata('{"a": 1}') == {"a": 1}
+
+    def test_decode_metadata_dict_passthrough(self):
+        from application.vectorstore.oracle import OracleVectorStore as OVS
+
+        assert OVS._decode_metadata({"a": 1}) == {"a": 1}
+
+    def test_decode_metadata_invalid_string(self):
+        from application.vectorstore.oracle import OracleVectorStore as OVS
+
+        assert OVS._decode_metadata("not-json") == {}


### PR DESCRIPTION
Closes #981 — adds Oracle Database 23ai as a vector store backend for DocsGPT.

**Files added:**
- `application/vectorstore/oracle.py` — Oracle vector store (479 lines)
- `tests/vectorstore/test_oracle.py` — 34 unit tests

**Files modified:**
- `application/vectorstore/vector_creator.py` — registered "oracle" entry
- `application/core/settings.py` — added ORACLE_* config fields

Uses oracledb driver, VECTOR(n, FLOAT64) column, HNSW index, COSINE similarity search. Full CRUD + JSON metadata support.