### PR TITLE
Minor UI polish

### DIFF
--- a/frontend/src/admin/index.tsx
+++ b/frontend/src/admin/index.tsx
@@ -17,7 +17,7 @@ import Users from './Users';
 const TABS = [
   { key: 'overview', label: 'Overview', path: '/admin' },
   { key: 'users', label: 'Users', path: '/admin/users' },
-  { key: 'admins', label: 'Admins', path: '/admin/admins' },
+  { key: 'admins', label: 'Admins', path: '/admin/roles' },
   { key: 'usage', label: 'Usage', path: '/admin/usage' },
   { key: 'audit', label: 'Audit', path: '/admin/audit' },
 ];
@@ -61,7 +61,7 @@ export default function Admin() {
         <Routes>
           <Route index element={<Overview />} />
           <Route path="users" element={<Users />} />
-          <Route path="admins" element={<Admins />} />
+          <Route path="roles" element={<Admins />} />
           <Route path="usage" element={<Usage />} />
           <Route path="audit" element={<Audit />} />
           <Route path="*" element={<Navigate to="/admin" replace />} />

--- a/frontend/src/components/ui/modal.tsx
+++ b/frontend/src/components/ui/modal.tsx
@@ -136,8 +136,7 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(function Modal(
               // overflow-y-auto forces overflow-x:auto and establishes a clip
               // box. pt-3 reserves room so a floating Input label (which sits
               // ~10px above its field) at the top of the scroll area isn't
-              // clipped; px-1 keeps focus-ring box-shadows inside the clip rect.
-              'no-scrollbar text-foreground overflow-y-auto px-1 pt-3',
+              'no-scrollbar text-foreground overflow-y-auto px-1 pt-3 pb-0.5',
               isMobileSheet && 'min-h-0 grow',
               contentClassName,
             )}

--- a/frontend/src/settings/Prompts.tsx
+++ b/frontend/src/settings/Prompts.tsx
@@ -309,19 +309,20 @@ export default function Prompts({
                       />
                     </>
                   )}
-                  <button
-                    type="button"
-                    onClick={() => setOpen(!open)}
-                    className="text-muted-foreground hover:bg-foreground/15 hover:text-foreground dark:hover:bg-foreground/20 focus-visible:ring-ring/50 my-auto mr-2.5 ml-1 shrink-0 rounded-full p-1.5 transition-colors outline-none focus-visible:ring-[3px]"
-                    aria-label="Toggle prompt list"
-                  >
-                    <ChevronDown
-                      className={cn(
-                        'h-4 w-4 transition-transform',
-                        open && 'rotate-180',
-                      )}
-                    />
-                  </button>
+                  <PopoverTrigger asChild>
+                    <button
+                      type="button"
+                      className="text-muted-foreground hover:bg-foreground/15 hover:text-foreground dark:hover:bg-foreground/20 focus-visible:ring-ring/50 my-auto mr-2.5 ml-1 shrink-0 rounded-full p-1.5 transition-colors outline-none focus-visible:ring-[3px]"
+                      aria-label="Toggle prompt list"
+                    >
+                      <ChevronDown
+                        className={cn(
+                          'h-4 w-4 transition-transform',
+                          open && 'rotate-180',
+                        )}
+                      />
+                    </button>
+                  </PopoverTrigger>
                 </div>
               </PopoverAnchor>
               <PopoverContent

--- a/frontend/src/teams/TeamSwitcher.tsx
+++ b/frontend/src/teams/TeamSwitcher.tsx
@@ -172,13 +172,16 @@ export default function TeamSwitcher({
         <DropdownMenuSeparator />
 
         {/* Personal account entry */}
-        <DropdownMenuItem onSelect={() => selectTeam(null)}>
-          <Building2 className="size-4" strokeWidth={1.75} />
-          <span className="min-w-0 flex-1 truncate">
-            {t('teams.switcher.personal')}
-          </span>
-          {!currentTeam && <Check className="size-4 shrink-0" />}
-        </DropdownMenuItem>
+        {
+          currentTeam &&
+          <DropdownMenuItem onSelect={() => selectTeam(null)}>
+            <Building2 className="size-4" strokeWidth={1.75} />
+            <span className="min-w-0 flex-1 truncate">
+              {t('teams.switcher.personal')}
+            </span>
+            {!currentTeam && <Check className="size-4 shrink-0" />}
+          </DropdownMenuItem>
+        }
 
         {/* Other teams to switch to */}
         {otherTeams.map((team) => (


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  - renamed the /admin/admins to /admin/roles to make it sound better
  - fixed the prompt selection dropdown to prevent reopening of the dropdown when the model is closed with the chevron button click
  - removed the option to select the personal account when it is selected already(currentTeam is Null)
  - fixed the team name input, was cropped from the bottom in the create team modal
- **Why was this change needed?** (You can also link to an open issue here)
  UI UX