### PR TITLE
fix(frontend): resolve mobile dark theme viewport background leak (#2488)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -74,7 +74,7 @@ export default function App() {
     return <div />;
   }
   return (
-    <div className="relative h-full overflow-hidden">
+    <div className="bg-background relative h-dvh w-full overflow-hidden">
       {notificationLink &&
         notificationText &&
         showNotification &&


### PR DESCRIPTION
Changed the root layout container styling in frontend/src/App.tsx from h-full to h-dvh and added bg-background to ensure the background dynamically fills mobile viewport safe areas and doesn't leak light theme canvas colors on mobile screens. Fixes #2488.