### PR TITLE
fix: correct iOS Safari dark theme UI borders

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -905,6 +905,22 @@ Avoid over-scrolling in mobile browsers
   }
   body {
     @apply bg-background text-foreground;
+    /* Ensure iOS Safari fills the overscroll area (rubber-band) with the
+       correct background instead of defaulting to white. */
+    min-height: 100vh;
+    min-height: -webkit-fill-available;
+  }
+  /* In dark mode Safari on iOS uses the `color-scheme` property to tint its
+     own chrome (address bar, home indicator area). Without this the bottom
+     overscroll region and toolbar borders remain white even when the page is
+     in dark mode. Setting it on <html> also fills the safe-area insets. */
+  html {
+    color-scheme: light;
+    background-color: var(--background);
+  }
+  html.dark {
+    color-scheme: dark;
+    background-color: var(--background);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #2488

On iOS Safari in dark mode, thin white borders/lines appear along the screen edges — around the address bar area, the home indicator gap, and the overscroll (rubber-band) region. This PR fixes the root cause with a purely additive CSS change.

## Root Cause

Safari on iOS uses two CSS signals on the `<html>` element to determine how to color its own chrome:

1. **`color-scheme`** — tells WebKit whether to render its own UI elements (address bar, home indicator safe area) in light or dark style. Without setting this to `dark`, even a fully dark-themed page will have a white-themed browser chrome.

2. **`background-color` on `<html>`** — Safari paints the safe-area insets and overscroll (bounce) regions using the `<html>` element's background, **not** `<body>`'s background. Our `<body>` had the correct dark background set via `@apply bg-background`, but the `<html>` element had no explicit background, so those gap regions defaulted to white.

The page already had `viewport-fit=cover` in the meta viewport tag (which is correct), but was missing these two signals.

## Changes

**`frontend/src/index.css`** — 16 lines added inside `@layer base`:

```css
body {
  /* Stretches body to fill the entire iOS viewport including safe areas,
     preventing a white gap at the bottom when content is short */
  min-height: 100vh;
  min-height: -webkit-fill-available;
}

/* Tell Safari/WebKit to render its chrome in light style and fill
   safe-area insets with the correct background color */
html {
  color-scheme: light;
  background-color: var(--background);
}

/* In dark mode, switch both the WebKit chrome tint and the
   safe-area / overscroll fill to match the dark background */
html.dark {
  color-scheme: dark;
  background-color: var(--background);
}
```

- `color-scheme` values match the existing `theme-color` meta tags already present in `index.html`
- `background-color` uses the existing `--background` CSS custom property, so it automatically adapts to the correct light/dark value without hardcoding any colors
- The `min-height: -webkit-fill-available` is a well-established Safari workaround; the standard `100vh` fallback immediately above it handles all other browsers

## Testing

1. Open the DocsGPT app on an iPhone/iPad in Safari
2. Enable **Dark Mode** in iOS Settings → Display & Brightness
3. Verify no white borders or lines appear at the top or bottom of the screen
4. Pull down to trigger rubber-band scroll — the overscroll region should match the dark background (`#222327`) instead of being white
5. Verify light mode is unaffected — no visual changes in light mode