### PR TITLE
fix: guard against empty/filtered LLM responses in OpenAI adapter

### DIFF
--- a/application/llm/openai.py
+++ b/application/llm/openai.py
@@ -283,10 +283,13 @@ class OpenAILLM(BaseLLM):
             request_params["response_format"] = response_format
         response = self.client.chat.completions.create(**request_params)
         logging.info(f"OpenAI response: {response}")
+        if not response.choices:
+            raise ValueError("LLM returned empty or filtered response")
         if tools:
             return response.choices[0]
-        else:
-            return response.choices[0].message.content
+        if response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
+        return response.choices[0].message.content
 
     def _raw_gen_stream(
         self,


### PR DESCRIPTION
## What

Add null checks before accessing `choices[0].message.content` in `application/llm/openai.py`.

## Why

Two crash vectors exist at `response.choices[0].message.content`:

1. **`IndexError`** — when `choices` is an empty list (network interruption, provider-side edge cases, some API-level errors that still return HTTP 200 with an empty response body)
2. **`AttributeError`** — when `choices[0].message` is `None`. This is observed on Gemini via OpenAI-compatible endpoints when content is filtered (PROHIBITED_CONTENT), which returns HTTP 200 with `message: null` rather than an HTTP error code

## Fix

```python
if not response.choices:
    raise ValueError("LLM returned empty or filtered response")
if tools:
    return response.choices[0]
if response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
return response.choices[0].message.content
```

No behaviour change for well-formed responses.