### PR TITLE
fix: batch embedding and chunk overlap for RAG quality (#2500)

### DIFF
--- a/application/parser/chunking.py
+++ b/application/parser/chunking.py
@@ -22,11 +22,13 @@ class Chunker:
         max_tokens: int = 2000,
         min_tokens: int = 150,
         duplicate_headers: bool = False,
+        chunk_overlap: int = 200,
     ):
         self.chunking_strategy = chunking_strategy
         self.max_tokens = max_tokens
         self.min_tokens = min_tokens
         self.duplicate_headers = duplicate_headers
+        self.chunk_overlap = chunk_overlap
         self.encoding = get_encoding()
 
     def separate_header_and_body(self, text: str) -> Tuple[str, str]:
@@ -61,7 +63,10 @@ class Chunker:
                 extra_info={**(doc.extra_info or {}), "token_count": len(chunk_tokens)}
             )
             split_docs.append(new_doc)
-            current_position = end_position
+            # Move forward by max_tokens minus overlap to preserve context
+            # at chunk boundaries. Without overlap, sentences split at
+            # boundaries are lost between consecutive chunks.
+            current_position = end_position - self.chunk_overlap
             part_index += 1
             header_tokens = []
         return split_docs

--- a/application/parser/embedding_pipeline.py
+++ b/application/parser/embedding_pipeline.py
@@ -23,6 +23,11 @@ class EmbeddingPipelineError(Exception):
     """
 
 
+# Batch size for embedding. Matches MongoDB's internal batch_size=100.
+# Reduces sequential HTTP requests from N (one per chunk) to N/100.
+EMBED_BATCH_SIZE = 100
+
+
 def sanitize_content(content: str) -> str:
     """
     Remove NUL characters that can cause vector store ingestion to fail.
@@ -45,23 +50,50 @@ def sanitize_content(content: str) -> str:
 @retry(tries=3, delay=5, backoff=2)
 def add_text_to_store_with_retry(store: Any, doc: Any, source_id: str) -> None:
     """Add a document's text and metadata to the vector store with retry logic.
-    
+
     Args:
         store: The vector store object.
         doc: The document to be added.
         source_id: Unique identifier for the source.
-        
+
     Raises:
         Exception: If document addition fails after all retry attempts.
     """
     try:
         # Sanitize content to remove NUL characters that cause ingestion failures
         doc.page_content = sanitize_content(doc.page_content)
-        
+
         doc.metadata["source_id"] = str(source_id)
         store.add_texts([doc.page_content], metadatas=[doc.metadata])
     except Exception as e:
         logging.error(f"Failed to add document with retry: {e}", exc_info=True)
+        raise
+
+
+@retry(tries=3, delay=5, backoff=2)
+def add_texts_batch_with_retry(
+    store: Any, texts: List[str], metadatas: List[dict], source_id: str
+) -> None:
+    """Add a batch of documents' texts and metadata to the vector store.
+
+    Reduces sequential HTTP requests from N (one per chunk) to N/BATCH_SIZE
+    for remote embeddings (e.g. OpenAI, Anthropic).
+
+    Args:
+        store: The vector store object.
+        texts: List of document texts to be added.
+        metadatas: List of metadata dicts for each text.
+        source_id: Unique identifier for the source.
+
+    Raises:
+        Exception: If batch addition fails after all retry attempts.
+    """
+    try:
+        clean_texts = [sanitize_content(t) for t in texts]
+        clean_metadatas = [{**m, "source_id": str(source_id)} for m in metadatas]
+        store.add_texts(clean_texts, metadatas=clean_metadatas)
+    except Exception as e:
+        logging.error(f"Failed to add batch with retry: {e}", exc_info=True)
         raise
 
 
@@ -259,26 +291,28 @@ def embed_and_store_documents(
         # tripwire still validates ``embedded == total`` afterwards.
         loop_start = total_docs
 
-    # Process and embed documents
+    # Process and embed documents in batches for better performance.
+    # Remote embeddings (OpenAI, Anthropic) benefit from batched requests:
+    # N chunks → N/BATCH_SIZE HTTP requests instead of N sequential ones.
     chunk_error: Exception | None = None
     failed_idx: int | None = None
     last_published_pct = -1
     source_id_str = str(source_id)
     progress_span = progress_end - progress_start
-    for idx in tqdm(
-        range(loop_start, total_docs),
-        desc="Embedding 🦖",
-        unit="docs",
-        total=total_docs - loop_start,
-        bar_format="{l_bar}{bar}| Time Left: {remaining}",
-    ):
-        doc = docs[idx]
-        try:
+    remaining_indices = list(range(loop_start, total_docs))
+
+    for batch_start in range(0, len(remaining_indices), EMBED_BATCH_SIZE):
+        batch_indices = remaining_indices[batch_start:batch_start + EMBED_BATCH_SIZE]
+        batch_texts: List[str] = []
+        batch_metadatas: List[dict] = []
+        batch_end_idx = batch_indices[-1]
+
+        for idx in batch_indices:
+            doc = docs[idx]
             # Map the embed loop into [progress_start, progress_end].
             progress = progress_start + int(
                 ((idx + 1) / total_docs) * progress_span
             )
-            task_status.update_state(state="PROGRESS", meta={"current": progress})
 
             # SSE push for sub-second upload-toast updates. Throttled to one
             # event per percent so a 10k-chunk ingest emits ~100 events,
@@ -298,20 +332,39 @@ def embed_and_store_documents(
                 )
                 last_published_pct = progress
 
-            # Add document to vector store
-            add_text_to_store_with_retry(store, doc, source_id)
-            _record_progress(source_id, last_index=idx, embedded_chunks=idx + 1)
+            batch_texts.append(doc.page_content)
+            batch_metadatas.append(doc.metadata)
+
+        try:
+            # Update progress bar for this batch
+            progress = progress_start + int(
+                ((batch_end_idx + 1) / total_docs) * progress_span
+            )
+            task_status.update_state(state="PROGRESS", meta={"current": progress})
+
+            # Add batch to vector store
+            add_texts_batch_with_retry(store, batch_texts, batch_metadatas, source_id)
+            _record_progress(
+                source_id,
+                last_index=batch_end_idx,
+                embedded_chunks=batch_end_idx + 1,
+            )
         except Exception as e:
             chunk_error = e
-            failed_idx = idx
-            logging.error(f"Error embedding document {idx}: {e}", exc_info=True)
-            logging.info(f"Saving progress at document {idx} out of {total_docs}")
+            failed_idx = batch_end_idx
+            logging.error(
+                f"Error embedding batch at index {batch_end_idx}: {e}", exc_info=True
+            )
+            logging.info(
+                f"Saving progress at document {batch_end_idx} out of {total_docs}"
+            )
             try:
                 store.save_local(folder_name)
                 logging.info("Progress saved successfully")
             except Exception as save_error:
-                logging.error(f"CRITICAL: Failed to save progress: {save_error}", exc_info=True)
-                # Continue without breaking to attempt final save
+                logging.error(
+                    f"CRITICAL: Failed to save progress: {save_error}", exc_info=True
+                )
             break
 
     # Save the vector store

--- a/tests/parser/file/test_embedding_pipeline.py
+++ b/tests/parser/file/test_embedding_pipeline.py
@@ -5,6 +5,7 @@ from unittest.mock import patch, MagicMock
 from application.parser.embedding_pipeline import (
     EmbeddingPipelineError,
     add_text_to_store_with_retry,
+    add_texts_batch_with_retry,
     assert_index_complete,
     embed_and_store_documents,
     sanitize_content,
@@ -35,6 +36,41 @@ def test_add_text_to_store_with_retry_success():
 
     store.add_texts.assert_called_once_with(
         ["Test content"], metadatas=[{"source_id": "123"}]
+    )
+
+
+def test_add_texts_batch_with_retry_success():
+    """Test that batch function sends multiple texts in one call."""
+    store = MagicMock()
+    texts = ["Text 1", "Text 2", "Text 3"]
+    metadatas = [{"key": "val1"}, {"key": "val2"}, {"key": "val3"}]
+
+    add_texts_batch_with_retry(store, texts, metadatas, "456")
+
+    store.add_texts.assert_called_once_with(
+        ["Text 1", "Text 2", "Text 3"],
+        metadatas=[
+            {"key": "val1", "source_id": "456"},
+            {"key": "val2", "source_id": "456"},
+            {"key": "val3", "source_id": "456"},
+        ],
+    )
+
+
+def test_add_texts_batch_with_retry_sanitizes_nul():
+    """Batch function should sanitize NUL characters from all texts."""
+    store = MagicMock()
+    texts = ["Has\x00null", "Clean text"]
+    metadatas = [{}, {}]
+
+    add_texts_batch_with_retry(store, texts, metadatas, "789")
+
+    store.add_texts.assert_called_once_with(
+        ["Hasnull", "Clean text"],
+        metadatas=[
+            {"source_id": "789"},
+            {"source_id": "789"},
+        ],
     )
 
 
@@ -123,11 +159,11 @@ def test_embed_and_store_documents_progress_band(
     assert currents == sorted(currents)
 
 
-@patch("application.parser.embedding_pipeline.add_text_to_store_with_retry")
+@patch("application.parser.embedding_pipeline.add_texts_batch_with_retry")
 def test_embed_and_store_documents_partial_failure_raises(
-    mock_add_retry, tmp_path, mock_settings, mock_vector_creator, caplog
+    mock_add_batch, tmp_path, mock_settings, mock_vector_creator, caplog
 ):
-    """Regression: a per-chunk failure must escape the function so
+    """Regression: a per-batch failure must escape the function so
     Celery's autoretry_for can fire and ``with_idempotency`` doesn't
     cache a partial index as ``completed``. Pre-fix, this branch
     swallowed and returned success.
@@ -146,11 +182,12 @@ def test_embed_and_store_documents_partial_failure_raises(
     mock_vector_creator.create_vectorstore.return_value = mock_store
 
     # First document succeeds (FAISS init seeds with docs[0]; the loop
-    # picks up at idx=1 and raises on the bad chunk).
+    # picks up at idx=1 and raises on the batch containing the bad chunk).
     def side_effect(*args, **kwargs):
-        if "bad" in args[1].page_content:
+        texts = args[1]
+        if any("bad" in t for t in texts):
             raise RuntimeError("Embedding failed")
-    mock_add_retry.side_effect = side_effect
+    mock_add_batch.side_effect = side_effect
 
     with caplog.at_level(logging.ERROR):
         with pytest.raises(EmbeddingPipelineError) as exc_info:
@@ -160,14 +197,14 @@ def test_embed_and_store_documents_partial_failure_raises(
 
     # Original cause is chained via ``raise ... from`` for diagnostics.
     assert isinstance(exc_info.value.__cause__, RuntimeError)
-    assert "Error embedding document" in caplog.text
+    assert "Error embedding batch" in caplog.text
     # Partial save still ran (chunks that did embed are flushed to disk).
     mock_store.save_local.assert_called()
 
 
-@patch("application.parser.embedding_pipeline.add_text_to_store_with_retry")
+@patch("application.parser.embedding_pipeline.add_texts_batch_with_retry")
 def test_embed_and_store_documents_all_chunks_succeed_no_raise(
-    mock_add_retry, tmp_path, mock_settings, mock_vector_creator,
+    mock_add_batch, tmp_path, mock_settings, mock_vector_creator,
 ):
     """Happy path: no exception escapes when every chunk succeeds."""
     mock_settings.VECTOR_STORE = "faiss"
@@ -290,4 +327,59 @@ def test_embed_and_store_documents_save_fails_raises_oserror(
 
     with pytest.raises(OSError, match="Unable to save vector store"):
         embed_and_store_documents(docs, str(folder_name), source_id, task_status)
+
+
+# ── Batch embedding tests ────────────────────────────────────────────────
+
+
+@patch("application.parser.embedding_pipeline.add_texts_batch_with_retry")
+def test_embed_and_store_documents_uses_batching(
+    mock_add_batch, tmp_path, mock_settings, mock_vector_creator,
+):
+    """Verify that the main loop calls the batch function instead of single-doc."""
+    mock_settings.VECTOR_STORE = "chromadb"
+
+    docs = [MagicMock(page_content=f"doc{i}", metadata={}) for i in range(5)]
+    mock_store = MagicMock()
+    mock_vector_creator.create_vectorstore.return_value = mock_store
+
+    embed_and_store_documents(
+        docs, str(tmp_path / "batch_store"), "batch-id", MagicMock(),
+    )
+
+    # Should be called once (all 5 docs fit in one batch of 100)
+    assert mock_add_batch.call_count == 1
+    call_args = mock_add_batch.call_args
+    texts = call_args[0][1]
+    metadatas = call_args[0][2]
+    assert len(texts) == 5
+    assert len(metadatas) == 5
+
+
+@patch("application.parser.embedding_pipeline.add_texts_batch_with_retry")
+def test_embed_and_store_documents_multiple_batches(
+    mock_add_batch, tmp_path, mock_settings, mock_vector_creator,
+):
+    """When docs exceed EMBED_BATCH_SIZE, multiple batch calls should be made."""
+    mock_settings.VECTOR_STORE = "chromadb"
+
+    # Create more docs than batch size to force multiple batches
+    from application.parser.embedding_pipeline import EMBED_BATCH_SIZE
+    num_docs = EMBED_BATCH_SIZE + 10
+    docs = [MagicMock(page_content=f"doc{i}", metadata={}) for i in range(num_docs)]
+    mock_store = MagicMock()
+    mock_vector_creator.create_vectorstore.return_value = mock_store
+
+    embed_and_store_documents(
+        docs, str(tmp_path / "multi_batch"), "mb-id", MagicMock(),
+    )
+
+    # Should be called twice: one full batch + one partial batch
+    assert mock_add_batch.call_count == 2
+    # First call has EMBED_BATCH_SIZE texts
+    first_call_texts = mock_add_batch.call_args_list[0][0][1]
+    assert len(first_call_texts) == EMBED_BATCH_SIZE
+    # Second call has remaining 10 texts
+    second_call_texts = mock_add_batch.call_args_list[1][0][1]
+    assert len(second_call_texts) == 10
 

--- a/tests/parser/test_chunking.py
+++ b/tests/parser/test_chunking.py
@@ -24,6 +24,7 @@ class TestChunkerInit:
         assert chunker.max_tokens == 2000
         assert chunker.min_tokens == 150
         assert chunker.duplicate_headers is False
+        assert chunker.chunk_overlap == 200
 
     def test_custom_init(self):
         chunker = Chunker(
@@ -281,3 +282,82 @@ class TestChunkerIntegration:
             assert doc.extra_info is not None
             assert "token_count" in doc.extra_info
             assert doc.extra_info["token_count"] > 0
+
+
+# =====================================================================
+# Chunk Overlap Tests
+# =====================================================================
+
+
+@pytest.mark.unit
+class TestChunkOverlap:
+
+    def test_overlap_default_value(self):
+        """Default chunk_overlap should be 200 tokens."""
+        chunker = Chunker()
+        assert chunker.chunk_overlap == 200
+
+    def test_custom_overlap(self):
+        """Custom chunk_overlap should be stored."""
+        chunker = Chunker(chunk_overlap=100)
+        assert chunker.chunk_overlap == 100
+
+    def test_zero_overlap_preserves_old_behavior(self):
+        """With overlap=0, behavior matches the old sequential cut."""
+        chunker_old = Chunker(max_tokens=50, min_tokens=5, chunk_overlap=0)
+        chunker_old.encoding.encode = lambda x: list(range(len(x.split())))
+
+        text = "word " * 100
+        doc = Document(text=text, doc_id="doc1")
+        result = chunker_old.split_document(doc)
+
+        # With 0 overlap, each chunk advances by exactly max_tokens
+        assert len(result) > 1
+
+    def test_overlap_creates_shared_boundary_text(self):
+        """With overlap>0, consecutive chunks should share boundary text."""
+        chunker = Chunker(max_tokens=30, min_tokens=5, chunk_overlap=10)
+
+        # Create a predictable text: "word0 word1 word2 ... word99"
+        words = [f"word{i}" for i in range(100)]
+        text = " ".join(words)
+        doc = Document(text=text, doc_id="doc1")
+
+        result = chunker.split_document(doc)
+        assert len(result) > 1
+
+        # Check that some words appear in consecutive chunks
+        for i in range(len(result) - 1):
+            chunk1_words = set(result[i].text.split())
+            chunk2_words = set(result[i + 1].text.split())
+            # With overlap, there should be some shared words
+            overlap = chunk1_words & chunk2_words
+            assert len(overlap) > 0, (
+                f"No overlap between chunk {i} and {i+1}. "
+                f"Chunk {i} ends with: {result[i].text[-50:]}"
+            )
+
+    def test_overlap_does_not_cause_infinite_loop(self):
+        """Ensure overlap doesn't create a loop where position doesn't advance."""
+        chunker = Chunker(max_tokens=50, min_tokens=5, chunk_overlap=40)
+
+        text = "word " * 200
+        doc = Document(text=text, doc_id="doc1")
+        result = chunker.split_document(doc)
+
+        # Should produce multiple chunks without hanging
+        assert len(result) > 1
+        # All chunk IDs should be unique
+        ids = [d.doc_id for d in result]
+        assert len(ids) == len(set(ids))
+
+    def test_overlap_with_header(self):
+        """Overlap should work correctly with header separation."""
+        chunker = Chunker(max_tokens=30, min_tokens=5, chunk_overlap=10)
+        text = "h1\nh2\nh3\n" + " ".join([f"word{i}" for i in range(100)])
+        doc = Document(text=text, doc_id="doc1")
+
+        result = chunker.split_document(doc)
+        assert len(result) > 1
+        # First chunk should still have header
+        assert "h1" in result[0].text


### PR DESCRIPTION
## Summary

This PR fixes two architectural bugs identified in Issue #2500 that cause RAG quality degradation and network latency.

### Changes

**1. Batch Embedding (`application/parser/embedding_pipeline.py`)**
- Added `EMBED_BATCH_SIZE = 100` constant (matches MongoDB's internal batch_size)
- New `add_texts_batch_with_retry()` function for batch vector store insertion
- Refactored main embed loop to accumulate chunks into batches instead of processing one at a time
- Reduces sequential HTTP requests from N (one per chunk) to N/BATCH_SIZE for remote embeddings (OpenAI, Anthropic, etc.)

**2. Chunk Overlap (`application/parser/chunking.py`)**
- Added `chunk_overlap` parameter to `Chunker` (default: 200 tokens)
- Modified `split_document()` to advance by `end_position - chunk_overlap` instead of `end_position`
- Preserves semantic context at chunk boundaries, preventing mid-sentence information loss

### Tests Updated
- `tests/parser/file/test_embedding_pipeline.py`: Added tests for batch function, batch sanitization, single-batch and multi-batch scenarios
- `tests/parser/test_chunking.py`: Added overlap tests including boundary text sharing, zero overlap backward compatibility, and header interaction

### Backward Compatibility
- `chunk_overlap=200` is the new default; set to `0` for old behavior
- Batch embedding is transparent to callers - same API, just faster

Fixes #2500