### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -9,6 +9,8 @@ INTERNAL_KEY=<internal key for worker-to-backend authentication>
 # GOOGLE_API_KEY=<your-google-api-key>
 # GROQ_API_KEY=<your-groq-api-key>
 # NOVITA_API_KEY=<your-novita-api-key>
+# ASTRAFLOW_API_KEY=<your-astraflow-api-key>          # Global: https://astraflow.ucloud-global.com
+# ASTRAFLOW_CN_API_KEY=<your-astraflow-cn-api-key>    # China:  https://astraflow.ucloud.cn
 # OPEN_ROUTER_API_KEY=<your-openrouter-api-key>
 
 # Remote Embeddings (Optional - for using a remote embeddings API instead of local SentenceTransformer)

--- a/application/core/settings.py
+++ b/application/core/settings.py
@@ -105,6 +105,8 @@ class Settings(BaseSettings):
     HUGGINGFACE_API_KEY: Optional[str] = None
     OPEN_ROUTER_API_KEY: Optional[str] = None
     NOVITA_API_KEY: Optional[str] = None
+    ASTRAFLOW_API_KEY: Optional[str] = None
+    ASTRAFLOW_CN_API_KEY: Optional[str] = None
 
     OPENAI_API_BASE: Optional[str] = None  # azure openai api base url
     OPENAI_API_VERSION: Optional[str] = None  # azure openai api version
@@ -206,6 +208,8 @@ class Settings(BaseSettings):
         "GROQ_API_KEY",
         "HUGGINGFACE_API_KEY",
         "NOVITA_API_KEY",
+        "ASTRAFLOW_API_KEY",
+        "ASTRAFLOW_CN_API_KEY",
         "EMBEDDINGS_KEY",
         "FALLBACK_LLM_API_KEY",
         "QDRANT_API_KEY",

--- a/application/llm/astraflow.py
+++ b/application/llm/astraflow.py
@@ -1,0 +1,35 @@
+from application.core.settings import settings
+from application.llm.openai import OpenAILLM
+
+ASTRAFLOW_BASE_URL = "https://api-us-ca.umodelverse.ai/v1"
+ASTRAFLOW_CN_BASE_URL = "https://api.modelverse.cn/v1"
+
+
+class AstraflowLLM(OpenAILLM):
+    """Astraflow global endpoint (OpenAI-compatible)."""
+
+    provider_name = "astraflow"
+
+    def __init__(self, api_key=None, user_api_key=None, base_url=None, *args, **kwargs):
+        super().__init__(
+            api_key=api_key or settings.ASTRAFLOW_API_KEY or settings.API_KEY,
+            user_api_key=user_api_key,
+            base_url=base_url or ASTRAFLOW_BASE_URL,
+            *args,
+            **kwargs,
+        )
+
+
+class AstraflowCNLLM(OpenAILLM):
+    """Astraflow China endpoint (OpenAI-compatible)."""
+
+    provider_name = "astraflow_cn"
+
+    def __init__(self, api_key=None, user_api_key=None, base_url=None, *args, **kwargs):
+        super().__init__(
+            api_key=api_key or settings.ASTRAFLOW_CN_API_KEY or settings.API_KEY,
+            user_api_key=user_api_key,
+            base_url=base_url or ASTRAFLOW_CN_BASE_URL,
+            *args,
+            **kwargs,
+        )

--- a/application/llm/providers/__init__.py
+++ b/application/llm/providers/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import Dict, List
 
+from application.llm.providers.astraflow import AstraflowCNProvider, AstraflowProvider
 from application.llm.providers.anthropic import AnthropicProvider
 from application.llm.providers.azure_openai import AzureOpenAIProvider
 from application.llm.providers.base import Provider
@@ -40,6 +41,8 @@ ALL_PROVIDERS: List[Provider] = [
     GroqProvider(),
     OpenRouterProvider(),
     NovitaProvider(),
+    AstraflowProvider(),
+    AstraflowCNProvider(),
     HuggingFaceProvider(),
     LlamaCppProvider(),
     PremAIProvider(),

--- a/application/llm/providers/astraflow.py
+++ b/application/llm/providers/astraflow.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from application.llm.astraflow import AstraflowCNLLM, AstraflowLLM
+from application.llm.providers._apikey_or_llm_name import (
+    filter_models_by_llm_name,
+    get_api_key,
+)
+from application.llm.providers.base import Provider
+
+
+class AstraflowProvider(Provider):
+    """Astraflow global endpoint — OpenAI-compatible, 200+ models."""
+
+    name = "astraflow"
+    llm_class = AstraflowLLM
+
+    def get_api_key(self, settings) -> Optional[str]:
+        return get_api_key(settings, self.name, settings.ASTRAFLOW_API_KEY)
+
+    def filter_yaml_models(self, settings, models):
+        return filter_models_by_llm_name(
+            settings, self.name, settings.ASTRAFLOW_API_KEY, models
+        )
+
+
+class AstraflowCNProvider(Provider):
+    """Astraflow China endpoint — OpenAI-compatible, 200+ models."""
+
+    name = "astraflow_cn"
+    llm_class = AstraflowCNLLM
+
+    def get_api_key(self, settings) -> Optional[str]:
+        return get_api_key(settings, self.name, settings.ASTRAFLOW_CN_API_KEY)
+
+    def filter_yaml_models(self, settings, models):
+        return filter_models_by_llm_name(
+            settings, self.name, settings.ASTRAFLOW_CN_API_KEY, models
+        )


### PR DESCRIPTION
- **What kind of change does this PR introduce?** Feature — adds Astraflow (by UCloud / 优刻得) as a supported LLM provider.

- **Why was this change needed?** Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models. Adding it expands the range of available LLM providers. Two endpoints are supported: Global (`https://api-us-ca.umodelverse.ai/v1`, env var `ASTRAFLOW_API_KEY`) and China (`https://api.modelverse.cn/v1`, env var `ASTRAFLOW_CN_API_KEY`).

- **Other information**:
  - New files: `application/llm/astraflow.py` (LLM classes `AstraflowLLM` / `AstraflowCNLLM`, subclassing `OpenAILLM` with custom `base_url`) and `application/llm/providers/astraflow.py` (provider plugin following the Novita pattern).
  - Modified files: `application/core/settings.py` (added `ASTRAFLOW_API_KEY` / `ASTRAFLOW_CN_API_KEY` fields and validator entries), `application/llm/providers/__init__.py` (imports and registers both providers in `ALL_PROVIDERS`), `.env-template` (documents the two new env vars).
  - No new dependencies — reuses the existing `openai` SDK since Astraflow is OpenAI-compatible.