### PR TITLE
fix(parser): harden classic chunker against oversized headers

### DIFF
--- a/application/parser/chunking.py
+++ b/application/parser/chunking.py
@@ -50,9 +50,16 @@ class Chunker:
         current_position = 0
         part_index = 0
         while current_position < len(body_tokens):
-            end_position = current_position + self.max_tokens - len(header_tokens)
-            chunk_tokens = (header_tokens + body_tokens[current_position:end_position]
-                            if self.duplicate_headers or part_index == 0 else body_tokens[current_position:end_position])
+            include_header = self.duplicate_headers or part_index == 0
+            active_header = header_tokens if include_header else []
+            # Reserve room for the header inside the token window, but always
+            # leave space for at least one body token so the loop keeps making
+            # forward progress even when the header alone meets or exceeds
+            # ``max_tokens``. Without this floor the step can be <= 0, which
+            # produces empty, duplicated, and oversized chunks.
+            body_capacity = max(self.max_tokens - len(active_header), 1)
+            end_position = current_position + body_capacity
+            chunk_tokens = active_header + body_tokens[current_position:end_position]
             chunk_text = self.encoding.decode(chunk_tokens)
             new_doc = Document(
                 text=chunk_text,
@@ -63,7 +70,6 @@ class Chunker:
             split_docs.append(new_doc)
             current_position = end_position
             part_index += 1
-            header_tokens = []
         return split_docs
 
     def classic_chunk(self, documents: List[Document]) -> List[Document]:

--- a/tests/parser/test_chunking.py
+++ b/tests/parser/test_chunking.py
@@ -147,6 +147,77 @@ class TestSplitDocument:
             assert "token_count" in split_doc.extra_info
 
 
+@pytest.mark.unit
+class TestSplitDocumentHeaderEdgeCases:
+    """Regression tests for split_document when the header is large or
+    when ``duplicate_headers`` is enabled.
+
+    Previously, when the header (first three lines) tokenised to >=
+    ``max_tokens``, the per-chunk step ``max_tokens - len(header_tokens)``
+    went non-positive. Negative slicing then produced an oversized first
+    chunk, an empty chunk, and re-chunked/duplicated body content. The
+    ``duplicate_headers`` flag was also a no-op past the first chunk
+    because ``header_tokens`` was reset to ``[]`` after each iteration.
+    """
+
+    def test_header_larger_than_max_tokens_conserves_body(self):
+        # Three long lines so the header alone exceeds max_tokens.
+        long_line = "alpha beta gamma delta epsilon zeta eta theta"
+        header_text = f"{long_line}\n{long_line}\n{long_line}\n"
+        body_text = "word " * 60
+        chunker = Chunker(max_tokens=20, min_tokens=5)
+
+        header, body = chunker.separate_header_and_body(header_text + body_text)
+        header_len = len(chunker.encoding.encode(header))
+        body_len = len(chunker.encoding.encode(body))
+        assert header_len >= chunker.max_tokens  # precondition: triggers the bug
+
+        result = chunker.split_document(Document(text=header_text + body_text, doc_id="d1"))
+
+        token_counts = [d.extra_info["token_count"] for d in result]
+        # No empty chunks.
+        assert all(tc > 0 for tc in token_counts)
+        # No corrupted oversize: a chunk is at most the (unavoidable) header
+        # plus one body window.
+        assert all(tc <= header_len + chunker.max_tokens for tc in token_counts)
+        # Every body token is emitted exactly once and the header exactly
+        # once (duplicate_headers defaults to False): total == header + body.
+        assert sum(token_counts) == header_len + body_len
+
+    def test_header_larger_than_max_tokens_terminates_and_keeps_header(self):
+        long_line = "alpha beta gamma delta epsilon zeta eta theta"
+        header_text = f"{long_line}\n{long_line}\n{long_line}\n"
+        doc = Document(text=header_text + "word " * 40, doc_id="d1")
+        chunker = Chunker(max_tokens=15, min_tokens=5)
+
+        result = chunker.split_document(doc)
+
+        assert len(result) > 0
+        assert "alpha" in result[0].text  # header preserved on first chunk
+        # Sequential, unique part ids.
+        assert [d.doc_id for d in result] == [f"d1-{i}" for i in range(len(result))]
+
+    def test_duplicate_headers_repeats_header_on_every_chunk(self):
+        text = "TITLE\nAUTHOR\nDATE\n" + "word " * 120
+        chunker = Chunker(max_tokens=30, min_tokens=5, duplicate_headers=True)
+
+        result = chunker.split_document(Document(text=text, doc_id="d1"))
+
+        assert len(result) > 1
+        # With duplicate_headers=True the header must appear in every chunk.
+        assert all("TITLE" in d.text for d in result)
+
+    def test_duplicate_headers_false_only_first_chunk_has_header(self):
+        text = "TITLE\nAUTHOR\nDATE\n" + "word " * 120
+        chunker = Chunker(max_tokens=30, min_tokens=5, duplicate_headers=False)
+
+        result = chunker.split_document(Document(text=text, doc_id="d1"))
+
+        assert len(result) > 1
+        assert "TITLE" in result[0].text
+        assert all("TITLE" not in d.text for d in result[1:])
+
+
 # =====================================================================
 # Classic Chunk
 # =====================================================================


### PR DESCRIPTION
## What & why

`Chunker.split_document` (the `classic_chunk` strategy in `application/parser/chunking.py`) derives its per-chunk step from `max_tokens - len(header_tokens)`. The header is the document's first three lines (`separate_header_and_body`), and it is prepended to the first chunk so each chunk stays within `max_tokens`.

When the header tokenises to **`>= max_tokens`** that step becomes **non-positive**, and Python's negative list slicing then silently corrupts the output:

- an **oversized first chunk** (header + a huge negative-indexed body slice),
- an **empty chunk** (`token_count == 0`),
- and the body gets **re-chunked / duplicated** from the start.

This is reachable in normal operation because `max_tokens` and `duplicate_headers` come straight from user config (`cfg.chunking.*` in `application/worker.py`). A small configured chunk size plus a document whose first three lines are long (long title / metadata / front-matter) is enough to trigger it.

While fixing this I also noticed `duplicate_headers` was a **no-op past the first chunk**: `header_tokens` was reset to `[]` at the end of every iteration, so the `self.duplicate_headers or part_index == 0` condition could never include the header again.

## Repro

`max_tokens=20`, a 36-token header, 61 tokens of body:

| | before | after |
|---|---|---|
| chunks | 5 | 4 |
| token counts | `[81, 0, 20, 20, 17]` | `[37, 20, 20, 20]` |
| empty chunks | **1** | 0 |
| largest chunk | **81** (4× the limit) | 37 (header + 1 body token — the minimum possible when the header alone exceeds the limit) |

`duplicate_headers=True`, header `TITLE\nAUTHOR\nDATE\n`:

| | before | after |
|---|---|---|
| chunks containing the header | **1 / 5** | 6 / 6 |

## The fix

`split_document` now mirrors the robustness already present in the sibling strategies in `chunking_strategies.py` (which clamp `max_tokens = max(1, …)` and never emit empty pieces):

- Reserve header space **per chunk** with a floor of one body token, so the loop always makes forward progress even when the header alone meets or exceeds `max_tokens`.
- Include the header on every chunk when `duplicate_headers` is set, and only on the first chunk otherwise — **default behaviour (`duplicate_headers=False`) is unchanged** and produces byte-identical chunks to before for the normal `header < max_tokens` path.

```diff
-            end_position = current_position + self.max_tokens - len(header_tokens)
-            chunk_tokens = (header_tokens + body_tokens[current_position:end_position]
-                            if self.duplicate_headers or part_index == 0 else body_tokens[current_position:end_position])
+            include_header = self.duplicate_headers or part_index == 0
+            active_header = header_tokens if include_header else []
+            body_capacity = max(self.max_tokens - len(active_header), 1)
+            end_position = current_position + body_capacity
+            chunk_tokens = active_header + body_tokens[current_position:end_position]
```

## Tests

Added 4 regression tests in `tests/parser/test_chunking.py` (`TestSplitDocumentHeaderEdgeCases`) covering the large-header edge case (token conservation, no empty / corrupted-oversize chunks) and both `duplicate_headers` modes.

The two key tests **fail on `main` and pass with this change**; the full file stays green:

```
$ python -m pytest tests/parser/test_chunking.py
...
28 passed
```

The large-header tests fail against the unpatched code, confirming they pin the bug:

```
FAILED ...::test_header_larger_than_max_tokens_conserves_body   - assert all(tc > 0 ...)  # empty chunk
FAILED ...::test_duplicate_headers_repeats_header_on_every_chunk - assert all("TITLE" in d.text ...)
```

> No UI surface for this change — it's pure backend chunking logic, so the pytest output above stands in for screenshots. `ruff check` passes on both files.
