### PR TITLE
feat: allow editing selected prompt directly without opening dropdown

### DIFF
--- a/frontend/src/settings/Prompts.tsx
+++ b/frontend/src/settings/Prompts.tsx
@@ -232,6 +232,29 @@ export default function Prompts({
                   />
                 </Button>
               </PopoverTrigger>
+              {selectedPrompt && selectedPrompt.type !== 'public' && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setModalType('EDIT');
+                    setEditPromptName(selectedPrompt.name);
+                    handleFetchPromptContent(selectedPrompt.id);
+                    setCurrentPromptEdit({
+                      id: selectedPrompt.id,
+                      name: selectedPrompt.name,
+                      type: selectedPrompt.type,
+                    });
+                    setModalState('ACTIVE');
+                  }}
+                  className="h-auto w-auto rounded p-1"
+                  aria-label="Edit prompt"
+                >
+                  <Pencil className="text-muted-foreground h-4 w-4" />
+                </Button>
+              )}
               <PopoverContent
                 align="start"
                 className={cn(


### PR DESCRIPTION
## Description

Adds an inline edit button (pencil icon) next to the currently selected prompt in the settings view, so users can edit the active prompt directly without having to open the dropdown menu first.

**Before:** To edit a prompt, users had to:
1. Open the dropdown
2. Find and click the pencil icon on the desired prompt
3. Edit in the modal

**After:** Users can click a pencil icon next to the dropdown trigger button to immediately edit the currently selected prompt. The dropdown-based edit path remains available as before.

## Key implementation details

- The edit button only appears when a prompt is selected and it is not a public/default prompt (matching the existing edit constraint)
- Clicking the button directly opens the edit modal with the correct prompt content pre-fetched
- The existing `handleFetchPromptContent` and `setModalState` logic is reused

Closes #2487