### PR TITLE
fix: replace print() with logger in encryption.py and classic_rag.py

### DIFF
--- a/application/retriever/classic_rag.py
+++ b/application/retriever/classic_rag.py
@@ -7,6 +7,8 @@ from application.retriever.labels import labels_from_metadata
 from application.utils import num_tokens_from_string
 from application.vectorstore.vector_creator import VectorCreator
 
+logger = logging.getLogger(__name__)
+
 
 class ClassicRAG(BaseRetriever):
     def __init__(
@@ -33,14 +35,14 @@ class ClassicRAG(BaseRetriever):
             try:
                 self.chunks = int(chunks)
             except ValueError:
-                logging.warning(
+                logger.warning(
                     f"Invalid chunks value '{chunks}', using default value 2"
                 )
                 self.chunks = 2
         else:
             self.chunks = chunks
         user_id = decoded_token.get("sub") if decoded_token else "default"
-        logging.info(
+        logger.info(
             f"ClassicRAG initialized with chunks={self.chunks}, user_id={user_id}, "
             f"sources={'active_docs' in source and source['active_docs'] is not None}"
         )
@@ -99,13 +101,13 @@ class ClassicRAG(BaseRetriever):
     def _validate_vectorstore_config(self):
         """Validate vectorstore IDs and remove any empty/invalid entries"""
         if not self.vectorstores:
-            logging.warning("No vectorstores configured for retrieval")
+            logger.warning("No vectorstores configured for retrieval")
             return
         invalid_ids = [
             vs_id for vs_id in self.vectorstores if not vs_id or not vs_id.strip()
         ]
         if invalid_ids:
-            logging.warning(f"Found invalid vectorstore IDs: {invalid_ids}")
+            logger.warning(f"Found invalid vectorstore IDs: {invalid_ids}")
             self.vectorstores = [
                 vs_id for vs_id in self.vectorstores if vs_id and vs_id.strip()
             ]
@@ -138,10 +140,10 @@ class ClassicRAG(BaseRetriever):
                 model=getattr(self.llm, "model_id", None) or self.model_id,
                 messages=messages,
             )
-            print(f"Rephrased query: {rephrased_query}")
+            logger.debug(f"Rephrased query: {rephrased_query}")
             return rephrased_query if rephrased_query else self.original_question
         except Exception as e:
-            logging.error(f"Error rephrasing query: {e}", exc_info=True)
+            logger.error(f"Error rephrasing query: {e}", exc_info=True)
             return self.original_question
 
     def _fetch_candidates(self, docsearch, question, src_k, score_threshold):
@@ -161,7 +163,7 @@ class ClassicRAG(BaseRetriever):
 
     def _get_data(self):
         if self.chunks == 0 or not self.vectorstores:
-            logging.info(
+            logger.info(
                 f"ClassicRAG._get_data: Skipping retrieval - chunks={self.chunks}, "
                 f"vectorstores_count={len(self.vectorstores) if self.vectorstores else 0}"
             )
@@ -238,13 +240,13 @@ class ClassicRAG(BaseRetriever):
                         break
 
                 except Exception as e:
-                    logging.error(
+                    logger.error(
                         f"Error searching vectorstore {vectorstore_id}: {e}",
                         exc_info=True,
                     )
                     continue
 
-        logging.info(
+        logger.info(
             f"ClassicRAG._get_data: Retrieval complete - retrieved {len(all_docs)} documents "
             f"(requested chunks={self.chunks}, chunks_per_source={chunks_per_source}, "
             f"cumulative_tokens={cumulative_tokens}/{token_budget})"

--- a/application/security/encryption.py
+++ b/application/security/encryption.py
@@ -1,6 +1,9 @@
 import base64
 import json
+import logging
 import os
+
+logger = logging.getLogger(__name__)
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
@@ -45,7 +48,7 @@ def encrypt_credentials(credentials: dict, user_id: str) -> str:
         result = salt + iv + encrypted_data
         return base64.b64encode(result).decode()
     except Exception as e:
-        print(f"Warning: Failed to encrypt credentials: {e}")
+        logger.warning(f"Failed to encrypt credentials: {e}")
         return ""
 
 
@@ -69,7 +72,7 @@ def decrypt_credentials(encrypted_data: str, user_id: str) -> dict:
 
         return json.loads(decrypted_data.decode())
     except Exception as e:
-        print(f"Warning: Failed to decrypt credentials: {e}")
+        logger.warning(f"Failed to decrypt credentials: {e}")
         return {}
 
 

--- a/application/security/encryption.py
+++ b/application/security/encryption.py
@@ -3,14 +3,14 @@ import json
 import logging
 import os
 
-logger = logging.getLogger(__name__)
-
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
 from application.core.settings import settings
+
+logger = logging.getLogger(__name__)
 
 
 def _derive_key(user_id: str, salt: bytes) -> bytes:


### PR DESCRIPTION
## Summary

- Replaces 3 bare `print()` calls with `logger.debug()` / `logger.warning()` using the standard `logging` module
- Adds `import logging` + `logger = logging.getLogger(__name__)` to `encryption.py` which had none
- Adds `logger = logging.getLogger(__name__)` to `classic_rag.py` and migrates all bare `logging.xxx()` calls to use it

## Motivation

Print statements bypass log-level filtering and structured logging pipelines. The encryption failure messages and rephrased query text could be exposed in production stdout without redaction.

Closes #2561

## Test Plan
- [x] Trigger a query rephrase and verify debug log appears at DEBUG level, not stdout
- [x] Trigger an encryption/decryption error and verify warning appears in logs, not stdout
- [x] Confirm no `print()` calls remain in the modified files