### PR TITLE
fix: iOS Safari dark theme borders use --border var instead of gray-200

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -32,6 +32,16 @@ layer(base);
   ::file-selector-button {
     border-color: var(--color-gray-200, currentcolor);
   }
+
+  /* iOS Safari preserves gray-200 borders in dark mode; use the
+     theme border color instead so borders are dark on dark backgrounds. */
+  .dark *,
+  .dark ::after,
+  .dark ::before,
+  .dark ::backdrop,
+  .dark ::file-selector-button {
+    border-color: var(--border);
+  }
 }
 
 @utility no-scrollbar {


### PR DESCRIPTION
## Description

On iOS Safari, the default `border-color` in the base layer uses `--color-gray-200` (Tailwind default ~#e5e7eb), which appears white on dark backgrounds. This happens because the base layer rule targets all elements with `var(--color-gray-200, currentcolor)` but has no dark-mode variant.

## Fix

Added a `.dark` variant to the base layer that overrides the border color to use the theme's `--border` CSS variable (`#44454c` in dark mode), ensuring borders render with the correct dark color when dark mode is active.

## Related Issue

Closes #2488

## Type of change

- [x] Bug fix / iOS Safari dark theme visual fix