### PR TITLE
i18n: add Korean (ko) translation

### DIFF
--- a/frontend/src/locale/i18n.ts
+++ b/frontend/src/locale/i18n.ts
@@ -9,6 +9,7 @@ import zh from './zh.json'; //Mandarin
 import zhTW from './zh-TW.json'; //Traditional Chinese
 import ru from './ru.json'; //Russian
 import de from './de.json'; //German
+import ko from './ko.json'; //Korean
 
 i18n
   .use(LanguageDetector)
@@ -35,6 +36,9 @@ i18n
       },
       de: {
         translation: de,
+      },
+      ko: {
+        translation: ko,
       },
     },
     fallbackLng: 'en',

--- a/frontend/src/locale/ko.json
+++ b/frontend/src/locale/ko.json
@@ -1,0 +1,1374 @@
+{
+  "language": "한국어",
+  "chat": "채팅",
+  "chats": "채팅",
+  "newChat": "새 채팅",
+  "inputPlaceholder": "DocsGPT에게 무엇을 도와드릴까요?",
+  "tagline": "DocsGPT는 생성형 AI를 사용합니다. 중요한 정보는 출처를 통해 확인해 주세요.",
+  "sourceDocs": "소스",
+  "none": "없음",
+  "cancel": "취소",
+  "help": "도움말",
+  "emailUs": "이메일 문의",
+  "documentation": "문서",
+  "manageAgents": "에이전트 관리",
+  "teamAccess": {
+    "editor": "편집자",
+    "viewer": "뷰어"
+  },
+  "notifications": {
+    "memberAddedTitle": "팀에 추가됨",
+    "memberAddedBody": "{{team}}에 {{role}}(으)로 추가되었습니다",
+    "sharedTitle": "회원님과 공유됨",
+    "sharedBody": "{{type}}이(가) 팀과 공유되었습니다: {{name}} ({{access}})",
+    "sharedBodyNoName": "{{type}}이(가) 팀과 공유되었습니다 ({{access}})",
+    "dismiss": "닫기"
+  },
+  "demo": [
+    {
+      "header": "DocsGPT에 대해 알아보기",
+      "query": "DocsGPT는 무엇인가요?"
+    },
+    {
+      "header": "문서 요약하기",
+      "query": "현재 컨텍스트를 요약해 주세요"
+    },
+    {
+      "header": "코드 작성하기",
+      "query": "/api/answer에 대한 API 요청 코드를 작성해 주세요"
+    },
+    {
+      "header": "학습 지원",
+      "query": "컨텍스트에 대한 예상 질문을 작성해 주세요"
+    }
+  ],
+  "auth": {
+    "signInToContinue": "계속하려면 DocsGPT에 로그인하세요",
+    "signInWithSSO": "SSO로 로그인",
+    "signInWith": "{{provider}}로 로그인",
+    "notAuthorized": "이 워크스페이스에 접근할 권한이 없습니다. 다른 계정으로 로그인하거나 관리자에게 문의하세요.",
+    "accountDisabled": "계정이 비활성화되었습니다. 관리자에게 문의하세요.",
+    "signOut": "로그아웃",
+    "account": "계정"
+  },
+  "settings": {
+    "label": "설정",
+    "general": {
+      "label": "일반",
+      "selectTheme": "테마 선택",
+      "light": "라이트",
+      "dark": "다크",
+      "selectLanguage": "언어 선택",
+      "chunks": "쿼리당 처리할 청크 수",
+      "prompt": "활성 프롬프트",
+      "deleteAllLabel": "모든 대화 삭제",
+      "deleteAllBtn": "모두 삭제",
+      "addNew": "새로 추가",
+      "convHistory": "대화 기록",
+      "none": "없음",
+      "low": "낮음",
+      "medium": "중간",
+      "high": "높음",
+      "unlimited": "무제한",
+      "default": "기본값",
+      "add": "추가"
+    },
+    "sources": {
+      "title": "여기에서 회원님이 이용할 수 있는 모든 소스 파일과 업로드한 파일을 관리할 수 있습니다.",
+      "subtitle": "응답을 생성하는 데 사용되는 문서와 지식 소스를 업로드하고 관리하세요",
+      "label": "소스",
+      "name": "소스 이름",
+      "date": "벡터화 날짜",
+      "type": "유형",
+      "tokenUsage": "토큰 사용량",
+      "noData": "기존 소스가 없습니다",
+      "searchPlaceholder": "검색...",
+      "addNew": "새로 추가",
+      "addSource": "소스 추가",
+      "addChunk": "청크 추가",
+      "preLoaded": "사전 로드됨",
+      "private": "비공개",
+      "sync": "동기화",
+      "syncNow": "지금 동기화",
+      "syncing": "동기화 중...",
+      "reingest": "재수집",
+      "ingestFailed": "색인 실패",
+      "ingestProcessing": "색인 생성 중…",
+      "syncConfirmation": "\"{{sourceName}}\"을(를) 동기화하시겠습니까? 클라우드 스토리지의 내용으로 업데이트되며, 개별 청크에서 수정한 내용은 덮어써질 수 있습니다.",
+      "syncFrequency": {
+        "never": "안 함",
+        "daily": "매일",
+        "weekly": "매주",
+        "monthly": "매월"
+      },
+      "actions": "작업",
+      "view": "보기",
+      "wiki": {
+        "view": "위키 보기",
+        "empty": "이 위키에는 아직 페이지가 없습니다.",
+        "selectPage": "내용을 보려면 페이지를 선택하세요.",
+        "edit": "편집",
+        "save": "저장",
+        "cancel": "취소",
+        "saving": "저장 중…",
+        "saveFailed": "페이지를 저장하지 못했습니다. 다시 시도해 주세요.",
+        "forbidden": "이 페이지를 편집할 권한이 없습니다.",
+        "conflict": "이 페이지가 열려 있는 동안 변경되어 다시 불러왔습니다. 아래에서 내용을 다시 적용한 뒤 저장해 주세요.",
+        "editPlaceholder": "Markdown으로 페이지를 작성하세요…",
+        "livingTitle": "살아있는 위키.",
+        "livingExplainer": "에이전트가 편집할 수 있는 소스입니다. 에이전트가 작업하는 동안 페이지가 읽히고 다시 작성되며, 기본적으로 에이전틱 검색 도구를 통해 에이전트에 노출됩니다.",
+        "livingExplainerEditable": "이 소스를 사용하는 모든 에이전트가 이를 편집할 수 있습니다.",
+        "stamp": {
+          "editedBy": "{{who}}이(가) 편집함",
+          "agent": "에이전트",
+          "human": "사람",
+          "you": "나",
+          "unknown": "알 수 없음",
+          "version": "v{{version}}"
+        },
+        "convert": {
+          "action": "위키로 변환",
+          "title": "살아있는 위키로 변환",
+          "intro": "\"{{name}}\"을(를) 에이전트가 읽고 다시 작성할 수 있는 편집 가능한 페이지들의 살아있는 위키로 변환합니다.",
+          "introGeneric": "이 소스를 에이전트가 읽고 다시 작성할 수 있는 편집 가능한 페이지들의 살아있는 위키로 변환합니다.",
+          "costReparse": "파일이 편집 가능한 페이지로 다시 파싱됩니다. 특히 PDF의 경우 서식이 단순화됩니다.",
+          "costSkipped": "텍스트가 아닌 파일(이미지, 바이너리)은 건너뜁니다.",
+          "costIrreversible": "이 작업은 되돌릴 수 없습니다 — 위키 페이지가 원본 소스가 됩니다.",
+          "confirm": "위키로 변환",
+          "inProgress": "파일을 위키 페이지로 변환하는 중…",
+          "summaryPages_one": "페이지 {{count}}개 생성됨",
+          "summaryPages_other": "페이지 {{count}}개 생성됨",
+          "summarySkipped_one": "파일 {{count}}개 건너뜀",
+          "summarySkipped_other": "파일 {{count}}개 건너뜀",
+          "skippedHeading": "건너뛴 파일",
+          "done": "완료",
+          "errors": {
+            "generic": "변환에 실패했습니다. 다시 시도해 주세요.",
+            "forbidden": "이 소스를 변환할 권한이 없습니다.",
+            "conflict": "이 소스는 아직 수집 중입니다. 완료된 후 변환해 주세요."
+          }
+        }
+      },
+      "graphrag": {
+        "badge": "GraphRAG",
+        "building": "그래프 생성 중…",
+        "buildingPct": "그래프 생성 중… {{pct}}%",
+        "enable": {
+          "action": "GraphRAG 활성화",
+          "title": "GraphRAG 활성화",
+          "intro": "에이전트가 연결된 엔터티와 관계를 추론할 수 있도록 \"{{name}}\"에 대한 지식 그래프를 구축합니다.",
+          "introGeneric": "에이전트가 연결된 엔터티와 관계를 추론할 수 있도록 이 소스에 대한 지식 그래프를 구축합니다.",
+          "costExtraction": "이 소스의 청크에 대해 LLM을 실행하여 엔터티와 관계를 추출합니다.",
+          "costCost": "청크당 한 번씩 LLM을 호출하므로 토큰을 소비하며 대용량 소스의 경우 시간이 걸릴 수 있습니다.",
+          "estimate": "청크당 LLM 호출 약 1회 · 총 토큰 약 {{lo}}~{{hi}}개(입력과 출력이 대략 절반씩); 출력량은 문서의 엔터티 밀도에 따라 달라집니다.",
+          "confirm": "GraphRAG 활성화",
+          "inProgress": "그래프 생성 중…",
+          "inProgressPct": "그래프 생성 중… {{pct}}%",
+          "summaryNodes_one": "엔터티 {{count}}개",
+          "summaryNodes_other": "엔터티 {{count}}개",
+          "summaryEdges_one": "관계 {{count}}개",
+          "summaryEdges_other": "관계 {{count}}개",
+          "summaryChunks_one": "청크 {{count}}개 처리됨",
+          "summaryChunks_other": "청크 {{count}}개 처리됨",
+          "done": "완료",
+          "errors": {
+            "generic": "GraphRAG 활성화에 실패했습니다. 다시 시도해 주세요.",
+            "forbidden": "이 소스에 GraphRAG를 활성화할 권한이 없습니다.",
+            "conflict": "이 소스는 아직 수집 중입니다. 완료된 후 GraphRAG를 활성화해 주세요."
+          }
+        },
+        "view": {
+          "action": "그래프 보기",
+          "title": "지식 그래프",
+          "explainer": "노드는 엔터티, 엣지는 그 관계를 나타냅니다. 노드를 클릭하면 설명과 추출된 청크를 확인할 수 있습니다.",
+          "stats": "엔터티 {{nodes}}개 · 관계 {{edges}}개",
+          "empty": "아직 그래프가 없습니다 — 추출이 진행 중일 수 있습니다.",
+          "selectNode": "노드를 선택하면 세부 정보를 확인할 수 있습니다.",
+          "linkedChunks": "연결된 청크",
+          "noChunks": "이 엔터티에 연결된 청크가 없습니다.",
+          "close": "닫기"
+        }
+      },
+      "editConfig": "소스 설정",
+      "shareWithTeam": "팀과 공유",
+      "deleteWarning": "\"{{name}}\"을(를) 삭제하시겠습니까?",
+      "confirmDelete": "이 파일을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+      "backToAll": "모든 소스로 돌아가기",
+      "chunks": "청크",
+      "noChunks": "청크를 찾을 수 없습니다",
+      "noChunksAlt": "청크를 찾을 수 없습니다",
+      "goToSources": "소스로 이동",
+      "uploadNew": "새로 업로드",
+      "searchFiles": "파일 검색...",
+      "noResults": "결과를 찾을 수 없습니다",
+      "fileName": "이름",
+      "tokens": "토큰",
+      "size": "크기",
+      "fileAlt": "파일",
+      "folderAlt": "폴더",
+      "parentFolderAlt": "상위 폴더",
+      "menuAlt": "메뉴",
+      "tokensUnit": "토큰",
+      "editAlt": "편집",
+      "uploading": "업로드 중…",
+      "deleting": "삭제 중…",
+      "queued": "대기 중: {{count}}",
+      "addFile": "파일 추가",
+      "uploadingFilesTitle": "파일 업로드 중...",
+      "deletingTitle": "삭제 중...",
+      "deleteDirectoryWarning": "\"{{name}}\" 디렉터리와 그 안의 모든 내용을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+      "searchAlt": "검색",
+      "retrievalOptions": {
+        "title": "고급 설정",
+        "retrieval": {
+          "title": "검색",
+          "note": "이 변경 사항은 즉시 적용되며 재수집이 필요하지 않습니다.",
+          "tag": "재수집 불필요",
+          "chunks": "가져올 청크 수 (top-k)",
+          "scoreThreshold": "점수 임계값",
+          "scoreThresholdPlaceholder": "없음",
+          "scoreThresholdHint": "이 관련성 점수(0~1) 이상인 청크만 반환합니다. 값이 높을수록 더 엄격합니다.",
+          "rephraseQuery": "검색 전 쿼리 재구성",
+          "retriever": "검색기",
+          "retrievers": {
+            "classic": "클래식",
+            "hybrid": "하이브리드",
+            "graphrag": "GraphRAG"
+          },
+          "retrieverHint": "하이브리드는 키워드 검색과 벡터 검색을 결합합니다. GraphRAG는 다중 홉 질문을 위해 이 소스에 대한 지식 그래프를 구축합니다.",
+          "exposure": "검색 노출 방식",
+          "exposures": {
+            "prefetch": "컨텍스트에 미리 가져오기",
+            "agentic_tool": "온디맨드 검색 도구"
+          },
+          "exposureHint": "이 소스를 프롬프트에 미리 가져오거나, 에이전트가 필요할 때 도구로 검색하도록 할 수 있습니다."
+        },
+        "prescreen": {
+          "enable": "LLM 사전 필터링 활성화",
+          "warning": "더 많은 후보 집합을 가져온 뒤 LLM으로 필터링합니다. 쿼리 시 지연 시간과 비용이 추가됩니다.",
+          "candidateK": "가져올 후보 수",
+          "maxKeep": "유지할 최대 청크 수",
+          "batchSize": "배치 크기",
+          "model": "모델 (선택 사항)",
+          "modelPlaceholder": "요청 모델을 기본값으로 사용"
+        },
+        "graph": {
+          "title": "그래프 추출",
+          "tag": "적용하려면 재수집 필요",
+          "extractionModel": "추출 모델",
+          "extractionModelHint": "각 청크에서 엔터티와 관계를 추출하는 데 사용되는 LLM입니다.",
+          "defaultModel": "기본 모델 사용",
+          "maxChunks": "추출할 최대 청크 수",
+          "maxChunksHint": "추출을 위해 전송할 청크 수를 제한합니다. 비워두면 인스턴스 기본값을 사용합니다.",
+          "maxChunksPlaceholder": "기본값"
+        },
+        "chunking": {
+          "title": "청크 분할",
+          "note": "수집 시점 설정입니다. 변경하려면 소스를 다시 수집해야 합니다.",
+          "tag": "적용하려면 재수집 필요",
+          "strategy": "청크 분할 전략",
+          "strategies": {
+            "classic_chunk": "클래식",
+            "recursive": "재귀형",
+            "markdown": "Markdown",
+            "parent_child": "부모/자식",
+            "semantic": "의미 기반"
+          },
+          "maxTokens": "청크당 최대 토큰 수",
+          "minTokens": "청크당 최소 토큰 수",
+          "duplicateHeaders": "청크마다 헤더 중복 포함"
+        }
+      },
+      "configModal": {
+        "title": "소스 설정",
+        "subtitle": "\"{{name}}\"의 청크 분할 및 검색 방식을 설정합니다.",
+        "subtitleGeneric": "이 소스의 청크 분할 및 검색 방식을 설정합니다.",
+        "save": "저장",
+        "saving": "저장 중…",
+        "readOnly": "이 공유 소스에 대해 보기 전용 권한이 있어 설정을 변경할 수 없습니다.",
+        "chunkingChangeHint": "청크 분할 설정을 변경했습니다. 저장하려면 이 소스를 다시 수집해야 적용됩니다.",
+        "prescreenInvalidHint": "사전 필터링 값을 확인해 주세요: 가져올 후보 수는 유지할 청크 수 이상이어야 하며, 유지할 청크 수는 가져올 후보 수를 초과할 수 없습니다.",
+        "reingestRequired": "변경 사항이 저장되었습니다. 변경한 청크 분할 설정은 재수집 후에만 적용됩니다. 지금 재수집하시겠습니까?",
+        "reingestLater": "나중에",
+        "errors": {
+          "forbidden": "이 소스의 설정을 편집할 권한이 없습니다.",
+          "saveFailed": "설정을 저장하지 못했습니다. 다시 시도해 주세요."
+        }
+      }
+    },
+    "apiKeys": {
+      "label": "챗봇",
+      "name": "이름",
+      "key": "API 키",
+      "sourceDoc": "소스 문서",
+      "createNew": "새로 만들기",
+      "noData": "기존 챗봇이 없습니다",
+      "deleteConfirmation": "API 키 '{{name}}'을(를) 삭제하시겠습니까?",
+      "description": "여기에서 챗봇을 만들고 관리할 수 있습니다. 챗봇은 웹사이트에 위젯으로 배포하거나 애플리케이션 내부에서 사용할 수 있습니다."
+    },
+    "analytics": {
+      "label": "분석",
+      "subtitle": "계정 전체의 메시지량, 토큰 사용량, 사용자 피드백을 추적하세요",
+      "filterByChatbot": "챗봇으로 필터링",
+      "selectChatbot": "챗봇 선택",
+      "filterOptions": {
+        "hour": "1시간",
+        "last24Hours": "24시간",
+        "last7Days": "7일",
+        "last15Days": "15일",
+        "last30Days": "30일"
+      },
+      "messages": "메시지",
+      "tokenUsage": "토큰 사용량",
+      "userFeedback": "사용자 피드백",
+      "filterPlaceholder": "필터",
+      "none": "없음",
+      "positiveFeedback": "긍정 피드백",
+      "negativeFeedback": "부정 피드백",
+      "groupBy": "그룹화 기준",
+      "groupOptions": {
+        "total": "전체",
+        "model": "모델별",
+        "agent": "에이전트별",
+        "source": "소스별"
+      },
+      "includeSideChannel": "백그라운드 토큰",
+      "promptTokens": "프롬프트 토큰",
+      "generatedTokens": "생성된 토큰",
+      "scheduledRuns": "예약 실행",
+      "toolUsage": "도구 사용",
+      "completed": "완료됨",
+      "failed": "실패",
+      "skipped": "건너뜀",
+      "successful": "성공",
+      "stats": {
+        "messages": "메시지",
+        "tokens": "토큰",
+        "toolCalls": "도구 호출",
+        "runSuccess": "실행 성공률",
+        "feedback": "피드백"
+      }
+    },
+    "logs": {
+      "label": "로그",
+      "subtitle": "계정 전체의 API 호출, 예약 실행, 오류를 확인하고 모니터링하세요",
+      "filterByChatbot": "챗봇으로 필터링",
+      "selectChatbot": "챗봇 선택",
+      "none": "없음",
+      "tableHeader": "API 생성 / 챗봇 대화",
+      "searchPlaceholder": "로그 검색...",
+      "noLogs": "로그를 찾을 수 없습니다",
+      "levels": {
+        "all": "모든 레벨",
+        "info": "정보",
+        "error": "오류",
+        "warning": "경고"
+      },
+      "types": {
+        "all": "모든 이벤트",
+        "chat": "채팅",
+        "schedule": "예약됨",
+        "webhook": "웹훅",
+        "workflow": "워크플로",
+        "system": "시스템"
+      },
+      "detail": {
+        "agent": "에이전트",
+        "status": "상태",
+        "trigger": "트리거",
+        "errorType": "오류 유형",
+        "tokens": "토큰",
+        "duration": "소요 시간",
+        "conversation": "대화",
+        "endpoint": "엔드포인트",
+        "instruction": "지시사항",
+        "response": "응답",
+        "output": "출력",
+        "error": "오류",
+        "toolCalls": "도구 호출",
+        "sources": "소스",
+        "workflow": "워크플로",
+        "activity": "활동",
+        "steps": "단계",
+        "result": "결과"
+      }
+    },
+    "teams": {
+      "label": "팀",
+      "subtitle": "팀, 팀원, 공유 리소스를 관리하세요.",
+      "newTeam": "새 팀",
+      "backToTeams": "팀으로 돌아가기",
+      "createTeam": "팀 만들기",
+      "createTeamDescription": "팀 이름을 입력하세요. 만든 후 팀원을 추가하고 리소스를 공유할 수 있습니다.",
+      "editTeam": "편집",
+      "teamNamePlaceholder": "팀 이름",
+      "descriptionLabel": "설명",
+      "descriptionPlaceholder": "이 팀은 어떤 용도인가요? (선택 사항)",
+      "create": "만들기",
+      "save": "저장",
+      "createTeamError": "팀을 만들지 못했습니다.",
+      "noTeams": "아직 팀이 없습니다.",
+      "noDescription": "설명 없음",
+      "memberCountOne": "팀원 {{count}}명",
+      "memberCountOther": "팀원 {{count}}명",
+      "sharedCount": "{{count}}개 공유됨",
+      "loadError": "팀을 불러오지 못했습니다.",
+      "roleAdmin": "관리자",
+      "roleMember": "팀원",
+      "sourceManual": "직접 추가됨",
+      "sourceSso": "SSO를 통해",
+      "sourceScim": "SCIM을 통해",
+      "teamsHeading": "내 팀",
+      "selectTeamHint": "팀을 선택하면 팀원과 공유 리소스를 관리할 수 있습니다.",
+      "selectTeamTitle": "선택된 팀 없음",
+      "teamSubtitle": "팀원과 이 팀과 공유된 리소스를 관리하세요.",
+      "deleteTeam": "팀 삭제",
+      "deleteTeamConfirmation": "\"{{name}}\"을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+      "members": "팀원",
+      "addMember": "팀원 추가",
+      "addMemberTitle": "팀원 추가",
+      "addMemberDescription": "이메일로 초대하세요. 초대받는 사람은 최소 한 번 로그인한 적이 있어야 합니다.",
+      "teamActions": "팀 작업",
+      "memberEmailLabel": "팀원 이메일",
+      "memberEmailPlaceholder": "name@example.com",
+      "memberRoleLabel": "역할",
+      "add": "추가",
+      "remove": "제거",
+      "removeMemberConfirmation": "이 팀원을 팀에서 제거하시겠습니까?",
+      "addMemberError": "팀원을 추가하지 못했습니다 (팀 관리자만 가능).",
+      "memberNotFound": "해당 이메일의 사용자를 찾을 수 없습니다 — 먼저 한 번 로그인해야 합니다.",
+      "noMembers": "아직 팀원이 없습니다. \"팀원 추가\"를 눌러 이메일로 초대하세요.",
+      "roleChangeError": "역할을 변경하지 못했습니다 (마지막 관리자는 보호됩니다).",
+      "removeMemberError": "팀원을 제거하지 못했습니다.",
+      "deleteTeamError": "팀을 삭제하지 못했습니다.",
+      "updateFailed": "업데이트에 실패했습니다",
+      "openTeamError": "팀 세부 정보를 불러오지 못했습니다.",
+      "sharedResources": "공유 리소스",
+      "sharedWithTeam": "이 팀과 공유됨 ({{count}})",
+      "nothingShared": "아직 공유된 항목이 없습니다. 메뉴에서 에이전트, 소스, 프롬프트, 도구를 공유해 보세요.",
+      "unshare": "공유 해제",
+      "unshareError": "리소스 공유를 해제하지 못했습니다.",
+      "resourceType": {
+        "agent": "에이전트",
+        "source": "소스",
+        "prompt": "프롬프트",
+        "tool": "도구"
+      },
+      "share": {
+        "titleNamed": "\"{{name}}\" 공유",
+        "titleGeneric": "이 {{type}} 공유",
+        "subtitle": "팀원은 이를 사용할 수 있고, 편집자는 수정도 할 수 있습니다. 소유권은 회원님에게 남습니다.",
+        "noTeams": "아직 어떤 팀에도 속해 있지 않습니다. 설정 → 팀에서 팀을 만들어 보세요.",
+        "accessLevel": {
+          "viewer": "뷰어",
+          "editor": "편집자"
+        },
+        "done": "완료",
+        "loadError": "현재 공유 상태를 불러오지 못했습니다.",
+        "shareError": "팀과 공유하지 못했습니다.",
+        "unshareError": "팀과의 공유를 해제하지 못했습니다.",
+        "addPlaceholder": "사람 또는 팀 추가…",
+        "searchPlaceholder": "사람 또는 팀 추가…",
+        "noMatches": "일치하는 사람이나 팀이 없습니다.",
+        "peopleWithAccess": "접근 권한이 있는 사람",
+        "you": "나",
+        "owner": "소유자",
+        "teamsGroup": "팀",
+        "peopleGroup": "사람",
+        "teamLabel": "팀",
+        "viaTeam": "{{team}}을(를) 통해",
+        "removeAccess": "접근 권한 제거",
+        "access": "접근 권한"
+      }
+    },
+    "tools": {
+      "label": "도구",
+      "subtitle": "에이전트를 강화하는 도구와 연동을 탐색, 연결, 설정하세요",
+      "searchPlaceholder": "도구 검색...",
+      "addTool": "도구 추가",
+      "noToolsFound": "도구를 찾을 수 없습니다",
+      "selectToolSetup": "설정할 도구를 선택하세요",
+      "settingsIconAlt": "설정 아이콘",
+      "configureToolAria": "{{toolName}} 설정",
+      "toggleToolAria": "{{toolName}} 전환",
+      "manageTools": "도구로 이동",
+      "edit": "편집",
+      "delete": "삭제",
+      "reconnect": "다시 연결",
+      "shareWithTeam": "팀과 공유",
+      "builtIn": "내장",
+      "authStatus": {
+        "connected": "연결됨",
+        "needsAuth": "인증 필요",
+        "configured": "설정됨"
+      },
+      "deleteWarning": "도구 \"{{toolName}}\"을(를) 삭제하시겠습니까?",
+      "unsavedChanges": "저장하지 않고 나가면 변경 사항이 사라집니다.",
+      "leaveWithoutSaving": "저장하지 않고 나가기",
+      "saveAndLeave": "저장하고 나가기",
+      "customName": "사용자 지정 이름",
+      "customNamePlaceholder": "사용자 지정 이름 입력 (선택 사항)",
+      "authentication": "인증",
+      "actions": "작업",
+      "addAction": "작업 추가",
+      "importSpec": "스펙 가져오기",
+      "searchActions": "작업 검색...",
+      "noActionsMatch": "검색과 일치하는 작업이 없습니다",
+      "actionAlreadyExists": "이 이름의 작업이 이미 존재합니다",
+      "noActionsFound": "작업을 찾을 수 없습니다",
+      "url": "URL",
+      "urlPlaceholder": "URL 입력",
+      "method": "메서드",
+      "description": "설명",
+      "descriptionPlaceholder": "설명 입력",
+      "bodyContentType": "본문 콘텐츠 유형",
+      "headers": "헤더",
+      "queryParameters": "쿼리 매개변수",
+      "body": "본문",
+      "deleteActionWarning": "작업 \"{{name}}\"을(를) 삭제하시겠습니까?",
+      "backToAllTools": "모든 도구로 돌아가기",
+      "save": "저장",
+      "saving": "저장 중...",
+      "saveFailed": "도구 설정을 저장하지 못했습니다",
+      "fieldName": "필드 이름",
+      "fieldType": "필드 유형",
+      "filledByLLM": "LLM이 채움",
+      "fieldDescription": "필드 설명",
+      "value": "값",
+      "addProperty": "속성 추가",
+      "propertyName": "새 속성 키",
+      "add": "추가",
+      "cancel": "취소",
+      "addNew": "새로 추가",
+      "name": "이름",
+      "type": "유형",
+      "mcp": {
+        "addServer": "MCP 서버 추가",
+        "editServer": "서버 편집",
+        "reconnectServer": "서버 다시 연결",
+        "reenterCredentials": "연결을 테스트하고 업데이트하려면 자격 증명을 다시 입력하세요.",
+        "serverName": "서버 이름",
+        "serverUrl": "서버 URL",
+        "headerName": "헤더 이름",
+        "timeout": "제한 시간(초)",
+        "testConnection": "연결 테스트",
+        "testing": "테스트 중",
+        "saving": "저장 중",
+        "save": "저장",
+        "cancel": "취소",
+        "noAuth": "인증 없음",
+        "oauthInProgress": "OAuth 완료를 기다리는 중...",
+        "oauthCompleted": "OAuth가 성공적으로 완료되었습니다",
+        "oauthPopupBlocked": "브라우저가 팝업을 차단했습니다. 아래를 클릭하여 인증하세요:",
+        "openAuthPage": "인증 페이지 열기",
+        "authType": "인증 유형",
+        "defaultServerName": "내 MCP 서버",
+        "authTypes": {
+          "none": "인증 없음",
+          "apiKey": "API 키",
+          "bearer": "Bearer 토큰",
+          "oauth": "OAuth",
+          "basic": "기본 인증"
+        },
+        "placeholders": {
+          "serverUrl": "https://api.example.com",
+          "apiKey": "비밀 API 키",
+          "bearerToken": "비밀 토큰",
+          "username": "사용자 이름",
+          "password": "비밀번호",
+          "oauthScopes": "OAuth 범위(쉼표로 구분)"
+        },
+        "errors": {
+          "nameRequired": "서버 이름을 입력해야 합니다",
+          "urlRequired": "서버 URL을 입력해야 합니다",
+          "invalidUrl": "유효한 URL을 입력하세요",
+          "apiKeyRequired": "API 키를 입력해야 합니다",
+          "tokenRequired": "Bearer 토큰을 입력해야 합니다",
+          "usernameRequired": "사용자 이름을 입력해야 합니다",
+          "passwordRequired": "비밀번호를 입력해야 합니다",
+          "testFailed": "연결 테스트에 실패했습니다",
+          "saveFailed": "MCP 서버를 저장하지 못했습니다",
+          "oauthFailed": "OAuth 처리에 실패했거나 취소되었습니다",
+          "oauthTimeout": "OAuth 처리 시간이 초과되었습니다. 다시 시도해 주세요",
+          "timeoutRange": "제한 시간은 1초에서 300초 사이여야 합니다"
+        }
+      }
+    },
+    "devices": {
+      "label": "디바이스",
+      "subtitle": "에이전트가 셸 명령으로 제어할 수 있는 원격 머신을 페어링하세요.",
+      "pair": "디바이스 페어링",
+      "empty": "페어링된 디바이스가 없습니다.",
+      "revoke": "해제",
+      "edit": "편집",
+      "revokeWarning": "{{name}}을(를) 해제하시겠습니까? CLI 연결이 끊어집니다.",
+      "approvalMode": "승인 모드",
+      "approvalAsk": "확인 요청",
+      "approvalFull": "전체 접근 허용",
+      "online": "온라인",
+      "offline": "오프라인",
+      "lastSeen": "마지막 접속: {{time}}",
+      "lastSeenLabel": "마지막 접속",
+      "seenAgo": "{{time}} 전 접속",
+      "nameLabel": "디바이스 이름",
+      "descriptionLabel": "설명 (에이전트에게 표시됨)",
+      "descriptionPlaceholder": "이 머신은 어떤 용도인가요?",
+      "identity": "신원",
+      "access": "접근 권한",
+      "connection": "연결",
+      "hostLabel": "호스트",
+      "dangerZone": "위험 구역",
+      "approvalAskDescription": "모든 명령을 실행하기 전에 승인합니다.",
+      "approvalFullDescription": "안전 차단 목록을 제외한 모든 명령을 확인 없이 실행합니다.",
+      "fullAccessWarning": "전체 접근 허용: 에이전트가 확인 없이 이 머신에서 모든 명령을 실행할 수 있습니다. 안전 차단 목록은 계속 적용됩니다.",
+      "deviceIdLabel": "디바이스 ID",
+      "offlineHint": "연결되어 있지 않습니다. 머신에서 `docsgpt-cli host`를 실행하여 온라인 상태로 전환하세요.",
+      "dangerZoneDescription": "해제하면 디바이스에서 데몬이 중지되고 페어링이 제거됩니다.",
+      "auditTitle": "최근 활동",
+      "auditLoading": "불러오는 중…",
+      "auditEmpty": "아직 활동이 없습니다.",
+      "auditDecision": "결정",
+      "auditExit": "종료",
+      "auditDuration": "소요 시간",
+      "pairing": {
+        "title": "원격 머신 페어링",
+        "subtitle": "원격 머신에서 아래 명령을 실행하고, 안내되는 코드를 입력하세요.",
+        "formSubtitle": "새 디바이스의 이름, 설명, 승인 모드를 설정하세요.",
+        "nameLabel": "디바이스 이름 (선택 사항)",
+        "namePlaceholder": "예: edge-server",
+        "descriptionLabel": "설명 (선택 사항)",
+        "descriptionPlaceholder": "에이전트에게 표시되어 올바른 디바이스를 선택하는 데 도움을 줍니다.",
+        "fullAccessWarning": "전체 접근 허용: 에이전트가 확인 없이 이 머신에서 모든 명령을 실행할 수 있습니다. 안전 차단 목록은 계속 적용됩니다.",
+        "stepOne": "1. 원격 머신에서 다음을 실행하세요:",
+        "installLink": "docsgpt-cli가 없으신가요? 설치하기",
+        "stepTwo": "2. 안내되는 코드를 입력하세요:",
+        "start": "코드 생성",
+        "starting": "처리 중…",
+        "waitingForCli": "CLI가 코드를 사용할 때까지 기다리는 중…",
+        "cancel": "취소"
+      }
+    },
+    "customModels": {
+      "label": "사용자 지정 모델",
+      "subtitle": "OpenAI 호환 모델을 직접 연결하세요.",
+      "addModel": "모델 추가",
+      "empty": "모델을 찾을 수 없습니다",
+      "searchPlaceholder": "모델 검색...",
+      "modalSubtitle": "OpenAI 호환 엔드포인트(Mistral, Together, vLLM 등)를 연결하세요.",
+      "addTitle": "사용자 지정 모델 추가",
+      "editTitle": "사용자 지정 모델 편집",
+      "save": "저장",
+      "saving": "저장 중",
+      "testConnection": "연결 테스트",
+      "testing": "테스트 중",
+      "testSuccess": "연결에 성공했습니다.",
+      "testHintNew": "연결 테스트를 활성화하려면 기본 URL, 모델 ID, API 키를 입력하세요.",
+      "disabledBadge": "비활성화됨",
+      "deleteWarning": "사용자 지정 모델 \"{{modelName}}\"을(를) 삭제하시겠습니까?",
+      "actionsMenuAria": "{{modelName}}에 대한 작업",
+      "modelsGroup": {
+        "builtin": "DocsGPT 모델",
+        "user": "내 모델"
+      },
+      "actions": {
+        "edit": "편집",
+        "delete": "삭제"
+      },
+      "fields": {
+        "displayName": "표시 이름",
+        "modelId": "모델 ID",
+        "description": "설명",
+        "baseUrl": "기본 URL",
+        "apiKey": "API 키"
+      },
+      "placeholders": {
+        "displayName": "내 Mistral",
+        "modelId": "예: mistral-large-latest",
+        "description": "설명 (선택 사항)",
+        "baseUrl": "https://api.mistral.ai/v1",
+        "apiKey": "sk-...",
+        "apiKeyEdit": "기존 값을 유지하려면 비워두세요"
+      },
+      "hints": {
+        "apiKeyEdit": "기존 키를 유지하려면 비워두세요."
+      },
+      "capabilities": {
+        "title": "기능",
+        "contextWindowShort": "컨텍스트 윈도우",
+        "chips": {
+          "tools": "도구",
+          "structuredOutput": "구조화된 출력",
+          "images": "이미지"
+        }
+      },
+      "errors": {
+        "displayNameRequired": "표시 이름을 입력해야 합니다",
+        "modelIdRequired": "모델 ID를 입력해야 합니다",
+        "baseUrlRequired": "기본 URL을 입력해야 합니다",
+        "baseUrlScheme": "기본 URL은 http:// 또는 https://로 시작해야 합니다",
+        "baseUrlInvalid": "유효한 URL을 입력하세요",
+        "apiKeyRequired": "API 키를 입력해야 합니다",
+        "contextWindowRange": "컨텍스트 윈도우는 1,000에서 10,000,000 사이여야 합니다",
+        "saveFailed": "사용자 지정 모델을 저장하지 못했습니다",
+        "testFailed": "연결 테스트에 실패했습니다"
+      }
+    },
+    "scrollTabsLeft": "탭 왼쪽으로 스크롤",
+    "tabsAriaLabel": "설정 탭",
+    "scrollTabsRight": "탭 오른쪽으로 스크롤"
+  },
+  "modals": {
+    "uploadDoc": {
+      "label": "새 문서 업로드",
+      "select": "DocsGPT에 문서를 업로드할 방법을 선택하세요",
+      "selectSource": "소스를 추가할 방법을 선택하세요",
+      "selectedFiles": "선택된 파일",
+      "noFilesSelected": "선택된 파일이 없습니다",
+      "file": "기기에서 업로드",
+      "back": "뒤로",
+      "wait": "잠시만 기다려 주세요...",
+      "remote": "웹사이트에서 수집",
+      "start": "채팅 시작",
+      "name": "이름",
+      "choose": "파일 선택",
+      "info": ".pdf, .txt, .rst, .csv, .xlsx, .docx, .md, .html, .epub, .json, .pptx, .zip 파일을 업로드하세요 (최대 25MB)",
+      "uploadedFiles": "업로드된 파일",
+      "cancel": "취소",
+      "train": "학습",
+      "create": "만들기",
+      "link": "링크",
+      "urlLink": "URL 링크",
+      "repoUrl": "저장소 URL",
+      "reddit": {
+        "id": "클라이언트 ID",
+        "secret": "클라이언트 시크릿",
+        "agent": "사용자 에이전트",
+        "searchQueries": "검색어",
+        "numberOfPosts": "게시물 수",
+        "addQuery": "검색어 추가"
+      },
+      "drag": {
+        "title": "첨부 파일을 여기에 놓으세요",
+        "description": "놓으면 첨부 파일이 업로드됩니다"
+      },
+      "progress": {
+        "upload": "업로드 진행 중",
+        "training": "업로드 진행 중",
+        "completed": "업로드 완료",
+        "failed": "업로드 실패",
+        "wait": "몇 분 정도 걸릴 수 있습니다",
+        "preparing": "업로드 준비 중",
+        "parsing": "파일 파싱 중…",
+        "embedding": "임베딩 중…",
+        "tokenLimit": "토큰 한도를 초과했습니다. 더 작은 문서를 업로드해 보세요",
+        "expandDetails": "업로드 세부 정보 펼치기",
+        "collapseDetails": "업로드 세부 정보 접기",
+        "dismiss": "업로드 알림 닫기",
+        "uploadProgress": "업로드 진행률 {{progress}}%",
+        "clear": "지우기"
+      },
+      "showAdvanced": "고급 옵션 표시",
+      "hideAdvanced": "고급 옵션 숨기기",
+      "ingestors": {
+        "local_file": {
+          "label": "파일 업로드",
+          "heading": "새 문서 업로드"
+        },
+        "crawler": {
+          "label": "크롤러",
+          "heading": "웹 크롤러로 콘텐츠 추가"
+        },
+        "url": {
+          "label": "링크",
+          "heading": "URL에서 콘텐츠 추가"
+        },
+        "github": {
+          "label": "GitHub",
+          "heading": "GitHub에서 콘텐츠 추가"
+        },
+        "reddit": {
+          "label": "Reddit",
+          "heading": "Reddit에서 콘텐츠 추가"
+        },
+        "google_drive": {
+          "label": "Google 드라이브",
+          "heading": "Google 드라이브에서 업로드"
+        },
+        "s3": {
+          "label": "Amazon S3",
+          "heading": "Amazon S3에서 콘텐츠 추가"
+        },
+        "share_point": {
+          "label": "SharePoint",
+          "heading": "SharePoint에서 업로드"
+        },
+        "confluence": {
+          "label": "Confluence",
+          "heading": "Confluence에서 업로드"
+        },
+        "wiki": {
+          "label": "새 위키",
+          "heading": "살아있는 위키 만들기"
+        }
+      },
+      "connectors": {
+        "auth": {
+          "connectedUser": "연결된 사용자",
+          "authFailed": "인증에 실패했습니다",
+          "authUrlFailed": "인증 URL을 가져오지 못했습니다",
+          "popupBlocked": "인증 창을 열지 못했습니다. 팝업을 허용해 주세요.",
+          "authCancelled": "인증이 취소되었습니다",
+          "connectedAs": "{{email}} 계정으로 연결됨",
+          "disconnect": "연결 해제"
+        },
+        "googleDrive": {
+          "connect": "Google 드라이브에 연결",
+          "sessionExpired": "세션이 만료되었습니다. Google 드라이브에 다시 연결해 주세요.",
+          "sessionExpiredGeneric": "세션이 만료되었습니다. 계정을 다시 연결해 주세요.",
+          "validateFailed": "세션 확인에 실패했습니다. 다시 연결해 주세요.",
+          "noSession": "유효한 세션을 찾을 수 없습니다. Google 드라이브에 다시 연결해 주세요.",
+          "noAccessToken": "액세스 토큰이 없습니다. Google 드라이브에 다시 연결해 주세요.",
+          "pickerFailed": "파일 선택 창을 열지 못했습니다. 다시 시도해 주세요.",
+          "selectedFiles": "선택된 파일",
+          "selectFiles": "파일 선택",
+          "loading": "불러오는 중...",
+          "noFilesSelected": "선택된 파일이나 폴더가 없습니다",
+          "folders": "폴더",
+          "files": "파일",
+          "remove": "제거",
+          "folderAlt": "폴더",
+          "fileAlt": "파일"
+        },
+        "sharePoint": {
+          "connect": "SharePoint에 연결",
+          "sessionExpired": "세션이 만료되었습니다. SharePoint에 다시 연결해 주세요.",
+          "sessionExpiredGeneric": "세션이 만료되었습니다. 계정을 다시 연결해 주세요.",
+          "validateFailed": "세션 확인에 실패했습니다. 다시 연결해 주세요.",
+          "noSession": "유효한 세션을 찾을 수 없습니다. SharePoint에 다시 연결해 주세요.",
+          "noAccessToken": "액세스 토큰이 없습니다. SharePoint에 다시 연결해 주세요.",
+          "pickerFailed": "파일 선택 창을 열지 못했습니다. 다시 시도해 주세요.",
+          "selectedFiles": "선택된 파일",
+          "selectFiles": "파일 선택",
+          "loading": "불러오는 중...",
+          "noFilesSelected": "선택된 파일이나 폴더가 없습니다",
+          "folders": "폴더",
+          "files": "파일",
+          "remove": "제거",
+          "folderAlt": "폴더",
+          "fileAlt": "파일"
+        }
+      }
+    },
+    "createAPIKey": {
+      "label": "새 API 키 만들기",
+      "apiKeyName": "API 키 이름",
+      "chunks": "쿼리당 처리할 청크 수",
+      "prompt": "활성 프롬프트 선택",
+      "sourceDoc": "소스 문서",
+      "create": "만들기"
+    },
+    "saveKey": {
+      "note": "키를 저장해 주세요",
+      "disclaimer": "이 키는 지금만 표시됩니다.",
+      "copy": "복사",
+      "copied": "복사됨",
+      "confirm": "키를 저장했습니다",
+      "apiKeyLabel": "API 키"
+    },
+    "deleteConv": {
+      "confirm": "모든 대화를 삭제하시겠습니까?",
+      "delete": "삭제"
+    },
+    "shareConv": {
+      "label": "공유용 공개 페이지 만들기",
+      "note": "소스 문서, 개인정보, 이후 대화 내용은 비공개로 유지됩니다",
+      "create": "만들기",
+      "option": "사용자가 추가로 질문할 수 있도록 허용"
+    },
+    "searchConversations": {
+      "searchPlaceholder": "대화 검색",
+      "noResults": "결과를 찾을 수 없습니다",
+      "loading": "불러오는 중..."
+    },
+    "configTool": {
+      "title": "도구 설정",
+      "type": "유형",
+      "apiKeyLabel": "API 키 / OAuth",
+      "apiKeyPlaceholder": "API 키 / OAuth 입력",
+      "addButton": "도구 추가",
+      "closeButton": "닫기",
+      "customNamePlaceholder": "사용자 지정 이름 입력 (선택 사항)"
+    },
+    "prompts": {
+      "addPrompt": "프롬프트 추가",
+      "addDescription": "사용자 지정 프롬프트를 추가하여 DocsGPT에 저장하세요",
+      "editPrompt": "프롬프트 편집",
+      "editDescription": "사용자 지정 프롬프트를 편집하여 DocsGPT에 저장하세요",
+      "viewPrompt": "프롬프트 보기",
+      "viewDescription": "내장 프롬프트는 편집할 수 없습니다. 복제하여 편집 가능한 사본을 만드세요.",
+      "duplicate": "복제",
+      "duplicatePrompt": "프롬프트 복제",
+      "duplicateDescription": "\"{{name}}\"의 사본을 편집하는 중입니다 — 나만의 프롬프트로 저장하세요",
+      "promptName": "프롬프트 이름",
+      "promptText": "프롬프트 텍스트",
+      "save": "저장",
+      "cancel": "취소",
+      "nameExists": "이미 존재하는 이름입니다",
+      "deleteConfirmation": "프롬프트 '{{name}}'을(를) 삭제하시겠습니까?",
+      "placeholderText": "여기에 프롬프트 텍스트를 입력하세요...",
+      "addExamplePlaceholder": "다음 텍스트를 요약해 주세요:",
+      "variablesLabel": "변수",
+      "variablesSubtext": "클릭하여 프롬프트에 삽입",
+      "variablesDescription": "클릭하여 프롬프트에 삽입",
+      "systemVariables": "클릭하여 프롬프트에 삽입",
+      "toolVariables": "도구 변수",
+      "systemVariablesDropdownLabel": "시스템 변수",
+      "systemVariableOptions": {
+        "sourceContent": "소스 콘텐츠",
+        "sourceSummaries": "콘텐츠의 별칭 (이전 버전과 호환)",
+        "sourceDocuments": "문서 객체 목록",
+        "sourceCount": "검색된 문서 수",
+        "systemDate": "현재 날짜 (YYYY-MM-DD)",
+        "systemTime": "현재 시간 (HH:MM:SS)",
+        "systemTimestamp": "ISO 8601 타임스탬프",
+        "systemRequestId": "고유 요청 식별자",
+        "systemUserId": "현재 사용자 ID",
+        "artifactsLookup": "ID별 아티팩트 메타데이터"
+      },
+      "learnAboutPrompts": "프롬프트에 대해 알아보기 →",
+      "publicPromptEditDisabled": "공개 프롬프트는 편집할 수 없습니다",
+      "promptTypePublic": "공개",
+      "promptTypePrivate": "비공개"
+    },
+    "chunk": {
+      "add": "청크 추가",
+      "edit": "편집",
+      "title": "제목",
+      "enterTitle": "제목 입력",
+      "bodyText": "본문 텍스트",
+      "promptText": "프롬프트 텍스트",
+      "save": "저장",
+      "close": "닫기",
+      "cancel": "취소",
+      "delete": "삭제",
+      "deleteConfirmation": "이 청크를 삭제하시겠습니까?"
+    },
+    "addAction": {
+      "title": "새 작업",
+      "actionNamePlaceholder": "작업 이름",
+      "invalidFormat": "함수 이름 형식이 올바르지 않습니다. 문자, 숫자, 밑줄, 하이픈만 사용하세요.",
+      "formatHelp": "문자, 숫자, 밑줄, 하이픈만 사용하세요 (예: `get_data`, `send_report` 등)",
+      "addButton": "추가"
+    },
+    "agentDetails": {
+      "title": "접근 세부 정보",
+      "publicLink": "공개 링크",
+      "apiKey": "API 키",
+      "webhookUrl": "웹훅 URL",
+      "generate": "생성",
+      "test": "테스트",
+      "learnMore": "자세히 알아보기"
+    },
+    "importSpec": {
+      "title": "API 스펙 가져오기",
+      "description": "OpenAPI 3.x 또는 Swagger 2.0 스펙 파일을 업로드하면 작업이 자동으로 생성됩니다.",
+      "dropzoneText": "클릭하여 업로드하거나 드래그 앤 드롭하세요",
+      "supportedFormats": "JSON 또는 YAML 형식",
+      "invalidFileType": "잘못된 파일 형식입니다. JSON 또는 YAML 파일을 업로드해 주세요.",
+      "parseError": "스펙을 파싱하지 못했습니다. 파일 형식을 확인해 주세요.",
+      "version": "버전",
+      "baseUrl": "기본 URL",
+      "actionsFound": "작업 {{count}}개를 찾았습니다",
+      "selectAll": "모두 선택",
+      "deselectAll": "모두 선택 해제",
+      "cancel": "취소",
+      "parse": "파싱",
+      "import": "가져오기 ({{count}})"
+    },
+    "importAgent": {
+      "title": "YAML에서 에이전트 가져오기",
+      "description": "에이전트 YAML 파일을 업로드하세요. 소스와 도구는 회원님의 계정에 맞춰 매칭되며, 누락된 항목은 다음 단계에서 매핑하거나 새로 만들 수 있습니다. 새 에이전트는 초안으로 가져와지며, 다시 가져오면 일치하는 에이전트를 업데이트하고 현재 상태를 유지합니다.",
+      "dropzoneText": ".yaml 파일을 클릭하여 업로드하거나 드래그 앤 드롭하세요",
+      "invalidFileType": ".yaml 또는 .yml 파일만 지원됩니다",
+      "readError": "이 에이전트 파일을 읽지 못했습니다",
+      "importError": "가져오기에 실패했습니다",
+      "willCreate": "새 에이전트를 만듭니다.",
+      "willUpdate": "기존 에이전트를 업데이트합니다 ({{matchedBy}} 기준으로 일치).",
+      "sources": "소스",
+      "tools": "도구",
+      "models": "모델",
+      "sourceMatched": "{{name}}: 기존 소스를 사용합니다",
+      "sourceMissing": "{{name}}: 찾을 수 없습니다",
+      "leaveUnattached": "연결하지 않고 두기",
+      "toolBuiltin": "{{type}}: 내장",
+      "toolReuse": "{{name}}: 기존 도구를 재사용합니다",
+      "toolUnavailable": "{{type}}: 이 인스턴스에서 사용할 수 없어 건너뜁니다",
+      "toolCreate": "{{name}}: 새로 생성됩니다",
+      "secretPlaceholder": "{{field}} (이 도구를 건너뛰려면 비워두세요)",
+      "modelCustom": "{{name}}: 사용자 지정 모델",
+      "apiKeyPlaceholder": "API 키 (이 모델을 건너뛰려면 비워두세요)",
+      "warningsTitle": "에이전트가 초안으로 가져와졌습니다. 다음 항목에 주의가 필요합니다:",
+      "warningsTitlePublished": "게시된 에이전트가 업데이트되었습니다. 다음 항목에 주의가 필요합니다:",
+      "cancel": "취소",
+      "review": "검토",
+      "import": "가져오기",
+      "continueToAgent": "에이전트로 계속하기"
+    }
+  },
+  "sharedConv": {
+    "subtitle": "제작:",
+    "button": "DocsGPT로 시작하기",
+    "meta": "DocsGPT는 생성형 AI를 사용합니다. 중요한 정보는 출처를 통해 확인해 주세요."
+  },
+  "convTile": {
+    "share": "공유",
+    "delete": "삭제",
+    "rename": "이름 변경",
+    "deleteWarning": "이 대화를 삭제하시겠습니까?"
+  },
+  "pagination": {
+    "rowsPerPage": "페이지당 행 수",
+    "pageOf": "{{totalPages}} 중 {{currentPage}} 페이지",
+    "firstPage": "첫 페이지",
+    "previousPage": "이전 페이지",
+    "nextPage": "다음 페이지",
+    "lastPage": "마지막 페이지"
+  },
+  "conversation": {
+    "copy": "복사",
+    "copied": "복사됨",
+    "speak": "읽어주기",
+    "answer": "답변",
+    "edit": {
+      "update": "수정",
+      "cancel": "취소",
+      "placeholder": "수정된 질문을 입력하세요..."
+    },
+    "sources": {
+      "title": "소스",
+      "text": "소스 선택",
+      "link": "소스 링크",
+      "view_more": "소스 {{count}}개 더 보기",
+      "noSourcesAvailable": "사용 가능한 소스가 없습니다"
+    },
+    "attachments": {
+      "attach": "첨부",
+      "remove": "첨부 파일 제거"
+    },
+    "retry": "다시 시도",
+    "reasoning": "추론 과정",
+    "wikiWrite": {
+      "edited": "위키 편집됨",
+      "create": "위키 페이지 생성됨",
+      "str_replace": "위키 페이지 편집됨",
+      "insert": "위키 페이지 편집됨",
+      "delete": "위키 페이지 삭제됨",
+      "rename": "위키 페이지 이름 변경됨",
+      "failed": "실패"
+    }
+  },
+  "agents": {
+    "title": "에이전트",
+    "edit": "편집",
+    "description": "지시사항, 추가 지식, 다양한 스킬 조합을 결합한 나만의 DocsGPT 버전을 찾아보고 만들어 보세요",
+    "newAgent": "새 에이전트",
+    "importAgent": "가져오기",
+    "exportAgent": "YAML로 내보내기",
+    "shareWithTeam": "팀과 공유",
+    "backToAll": "모든 에이전트로 돌아가기",
+    "pageHeader": {
+      "crumbs": {
+        "agents": "에이전트"
+      },
+      "tabs": {
+        "overview": "개요",
+        "logs": "로그",
+        "schedules": "예약"
+      },
+      "fallbackName": "제목 없는 에이전트",
+      "subnavAriaLabel": "에이전트 하위 탐색"
+    },
+    "searchPlaceholder": "검색...",
+    "noSearchResults": "에이전트를 찾을 수 없습니다",
+    "tryDifferentSearch": "다른 검색어를 시도해 보세요",
+    "filters": {
+      "all": "전체",
+      "byDocsGPT": "템플릿",
+      "byMe": "내 에이전트",
+      "team": "팀",
+      "shared": "발견됨"
+    },
+    "teamBadge": {
+      "editor": "편집자",
+      "viewer": "뷰어"
+    },
+    "sections": {
+      "template": {
+        "title": "템플릿",
+        "description": "DocsGPT에서 제공하는 에이전트",
+        "emptyState": "템플릿 에이전트를 찾을 수 없습니다."
+      },
+      "user": {
+        "title": "내 에이전트",
+        "description": "회원님이 만들거나 게시한 에이전트",
+        "emptyState": "아직 만든 에이전트가 없습니다."
+      },
+      "team": {
+        "title": "팀",
+        "description": "팀원이 공유한 에이전트",
+        "emptyState": "아직 팀과 공유된 에이전트가 없습니다."
+      },
+      "shared": {
+        "title": "발견됨",
+        "description": "링크로 열어본 공개 에이전트",
+        "emptyState": "아직 열어본 공개 에이전트가 없습니다."
+      }
+    },
+    "form": {
+      "headings": {
+        "new": "새 에이전트",
+        "edit": "에이전트 편집",
+        "draft": "새 에이전트 (초안)"
+      },
+      "buttons": {
+        "publish": "게시",
+        "save": "저장",
+        "saveDraft": "초안 저장",
+        "cancel": "취소",
+        "delete": "삭제",
+        "logs": "로그",
+        "schedules": "예약",
+        "accessDetails": "접근 세부 정보",
+        "add": "추가",
+        "moreActions": "추가 작업"
+      },
+      "sections": {
+        "meta": "메타 정보",
+        "source": "소스",
+        "prompt": "프롬프트",
+        "tools": "도구",
+        "agentType": "에이전트 유형",
+        "models": "모델",
+        "advanced": "고급",
+        "preview": "미리보기"
+      },
+      "placeholders": {
+        "agentName": "에이전트 이름",
+        "describeAgent": "에이전트를 설명해 주세요",
+        "selectSources": "소스 선택",
+        "chunksPerQuery": "쿼리당 청크 수",
+        "selectType": "유형 선택",
+        "selectTools": "도구 선택",
+        "selectModels": "이 에이전트에 사용할 모델 선택",
+        "selectDefaultModel": "기본 모델 선택",
+        "enterTokenLimit": "토큰 한도 입력",
+        "enterRequestLimit": "요청 한도 입력"
+      },
+      "sourcePopup": {
+        "title": "소스 선택",
+        "searchPlaceholder": "소스 검색...",
+        "noOptionsMessage": "사용 가능한 소스가 없습니다"
+      },
+      "toolsPopup": {
+        "title": "도구 선택",
+        "searchPlaceholder": "도구 검색...",
+        "noOptionsMessage": "사용 가능한 도구가 없습니다",
+        "groupBuiltin": "내장",
+        "groupDefault": "기본",
+        "groupCustom": "사용자 지정"
+      },
+      "modelsPopup": {
+        "title": "모델 선택",
+        "searchPlaceholder": "모델 검색...",
+        "noOptionsMessage": "사용 가능한 모델이 없습니다"
+      },
+      "upload": {
+        "clickToUpload": "클릭하여 업로드",
+        "dragAndDrop": " 또는 드래그 앤 드롭"
+      },
+      "agentTypes": {
+        "classic": "클래식",
+        "react": "ReAct"
+      },
+      "labels": {
+        "defaultModel": "기본 모델"
+      },
+      "advanced": {
+        "jsonSchema": "JSON 응답 스키마",
+        "jsonSchemaDescription": "구조화된 출력 형식을 강제하는 JSON 스키마를 정의하세요",
+        "validJson": "유효한 JSON",
+        "invalidJson": "유효하지 않은 JSON - 저장하려면 수정하세요",
+        "tokenLimiting": "토큰 제한",
+        "tokenLimitingDescription": "이 에이전트가 사용할 수 있는 일일 총 토큰 수를 제한합니다",
+        "requestLimiting": "요청 제한",
+        "requestLimitingDescription": "이 에이전트에 대해 만들 수 있는 일일 총 요청 수를 제한합니다",
+        "systemPromptOverride": "프롬프트 재정의 허용",
+        "systemPromptOverrideDescription": "v1 API 호출자가 이 에이전트의 시스템 프롬프트를 교체할 수 있도록 허용합니다"
+      },
+      "preview": {
+        "publishedPreview": "게시된 에이전트는 여기에서 미리 볼 수 있습니다"
+      },
+      "dangerZone": {
+        "heading": "위험 구역",
+        "description": "이 에이전트를 삭제하면 영구적으로 제거되며, 모든 예약과 실행 기록도 함께 삭제됩니다.",
+        "deleteButton": "에이전트 삭제"
+      },
+      "externalKb": "외부 지식베이스"
+    },
+    "logs": {
+      "title": "에이전트 로그",
+      "lastUsedAt": "마지막 사용",
+      "noUsageHistory": "사용 기록이 없습니다",
+      "tableHeader": "에이전트 엔드포인트 로그"
+    },
+    "schedules": {
+      "title": "에이전트 예약",
+      "heading": "예약",
+      "newRecurring": "새 예약",
+      "closeForm": "양식 닫기",
+      "edit": "편집",
+      "recurring": "반복",
+      "oneTime": "일회성 작업",
+      "noRecurring": "아직 반복 예약이 없습니다.",
+      "noOneTime": "아직 일회성 작업이 없습니다.",
+      "pause": "일시 중지",
+      "resume": "재개",
+      "runNow": "지금 실행",
+      "delete": "삭제",
+      "deleteConfirm": "이 예약을 삭제하시겠습니까? 실행 기록도 함께 삭제됩니다. 이 작업은 되돌릴 수 없습니다.",
+      "cancel": "취소",
+      "showRuns": "실행 내역 표시",
+      "hideRuns": "실행 내역 숨기기",
+      "modal": {
+        "titleCreate": "새 예약",
+        "titleEdit": "예약 편집",
+        "namePlaceholder": "작업 이름",
+        "frequency": {
+          "once": "한 번",
+          "daily": "매일",
+          "weekly": "매주",
+          "monthly": "매월",
+          "yearly": "매년"
+        },
+        "on": "날짜",
+        "at": "시각",
+        "pickDate": "날짜 선택",
+        "timezone": "표준시간대",
+        "timezonePlaceholder": "표준시간대 선택",
+        "timezoneSearchPlaceholder": "표준시간대 검색…",
+        "timezoneEmpty": "표준시간대를 찾을 수 없습니다.",
+        "instructionsLabel": "지시사항",
+        "instructionsPlaceholder": "여기에 프롬프트를 입력하세요.",
+        "create": "작업 만들기",
+        "save": "변경 사항 저장",
+        "errors": {
+          "instructionRequired": "지시사항을 입력해야 합니다.",
+          "runAtInPast": "미래의 날짜/시간을 선택하세요."
+        },
+        "days": {
+          "mon": "월",
+          "tue": "화",
+          "wed": "수",
+          "thu": "목",
+          "fri": "금",
+          "sat": "토",
+          "sun": "일"
+        },
+        "months": {
+          "jan": "1월",
+          "feb": "2월",
+          "mar": "3월",
+          "apr": "4월",
+          "may": "5월",
+          "jun": "6월",
+          "jul": "7월",
+          "aug": "8월",
+          "sep": "9월",
+          "oct": "10월",
+          "nov": "11월",
+          "dec": "12월"
+        }
+      }
+    },
+    "shared": {
+      "notFound": "에이전트를 찾을 수 없습니다. 에이전트가 공유되었는지 확인해 주세요."
+    },
+    "preview": {
+      "testMessage": "여기에서 에이전트를 테스트해 보세요. 게시된 에이전트는 대화에서 사용할 수 있습니다."
+    },
+    "deleteConfirmation": "이 에이전트를 삭제하시겠습니까?",
+    "folders": {
+      "newFolder": "새 폴더",
+      "createFolder": "폴더 만들기",
+      "folderName": "폴더 이름",
+      "rename": "이름 변경",
+      "delete": "삭제",
+      "deleteConfirm": "이 폴더를 삭제하시겠습니까? 폴더 안의 에이전트는 폴더 밖으로 이동됩니다.",
+      "empty": "이 폴더는 비어 있습니다",
+      "moveToFolder": "폴더로 이동",
+      "moveTo": "이동",
+      "move": "이동",
+      "noFolder": "폴더 없음 (루트)",
+      "backToRoot": "뒤로",
+      "currentFolder": "이 폴더",
+      "noSubfolders": "하위 폴더가 없습니다",
+      "noFolders": "아직 폴더가 없습니다"
+    }
+  },
+  "components": {
+    "fileUpload": {
+      "clickToUpload": "클릭하여 업로드하거나 드래그 앤 드롭하세요",
+      "dropFiles": "여기에 파일을 놓으세요",
+      "fileTypes": "PNG, JPG, JPEG 파일, 최대",
+      "sizeLimitUnit": "MB",
+      "fileSizeError": "파일이 {{size}}MB 한도를 초과합니다"
+    }
+  },
+  "pageNotFound": {
+    "title": "404",
+    "message": "찾으시는 페이지가 존재하지 않습니다.",
+    "goHome": "홈으로 돌아가기"
+  },
+  "filePicker": {
+    "searchPlaceholder": "파일 및 폴더 검색...",
+    "itemsSelected": "{{count}}개 선택됨",
+    "name": "이름",
+    "lastModified": "마지막 수정",
+    "size": "크기",
+    "myFiles": "내 파일",
+    "sharedWithMe": "공유받은 항목",
+    "loadingMore": "파일을 더 불러오는 중..."
+  },
+  "actionButtons": {
+    "openNewChat": "새 채팅 열기",
+    "share": "공유"
+  },
+  "mermaid": {
+    "downloadOptions": "다운로드 옵션",
+    "viewCode": "코드 보기",
+    "decreaseZoom": "축소",
+    "resetZoom": "확대/축소 초기화",
+    "increaseZoom": "확대"
+  },
+  "navigation": {
+    "agents": "에이전트"
+  },
+  "teams": {
+    "switcher": {
+      "ariaLabel": "팀 전환",
+      "personal": "개인 계정",
+      "personalSubtitle": "개인 워크스페이스",
+      "roleAdmin": "관리자",
+      "roleMember": "팀원",
+      "manageTeam": "팀 관리",
+      "createTeam": "팀 만들기"
+    }
+  },
+  "notification": {
+    "ariaLabel": "알림",
+    "closeAriaLabel": "알림 닫기"
+  },
+  "prompts": {
+    "textAriaLabel": "프롬프트 텍스트"
+  }
+}

--- a/frontend/src/settings/General.tsx
+++ b/frontend/src/settings/General.tsx
@@ -38,6 +38,7 @@ export default function General() {
     { label: '普通话', value: 'zh' },
     { label: '繁體中文（臺灣）', value: 'zhTW' },
     { label: 'Русский', value: 'ru' },
+    { label: '한국어', value: 'ko' },
   ];
   const prompts = useSelector(selectPrompts);
   const [isDarkTheme, toggleTheme] = useDarkTheme();


### PR DESCRIPTION
## Motivation

This adds Korean (`ko`) translation support — to help Korean-speaking users use this
open-source project more comfortably in their own language.

한국 사람들의 오픈소스 이용에 도움이 되게 하기 위해서 한글화 작업을 하였습니다.

## Changes

- Added `frontend/src/locale/ko.json` with a full Korean translation (1,071 leaf keys — 100% coverage of `en.json`, including all `{{placeholder}}` interpolation tokens).
- Registered the new locale in `frontend/src/locale/i18n.ts` (import + `resources.ko`).
- Added `{ label: '한국어', value: 'ko' }` to the language switcher in `frontend/src/settings/General.tsx`, following the existing pattern for other locales.

## Testing

- **Key parity**: Programmatically flattened `en.json` and `ko.json` to leaf keys and diffed — 0 missing, 0 extra keys. Nested structure/types match exactly.
- **Placeholder parity**: Extracted all `{{...}}` interpolation tokens from every string and diffed en vs ko — 0 mismatches across all 1,071 keys.
- **Translation quality**: Manually spot-checked 60+ strings across chat, settings, teams, analytics, agents, modals, auth, notifications, navigation, and more — natural, consistent Korean phrasing (해요체), correct particle handling for dynamic placeholders (e.g. `{{team}}을(를)`), and brand names/URLs (GitHub, SharePoint, GraphRAG, OAuth, ReAct, etc.) intentionally left untranslated.
- **Lint**: `npm run lint` — no new errors introduced by the changed files (`i18n.ts`, `General.tsx`); pre-existing warning on `General.tsx` unrelated to this change (present identically on `main`).
- **Runtime verification**: Ran the frontend locally (`npm run dev`) and loaded `/settings/general` with `docsgpt-locale` set to `ko` in `localStorage` — confirmed the UI renders fully in Korean (see screenshot below).

### Screenshot

Captured locally via a headless Playwright browser hitting the running dev server (`npm run dev`), with the Korean locale selected on the Settings page:

- Title "Settings" → "설정"
- Tabs: 일반 / 소스 / 분석 / 로그 / 도구 / 사용자 지정 모델
- "Select Language" → "언어 선택", with "한국어" showing as the selected value

This environment doesn't have a way to host/attach the actual image file to this PR description (no image-hosting/upload tool available here). I'm happy to attach the real screenshot as a follow-up comment via the GitHub web UI, or reproduce it live on request — I did not want to skip mentioning it or fabricate a placeholder image.

### Note on existing locales (nice-to-have observation, not a complaint)

While verifying key parity, I checked all existing locale files against `en.json`'s 1,071 keys:

| Locale | Keys present | Missing |
|---|---|---|
| de | 628 | 443 |
| es, jp, ru, zh, zh-TW | 644 | 427 |
| ko (this PR) | 1,071 | 0 |

The existing locales appear to predate several newer features (teams, analytics, agents, etc.) and haven't been updated since. Not asking for those to be fixed here — just flagging it in case it's useful context for a future translation-refresh pass.
