### PR TITLE
fix: iOS Safari dark mode border rendering in .dark class

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -893,6 +893,8 @@ Avoid over-scrolling in mobile browsers
   --sidebar-border: #2b2c31;
   --sidebar-ring: #976af3;
   --answer-bubble: #2e303e;
+  /* Fix: iOS Safari does not apply CSS variables to borders in dark mode */
+    color-scheme: dark;
 }
 
 /*


### PR DESCRIPTION
## Problem
On iOS Safari, borders appear white even when dark theme is enabled. 
This is because iOS Safari does not correctly apply CSS variables to 
border colors in dark mode.

## Fix
Added `color-scheme: dark` property to the `.dark` class in 
`index.css`. This explicitly tells iOS Safari that the component 
is dark-themed, ensuring borders, inputs and scrollbars render 
correctly instead of defaulting to white.

## Changes
- `frontend/src/index.css` → added `color-scheme: dark` inside 
  `.dark` block

Fixes #2488