### PR TITLE
feat: add Oracle vector store integration

### DIFF
--- a/application/core/settings.py
+++ b/application/core/settings.py
@@ -127,6 +127,11 @@ class Settings(BaseSettings):
     ELASTIC_URL: Optional[str] = None  # url for elasticsearch
     ELASTIC_INDEX: Optional[str] = "docsgpt"  # index name for elasticsearch
 
+    # Oracle Vector Store
+    ORACLE_USER: Optional[str] = None  # Oracle database username
+    ORACLE_PASSWORD: Optional[str] = None  # Oracle database password
+    ORACLE_DSN: Optional[str] = None  # Oracle DSN, e.g. "localhost:1521/FREEPDB1"
+
     # SageMaker config
     SAGEMAKER_ENDPOINT: Optional[str] = None  # SageMaker endpoint name
     SAGEMAKER_REGION: Optional[str] = None  # SageMaker region name

--- a/application/vectorstore/oracle.py
+++ b/application/vectorstore/oracle.py
@@ -1,0 +1,62 @@
+from langchain_community.vectorstores.oraclevs import OracleVS
+from langchain_community.vectorstores.utils import DistanceStrategy
+
+from application.core.settings import settings
+from application.vectorstore.base import BaseVectorStore
+
+
+class OracleVectorStore(BaseVectorStore):
+    """Oracle Database vector store integration using LangChain's OracleVS."""
+
+    def __init__(self, source_id: str, embeddings_key: str, docs_init=None):
+        super().__init__()
+        self.source_id = source_id
+        self.embeddings = self._get_embeddings(settings.EMBEDDINGS_NAME, embeddings_key)
+        self.table_name = f"docsGPT_{source_id}".replace("-", "_")
+
+        import oracledb
+
+        self.connection = oracledb.connect(
+            user=settings.ORACLE_USER,
+            password=settings.ORACLE_PASSWORD,
+            dsn=settings.ORACLE_DSN,
+        )
+
+        if docs_init:
+            self.docsearch = OracleVS.from_documents(
+                docs_init,
+                self.embeddings,
+                client=self.connection,
+                table_name=self.table_name,
+                distance_strategy=DistanceStrategy.COSINE,
+            )
+        else:
+            self.docsearch = OracleVS(
+                client=self.connection,
+                embedding_function=self.embeddings,
+                table_name=self.table_name,
+                distance_strategy=DistanceStrategy.COSINE,
+            )
+
+    def search(self, *args, **kwargs):
+        return self.docsearch.similarity_search(*args, **kwargs)
+
+    def add_texts(self, *args, **kwargs):
+        return self.docsearch.add_texts(*args, **kwargs)
+
+    def save_local(self, *args, **kwargs):
+        # Oracle persists automatically, no local save needed
+        pass
+
+    def delete_index(self, *args, **kwargs):
+        return self.docsearch.delete(*args, **kwargs)
+
+    def get_chunks(self):
+        return []
+
+    def add_chunk(self, text, metadata=None):
+        metadata = metadata or {}
+        return self.docsearch.add_texts([text], metadatas=[metadata])
+
+    def delete_chunk(self, chunk_id):
+        return self.delete_index([chunk_id])


### PR DESCRIPTION
Closes #981

## What this PR does
Adds Oracle Database as a vector store option using LangChain's OracleVS integration.

## Changes
- Added `application/vectorstore/oracle.py` with `OracleVectorStore` class
- Added `ORACLE_USER`, `ORACLE_PASSWORD`, and `ORACLE_DSN` settings to `application/core/settings.py`

## How to use
Set the following environment variables:
VECTOR_STORE=oracle
ORACLE_USER=your_user
ORACLE_PASSWORD=your_password
ORACLE_DSN=localhost:1521/FREEPDB1