### PR TITLE
Fix typos in application/ backend found by codespell

### DIFF
--- a/application/api/v1/routes.py
+++ b/application/api/v1/routes.py
@@ -325,7 +325,7 @@ def list_models():
         # Repository rows now go through ``coerce_pg_native`` at SELECT
         # time, so timestamps arrive as ISO 8601 strings. Parse before
         # taking ``.timestamp()``; fall back to ``time.time()`` only when
-        # the value is genuinely missing or unparseable.
+        # the value is genuinely missing or unparsable.
         created = agent.get("created_at") or agent.get("createdAt")
         if isinstance(created, str):
             try:

--- a/application/core/settings.py
+++ b/application/core/settings.py
@@ -118,7 +118,7 @@ class Settings(BaseSettings):
     OPENAI_API_VERSION: Optional[str] = None  # azure openai api version
     AZURE_DEPLOYMENT_NAME: Optional[str] = None  # azure deployment name for answering
     AZURE_EMBEDDINGS_DEPLOYMENT_NAME: Optional[str] = None  # azure deployment name for embeddings
-    OPENAI_BASE_URL: Optional[str] = None  # openai base url for open ai compatable models
+    OPENAI_BASE_URL: Optional[str] = None  # openai base url for open ai compatible models
 
     # elasticsearch
     ELASTIC_CLOUD_ID: Optional[str] = None  # cloud id for elasticsearch

--- a/application/security/safe_url.py
+++ b/application/security/safe_url.py
@@ -143,7 +143,7 @@ def _resolve(host: str) -> Iterable[ipaddress.IPv4Address | ipaddress.IPv6Addres
         except ValueError:
             # An entry we can't parse is itself suspicious; treat as unsafe.
             raise UnsafeUserUrlError(
-                f"hostname {host!r} resolved to unparseable address {ip_str!r}"
+                f"hostname {host!r} resolved to unparsable address {ip_str!r}"
             ) from None
     return addresses
 


### PR DESCRIPTION
Ran `codespell --write` on the `application/` directory and auto-fixed 3 typos:

- `compatable` → `compatible` in `application/core/settings.py`
- `unparseable` → `unparsable` in `application/security/safe_url.py`
- `unparseable` → `unparsable` in `application/api/v1/routes.py`

All changes are purely cosmetic spelling fixes with no behavioral impact.