### PR TITLE
Prevent ZIP bomb attacks during upload extraction

### DIFF
--- a/application/api/user/sources/upload.py
+++ b/application/api/user/sources/upload.py
@@ -35,6 +35,55 @@ sources_upload_ns = Namespace(
 
 
 _IDEMPOTENCY_KEY_MAX_LEN = 256
+_MAX_UNCOMPRESSED_UPLOAD_ZIP_SIZE = 500 * 1024 * 1024
+_MAX_UPLOAD_ZIP_FILE_COUNT = 10000
+_MAX_UPLOAD_ZIP_COMPRESSION_RATIO = 100
+
+
+class ZipUploadValidationError(Exception):
+    """Raised when an uploaded zip fails pre-extraction safety checks."""
+
+
+def _is_zip_target_safe(base_path: str, member_name: str) -> bool:
+    base_resolved = os.path.realpath(base_path)
+    target_resolved = os.path.realpath(os.path.join(base_path, member_name))
+    return (
+        target_resolved == base_resolved
+        or target_resolved.startswith(base_resolved + os.sep)
+    )
+
+
+def _validate_upload_zip_safety(
+    zip_ref: zipfile.ZipFile, zip_path: str, extract_to: str
+) -> None:
+    compressed_size = os.path.getsize(zip_path)
+    total_uncompressed = 0
+    file_count = 0
+
+    for info in zip_ref.infolist():
+        file_count += 1
+        if file_count > _MAX_UPLOAD_ZIP_FILE_COUNT:
+            raise ZipUploadValidationError(
+                f"Zip file contains too many files (>{_MAX_UPLOAD_ZIP_FILE_COUNT})"
+            )
+
+        total_uncompressed += info.file_size
+        if total_uncompressed > _MAX_UNCOMPRESSED_UPLOAD_ZIP_SIZE:
+            raise ZipUploadValidationError(
+                "Zip file uncompressed size exceeds the upload limit"
+            )
+
+        if not _is_zip_target_safe(extract_to, info.filename):
+            raise ZipUploadValidationError(
+                f"Zip file contains an unsafe path: {info.filename}"
+            )
+
+    if compressed_size > 0 and total_uncompressed > 0:
+        compression_ratio = total_uncompressed / compressed_size
+        if compression_ratio > _MAX_UPLOAD_ZIP_COMPRESSION_RATIO:
+            raise ZipUploadValidationError(
+                "Zip file has a suspicious compression ratio"
+            )
 
 
 def _read_idempotency_key():
@@ -210,6 +259,9 @@ class UploadFile(Resource):
                     if zipfile.is_zipfile(temp_file_path) and not is_office_format:
                         try:
                             with zipfile.ZipFile(temp_file_path, "r") as zip_ref:
+                                _validate_upload_zip_safety(
+                                    zip_ref, temp_file_path, temp_dir
+                                )
                                 zip_ref.extractall(path=temp_dir)
 
                                 # Walk through extracted files and upload them
@@ -234,6 +286,8 @@ class UploadFile(Resource):
                                             os.path.join(root, extracted_file), "rb"
                                         ) as f:
                                             storage.save_file(f, storage_path)
+                        except ZipUploadValidationError:
+                            raise
                         except Exception as e:
                             current_app.logger.error(
                                 f"Error extracting zip: {e}", exc_info=True
@@ -285,6 +339,18 @@ class UploadFile(Resource):
                     {
                         "success": False,
                         "message": build_stt_file_size_limit_message(),
+                    }
+                ),
+                413,
+            )
+        except ZipUploadValidationError as err:
+            if scoped_key:
+                _release_claim(scoped_key)
+            return make_response(
+                jsonify(
+                    {
+                        "success": False,
+                        "message": str(err),
                     }
                 ),
                 413,

--- a/tests/api/user/sources/test_upload.py
+++ b/tests/api/user/sources/test_upload.py
@@ -181,6 +181,76 @@ class TestUploadFile:
         # save_file called at least twice (for 2 files in zip)
         assert fake_storage.save_file.call_count >= 2
 
+    def test_upload_rejects_zip_bomb_before_extracting(self, app):
+        from application.api.user.sources.upload import UploadFile
+        import zipfile
+
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("huge.txt", "A" * (1024 * 1024))
+        zip_buffer.seek(0)
+
+        fake_storage = MagicMock()
+
+        with patch(
+            "application.api.user.sources.upload.StorageCreator.get_storage",
+            return_value=fake_storage,
+        ), patch(
+            "application.api.user.sources.upload.ingest.apply_async",
+        ) as mock_ingest, app.test_request_context(
+            "/api/upload", method="POST",
+            data={
+                "user": "alice", "name": "job",
+                "file": (zip_buffer, "bomb.zip"),
+            },
+            content_type="multipart/form-data",
+        ):
+            from flask import request
+            request.decoded_token = {"sub": "alice"}
+            response = UploadFile().post()
+
+        assert response.status_code == 413
+        assert "compression ratio" in response.json["message"]
+        fake_storage.save_file.assert_not_called()
+        mock_ingest.assert_not_called()
+
+    def test_upload_rejects_zip_with_too_many_files(self, app):
+        from application.api.user.sources.upload import (
+            UploadFile,
+            _MAX_UPLOAD_ZIP_FILE_COUNT,
+        )
+        import zipfile
+
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_STORED) as zf:
+            for index in range(_MAX_UPLOAD_ZIP_FILE_COUNT + 1):
+                zf.writestr(f"{index}.txt", "x")
+        zip_buffer.seek(0)
+
+        fake_storage = MagicMock()
+
+        with patch(
+            "application.api.user.sources.upload.StorageCreator.get_storage",
+            return_value=fake_storage,
+        ), patch(
+            "application.api.user.sources.upload.ingest.apply_async",
+        ) as mock_ingest, app.test_request_context(
+            "/api/upload", method="POST",
+            data={
+                "user": "alice", "name": "job",
+                "file": (zip_buffer, "many.zip"),
+            },
+            content_type="multipart/form-data",
+        ):
+            from flask import request
+            request.decoded_token = {"sub": "alice"}
+            response = UploadFile().post()
+
+        assert response.status_code == 413
+        assert "too many files" in response.json["message"]
+        fake_storage.save_file.assert_not_called()
+        mock_ingest.assert_not_called()
+
     def test_office_format_zip_saved_as_is(self, app):
         from application.api.user.sources.upload import UploadFile
         import zipfile


### PR DESCRIPTION
## Summary

This PR adds API-side ZIP archive safety validation before extracting uploaded ZIP files in POST /api/upload.

## Problem

The upload route saves a user-provided ZIP file to a temporary location, detects it using zipfile.is_zipfile(), and then extracts it using the following:

python zip_ref.extractall(path=temp_dir) 

This extraction happens in the API request path before the worker’s existing hardened ZIP extraction logic runs.

As a result, a malicious archive could consume excessive resources in the web/API process before worker-side protections are reached.

Potential abuse cases include:

- ZIP bombs with very high compression ratios
- Archives with excessive uncompressed size
- Archives containing too many files
- ZIP members attempting to escape the extraction directory

## Fix

This PR adds _validate_upload_zip_safety() before extractall().

The validation rejects ZIP archives when:

- file count exceeds 10000
- total uncompressed size exceeds 500 MB
- compression ratio exceeds 100:1
- any ZIP member resolves outside the temporary extraction directory

If validation fails, the route returns 413 and does not save extracted files to storage or enqueue ingestion.

## Tests

Added regression tests covering:

- rejection of a highly compressed ZIP before extraction
- rejection of a ZIP containing more than the allowed number of files
- verification that rejected archives do not write to storage
- verification that rejected archives do not enqueue ingestion

## Security Impact

This reduces the risk of resource exhaustion during ZIP upload handling.

Related weakness categories:

- CWE-400: Uncontrolled Resource Consumption
- CWE-409: Improper Handling of Highly Compressed Data