### PR TITLE
feat(prompts): Edit selected prompt directly

### DIFF
--- a/frontend/src/settings/Prompts.test.tsx
+++ b/frontend/src/settings/Prompts.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { act } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Prompts from './Prompts';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const getSinglePromptMock = vi.hoisted(() => vi.fn());
+
+vi.mock('react-redux', () => ({
+  useSelector: () => 'test-token',
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string>) =>
+      options?.name ? `${key} ${options.name}` : key,
+  }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  Link: ({
+    to,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { to: string }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('../api/services/userService', () => ({
+  default: {
+    createPrompt: vi.fn(),
+    deletePrompt: vi.fn(),
+    getSinglePrompt: getSinglePromptMock,
+    getUserTools: vi.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({ success: true, tools: [] }),
+      }),
+    ),
+    updatePrompt: vi.fn(),
+  },
+}));
+
+const prompts = [
+  { id: 'default', name: 'Default', type: 'public' },
+  { id: 'custom', name: 'Custom', type: 'private' },
+];
+
+let container: HTMLDivElement;
+let root: Root;
+
+const renderPrompts = (selectedPrompt = prompts[1]) => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <Prompts
+        prompts={prompts}
+        selectedPrompt={selectedPrompt}
+        onSelectPrompt={vi.fn()}
+        setPrompts={vi.fn()}
+      />,
+    );
+  });
+};
+
+describe('Prompts', () => {
+  beforeEach(() => {
+    getSinglePromptMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ content: 'Saved custom prompt' }),
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount();
+    });
+    container?.remove();
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
+  });
+
+  it('lets users edit the selected private prompt without opening the dropdown', async () => {
+    renderPrompts(prompts[1]);
+
+    const editButton = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Edit selected prompt"]',
+    );
+
+    expect(editButton).not.toBeNull();
+
+    await act(async () => {
+      editButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(getSinglePromptMock).toHaveBeenCalledWith('custom', 'test-token');
+    expect(document.body.textContent).toContain('modals.prompts.editPrompt');
+  });
+
+  it('does not show direct editing for public prompts', () => {
+    renderPrompts(prompts[0]);
+
+    expect(
+      container.querySelector('[aria-label="Edit selected prompt"]'),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/settings/Prompts.tsx
+++ b/frontend/src/settings/Prompts.tsx
@@ -35,6 +35,12 @@ type ExtendedPromptProps = PromptProps & {
   showAddButton?: boolean;
 };
 
+type PromptItem = {
+  name: string;
+  id: string;
+  type: string;
+};
+
 export default function Prompts({
   prompts,
   selectedPrompt,
@@ -65,11 +71,7 @@ export default function Prompts({
     name: string;
   } | null>(null);
 
-  const handleSelectPrompt = (prompt: {
-    name: string;
-    id: string;
-    type: string;
-  }) => {
+  const handleSelectPrompt = (prompt: PromptItem) => {
     setEditPromptName(prompt.name);
     onSelectPrompt(prompt.name, prompt.id, prompt.type);
     setOpen(false);
@@ -153,6 +155,19 @@ export default function Prompts({
     } catch (error) {
       console.error(error);
     }
+  };
+
+  const handleOpenEditPrompt = (prompt: PromptItem) => {
+    setModalType('EDIT');
+    setEditPromptName(prompt.name);
+    handleFetchPromptContent(prompt.id);
+    setCurrentPromptEdit({
+      id: prompt.id,
+      name: prompt.name,
+      type: prompt.type,
+    });
+    setModalState('ACTIVE');
+    setOpen(false);
   };
 
   const handleSaveChanges = (id: string, type: string) => {
@@ -265,16 +280,7 @@ export default function Prompts({
                                 size="icon-sm"
                                 onClick={(e) => {
                                   e.stopPropagation();
-                                  setModalType('EDIT');
-                                  setEditPromptName(prompt.name);
-                                  handleFetchPromptContent(prompt.id);
-                                  setCurrentPromptEdit({
-                                    id: prompt.id,
-                                    name: prompt.name,
-                                    type: prompt.type,
-                                  });
-                                  setModalState('ACTIVE');
-                                  setOpen(false);
+                                  handleOpenEditPrompt(prompt);
                                 }}
                                 className="h-auto w-auto rounded p-1"
                                 aria-label="Edit prompt"
@@ -305,6 +311,19 @@ export default function Prompts({
                 </Command>
               </PopoverContent>
             </Popover>
+            {selectedPrompt?.type !== 'public' && selectedPrompt?.id && (
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={() => handleOpenEditPrompt(selectedPrompt)}
+                className="border-border bg-card text-foreground hover:bg-accent size-11 rounded-full"
+                aria-label="Edit selected prompt"
+                title="Edit selected prompt"
+              >
+                <Pencil className="text-muted-foreground h-4 w-4" />
+              </Button>
+            )}
             {showAddButton && (
               <Button
                 type="button"


### PR DESCRIPTION
Add a direct edit action next to the selected prompt for custom prompts.

Users can now open the existing edit prompt modal without first opening the prompt dropdown. Public prompts remain locked because the shortcut only renders for non-public prompts, and the modal save guard still prevents editing public prompts.

The dropdown row edit action now shares the same edit-opening path as the selected prompt shortcut.

Fixes #2487