### PR TITLE
fix: enable Chokidar polling for Vite HMR in Docker on Windows

### DIFF
--- a/deployment/docker-compose-local.yaml
+++ b/deployment/docker-compose-local.yaml
@@ -7,6 +7,7 @@ services:
       - VITE_API_HOST=http://localhost:7091
       - VITE_API_STREAMING=$VITE_API_STREAMING
       - VITE_EMBEDDINGS_NAME=$EMBEDDINGS_NAME
+      - DOCKER=true
     ports:
       - "5173:5173"
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -22,6 +22,12 @@ export default defineConfig(({ mode }) => {
             .map((h) => h.trim())
             .filter(Boolean)
         : [],
+      // Use polling for file watching when running inside Docker.
+      // Native fs events do not propagate from Windows hosts into Linux
+      // containers, so Chokidar falls back to polling which works reliably.
+      watch: env.DOCKER
+        ? { usePolling: true, interval: 300 }
+        : undefined,
     },
     test: {
       environment: 'happy-dom',


### PR DESCRIPTION
## Summary

Fixes #2456

Native fs events do not propagate from Windows hosts into Linux containers, causing Vite's HMR to stop detecting file changes when using .

## Changes

- ****: When the  environment variable is set, Chokidar falls back to polling with a 300ms interval. This reliably detects file changes across the Docker volume mount boundary on Windows.
- ****: Added  to the frontend service environment.

## How it works

Vite uses Chokidar for file watching. On Linux, Chokidar uses  which works natively. However, when running Docker on Windows, the Linux container cannot receive filesystem events from the Windows host through the mounted volume. Polling bypasses this limitation by periodically checking file timestamps.

The  option is only enabled when  is set, so native Linux/Mac development environments are not affected by the additional CPU overhead.

## Testing

1. Run 
2. Edit any file in 
3. Vite HMR should now detect the change and hot-reload automatically