### PR TITLE
fix: sync iOS Safari theme-color meta tag with app dark/light toggle

### DIFF
--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -103,9 +103,13 @@ export function useDarkTheme() {
     } else {
       document.body?.classList.remove('dark');
     }
+    // Sync iOS Safari bottom bar color with app theme (fixes #2488)
+    const themeColorMetas = document.querySelectorAll('meta[name="theme-color"]');
+    themeColorMetas.forEach((meta) => {
+      meta.setAttribute('content', isDarkTheme ? '#161616' : '#fbfbfb');
+    });
     setComponentMounted(true);
   }, [isDarkTheme]);
-
   const toggleTheme = () => {
     setIsDarkTheme(!isDarkTheme);
   };


### PR DESCRIPTION
Closes #2488

On iOS Safari, the bottom safe area bar color was controlled by 
theme-color meta tags tied to system preference only. When users 
manually toggled dark/light theme in the app, the bottom bar 
color didn't update.

This fix syncs the theme-color meta tags with the app's actual 
theme state whenever it changes.