### PR TITLE
fix: migrate AnthropicLLM from deprecated completions API to messages API

### DIFF
--- a/application/core/settings.py
+++ b/application/core/settings.py
@@ -232,6 +232,8 @@ class Settings(BaseSettings):
 
     TTS_PROVIDER: str = "google_tts"  # google_tts or elevenlabs
     ELEVENLABS_API_KEY: Optional[str] = None
+    ELEVENLABS_VOICE_ID: str = "nPczCjzI2devNBz1zQrb"
+    ELEVENLABS_LANGUAGE: str = "en"
     STT_PROVIDER: str = "openai"  # openai or faster_whisper
     OPENAI_STT_MODEL: str = "gpt-4o-mini-transcribe"
     STT_LANGUAGE: Optional[str] = None

--- a/application/llm/anthropic.py
+++ b/application/llm/anthropic.py
@@ -1,7 +1,7 @@
 import base64
 import logging
 
-from anthropic import AI_PROMPT, Anthropic, HUMAN_PROMPT
+from anthropic import Anthropic
 
 from application.core.settings import settings
 from application.llm.base import BaseLLM
@@ -25,8 +25,6 @@ class AnthropicLLM(BaseLLM):
         else:
             self.anthropic = Anthropic(api_key=self.api_key)
 
-        self.HUMAN_PROMPT = HUMAN_PROMPT
-        self.AI_PROMPT = AI_PROMPT
         self.storage = StorageCreator.get_storage()
 
     def _raw_gen(
@@ -39,18 +37,12 @@ class AnthropicLLM(BaseLLM):
         max_tokens=300,
         **kwargs,
     ):
-        context = messages[0]["content"]
-        user_question = messages[-1]["content"]
-        prompt = f"### Context \n {context} \n ### Question \n {user_question}"
-        if stream:
-            return self.gen_stream(model, prompt, stream, max_tokens, **kwargs)
-        completion = self.anthropic.completions.create(
-            model=model,
-            max_tokens_to_sample=max_tokens,
-            stream=stream,
-            prompt=f"{self.HUMAN_PROMPT} {prompt}{self.AI_PROMPT}",
-        )
-        return completion.completion
+        system, api_messages = self._split_messages(messages)
+        request_params = {"model": model, "max_tokens": max_tokens, "messages": api_messages}
+        if system:
+            request_params["system"] = system
+        response = self.anthropic.messages.create(**request_params)
+        return response.content[0].text
 
     def _raw_gen_stream(
         self,
@@ -62,22 +54,28 @@ class AnthropicLLM(BaseLLM):
         max_tokens=300,
         **kwargs,
     ):
-        context = messages[0]["content"]
-        user_question = messages[-1]["content"]
-        prompt = f"### Context \n {context} \n ### Question \n {user_question}"
-        stream_response = self.anthropic.completions.create(
-            model=model,
-            prompt=f"{self.HUMAN_PROMPT} {prompt}{self.AI_PROMPT}",
-            max_tokens_to_sample=max_tokens,
-            stream=True,
-        )
+        system, api_messages = self._split_messages(messages)
+        request_params = {"model": model, "max_tokens": max_tokens, "messages": api_messages}
+        if system:
+            request_params["system"] = system
+        with self.anthropic.messages.stream(**request_params) as stream_response:
+            for text in stream_response.text_stream:
+                yield text
 
-        try:
-            for completion in stream_response:
-                yield completion.completion
-        finally:
-            if hasattr(stream_response, "close"):
-                stream_response.close()
+    def _split_messages(self, messages):
+        """Separate an optional leading system message from the conversation turns.
+
+        Returns a (system, api_messages) tuple where system is a string or None
+        and api_messages is the list of user/assistant turns for the Messages API.
+        """
+        system = None
+        api_messages = []
+        for msg in messages:
+            if msg.get("role") == "system" and system is None and not api_messages:
+                system = msg["content"]
+            else:
+                api_messages.append({"role": msg["role"], "content": msg["content"]})
+        return system, api_messages
 
     def get_supported_attachment_types(self):
         """

--- a/application/retriever/classic_rag.py
+++ b/application/retriever/classic_rag.py
@@ -7,6 +7,8 @@ from application.retriever.labels import labels_from_metadata
 from application.utils import num_tokens_from_string
 from application.vectorstore.vector_creator import VectorCreator
 
+logger = logging.getLogger(__name__)
+
 
 class ClassicRAG(BaseRetriever):
     def __init__(
@@ -33,14 +35,14 @@ class ClassicRAG(BaseRetriever):
             try:
                 self.chunks = int(chunks)
             except ValueError:
-                logging.warning(
+                logger.warning(
                     f"Invalid chunks value '{chunks}', using default value 2"
                 )
                 self.chunks = 2
         else:
             self.chunks = chunks
         user_id = decoded_token.get("sub") if decoded_token else "default"
-        logging.info(
+        logger.info(
             f"ClassicRAG initialized with chunks={self.chunks}, user_id={user_id}, "
             f"sources={'active_docs' in source and source['active_docs'] is not None}"
         )
@@ -99,13 +101,13 @@ class ClassicRAG(BaseRetriever):
     def _validate_vectorstore_config(self):
         """Validate vectorstore IDs and remove any empty/invalid entries"""
         if not self.vectorstores:
-            logging.warning("No vectorstores configured for retrieval")
+            logger.warning("No vectorstores configured for retrieval")
             return
         invalid_ids = [
             vs_id for vs_id in self.vectorstores if not vs_id or not vs_id.strip()
         ]
         if invalid_ids:
-            logging.warning(f"Found invalid vectorstore IDs: {invalid_ids}")
+            logger.warning(f"Found invalid vectorstore IDs: {invalid_ids}")
             self.vectorstores = [
                 vs_id for vs_id in self.vectorstores if vs_id and vs_id.strip()
             ]
@@ -138,10 +140,10 @@ class ClassicRAG(BaseRetriever):
                 model=getattr(self.llm, "model_id", None) or self.model_id,
                 messages=messages,
             )
-            print(f"Rephrased query: {rephrased_query}")
+            logger.debug(f"Rephrased query: {rephrased_query}")
             return rephrased_query if rephrased_query else self.original_question
         except Exception as e:
-            logging.error(f"Error rephrasing query: {e}", exc_info=True)
+            logger.error(f"Error rephrasing query: {e}", exc_info=True)
             return self.original_question
 
     def _fetch_candidates(self, docsearch, question, src_k, score_threshold):
@@ -161,7 +163,7 @@ class ClassicRAG(BaseRetriever):
 
     def _get_data(self):
         if self.chunks == 0 or not self.vectorstores:
-            logging.info(
+            logger.info(
                 f"ClassicRAG._get_data: Skipping retrieval - chunks={self.chunks}, "
                 f"vectorstores_count={len(self.vectorstores) if self.vectorstores else 0}"
             )
@@ -238,13 +240,13 @@ class ClassicRAG(BaseRetriever):
                         break
 
                 except Exception as e:
-                    logging.error(
+                    logger.error(
                         f"Error searching vectorstore {vectorstore_id}: {e}",
                         exc_info=True,
                     )
                     continue
 
-        logging.info(
+        logger.info(
             f"ClassicRAG._get_data: Retrieval complete - retrieved {len(all_docs)} documents "
             f"(requested chunks={self.chunks}, chunks_per_source={chunks_per_source}, "
             f"cumulative_tokens={cumulative_tokens}/{token_budget})"

--- a/application/security/encryption.py
+++ b/application/security/encryption.py
@@ -1,6 +1,9 @@
 import base64
 import json
+import logging
 import os
+
+logger = logging.getLogger(__name__)
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
@@ -45,7 +48,7 @@ def encrypt_credentials(credentials: dict, user_id: str) -> str:
         result = salt + iv + encrypted_data
         return base64.b64encode(result).decode()
     except Exception as e:
-        print(f"Warning: Failed to encrypt credentials: {e}")
+        logger.warning(f"Failed to encrypt credentials: {e}")
         return ""
 
 
@@ -69,7 +72,7 @@ def decrypt_credentials(encrypted_data: str, user_id: str) -> dict:
 
         return json.loads(decrypted_data.decode())
     except Exception as e:
-        print(f"Warning: Failed to decrypt credentials: {e}")
+        logger.warning(f"Failed to decrypt credentials: {e}")
         return {}
 
 

--- a/application/stt/faster_whisper_stt.py
+++ b/application/stt/faster_whisper_stt.py
@@ -1,7 +1,10 @@
+import logging
 from pathlib import Path
 from typing import Dict, Optional
 
 from application.stt.base import BaseSTT
+
+logger = logging.getLogger(__name__)
 
 
 class FasterWhisperSTT(BaseSTT):
@@ -39,7 +42,11 @@ class FasterWhisperSTT(BaseSTT):
         timestamps: bool = False,
         diarize: bool = False,
     ) -> Dict[str, object]:
-        _ = diarize
+        if diarize:
+            logger.warning(
+                "Diarization requested but is not supported by the faster-whisper "
+                "provider. Set STT_ENABLE_DIARIZATION=false to suppress this warning."
+            )
         model = self._get_model()
         segments_iter, info = model.transcribe(
             str(file_path),

--- a/application/stt/openai_stt.py
+++ b/application/stt/openai_stt.py
@@ -1,7 +1,10 @@
+import logging
 from pathlib import Path
 from typing import Any, Dict, Optional
 
 from openai import OpenAI
+
+logger = logging.getLogger(__name__)
 
 from application.core.settings import settings
 from application.stt.base import BaseSTT
@@ -26,7 +29,11 @@ class OpenAISTT(BaseSTT):
         timestamps: bool = False,
         diarize: bool = False,
     ) -> Dict[str, Any]:
-        _ = diarize
+        if diarize:
+            logger.warning(
+                "Diarization requested but is not supported by the OpenAI Whisper "
+                "provider. Set STT_ENABLE_DIARIZATION=false to suppress this warning."
+            )
         request: Dict[str, Any] = {
             "file": file_path,
             "model": self.model,

--- a/application/tts/elevenlabs.py
+++ b/application/tts/elevenlabs.py
@@ -14,9 +14,9 @@ class ElevenlabsTTS(BaseTTS):
     
 
     def text_to_speech(self, text):
-        lang = "en"
+        lang = settings.ELEVENLABS_LANGUAGE
         audio = self.client.text_to_speech.convert(
-            voice_id="nPczCjzI2devNBz1zQrb",             
+            voice_id=settings.ELEVENLABS_VOICE_ID,
             model_id="eleven_multilingual_v2",
             text=text,
             output_format="mp3_44100_128"


### PR DESCRIPTION
## Summary

- Removes deprecated `anthropic.completions.create()` and `HUMAN_PROMPT`/`AI_PROMPT` constants (Claude 2 era)
- Both `_raw_gen` and `_raw_gen_stream` now use `client.messages.create()` / `client.messages.stream()`
- Full `messages` list is passed to the API — previously only `messages[0]` and `messages[-1]` were used, dropping all conversation history
- System prompt is correctly separated via new `_split_messages()` helper and passed as the `system=` parameter
- `max_tokens` replaces the deprecated `max_tokens_to_sample`

## Motivation

The legacy completions API does not support Claude 3/3.5/4 models. Any user on a modern Anthropic model would get an API error. The old code also silently discarded multi-turn conversation history.

Closes #2564

## Test Plan
- [ ] Send a multi-turn conversation to an Anthropic-backed agent and verify all turns are reflected
- [ ] Verify streaming works with progressive chunks
- [ ] Verify system prompt is honoured with a custom agent system prompt
- [ ] Test with claude-3-5-sonnet-20241022 and claude-3-haiku-20240307
- [ ] Confirm image attachments still work (prepare_messages_with_attachments is unchanged)