### PR TITLE
(feat) add direct edit button for selected prompts

### DIFF
--- a/frontend/src/settings/Prompts.tsx
+++ b/frontend/src/settings/Prompts.tsx
@@ -1,3 +1,4 @@
+import { Pencil } from 'lucide-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
@@ -138,6 +139,22 @@ export default function Prompts({
     }
   };
 
+  const openEditPrompt = ({
+    id,
+    name,
+    type,
+  }: {
+    id: string;
+    name: string;
+    type?: string;
+  }) => {
+    setModalType('EDIT');
+    setEditPromptName(name);
+    handleFetchPromptContent(id);
+    setCurrentPromptEdit({ id, name, type: type ?? '' });
+    setModalState('ACTIVE');
+  };
+
   const handleSaveChanges = (id: string, type: string) => {
     userService
       .updatePrompt(
@@ -178,6 +195,19 @@ export default function Prompts({
         console.error(error);
       });
   };
+  const promptOptions = prompts.map((prompt: any) =>
+    typeof prompt === 'string'
+      ? { name: prompt, id: prompt, type: '' }
+      : prompt,
+  );
+
+  const selectedPromptForEdit = promptOptions.find(
+    (prompt) => prompt.id === selectedPrompt?.id,
+  );
+
+  const canEditSelectedPrompt =
+    selectedPromptForEdit?.id && selectedPromptForEdit.type !== 'public';
+
   return (
     <>
       <div>
@@ -188,34 +218,27 @@ export default function Prompts({
           <div className="flex flex-row flex-wrap items-end justify-start gap-6">
             <Dropdown
               searchable
-              options={prompts.map((prompt: any) =>
-                typeof prompt === 'string'
-                  ? { name: prompt, id: prompt, type: '' }
-                  : prompt,
-              )}
+              options={promptOptions}
               selectedValue={selectedPrompt ? selectedPrompt.name : ''}
               onSelect={handleSelectPrompt}
               showEdit
               showDelete={(prompt) => prompt.type !== 'public'}
-              onEdit={({
-                id,
-                name,
-                type,
-              }: {
-                id: string;
-                name: string;
-                type?: string;
-              }) => {
-                setModalType('EDIT');
-                setEditPromptName(name);
-                handleFetchPromptContent(id);
-                setCurrentPromptEdit({ id: id, name: name, type: type ?? '' });
-                setModalState('ACTIVE');
-              }}
+              onEdit={openEditPrompt}
               onDelete={handleDeletePrompt}
               placeholder={'Select a prompt'}
               {...dropdownProps}
             />
+            {canEditSelectedPrompt && selectedPromptForEdit && (
+              <button
+                type="button"
+                onClick={() => openEditPrompt(selectedPromptForEdit)}
+                aria-label={t('modals.prompts.editPrompt')}
+                title={t('modals.prompts.editPrompt')}
+                className="border-border bg-card text-muted-foreground hover:bg-accent flex h-11 w-11 items-center justify-center rounded-3xl border transition-colors"
+              >
+                <Pencil className="h-4 w-4" />
+              </button>
+            )}
             {showAddButton && (
               <button
                 className="border-primary text-primary hover:bg-primary/90 w-20 rounded-3xl border border-solid py-3 text-sm transition-colors hover:text-white"


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

- **Why was this change needed?** (You can also link to an open issue here)

Closes #2487.

Currently, users need to open the prompt dropdown to access the edit action for a selected prompt. This PR adds a direct edit button beside the selected prompt dropdown, making custom/private prompts easier to edit while keeping public/default prompts non-editable.

- **Other information**:

Changes:
- Added a direct edit button beside the selected prompt dropdown.
- Reused the existing edit prompt modal flow.
- Hid the direct edit button for public/default prompts.
- Preserved the existing dropdown edit behavior.

Validation:
- `cd frontend && npm run lint` — passed with existing warnings, 0 errors
- `cd frontend && npm run build` — passed

Screenshots:
- Custom/private prompt selected: direct edit button visible.
<img width="1600" height="707" alt="custom_prompt" src="https://github.com/user-attachments/assets/239dd2c5-f9e7-4e57-9680-355e27298e3d" />

- Public/default prompt selected: direct edit button hidden.
<img width="1600" height="707" alt="default_prompt" src="https://github.com/user-attachments/assets/011316e1-e490-4078-af2b-92ef72661031" />
