### PR TITLE
feat: add HNSW ANN indexes for FAISS and pgvector (#2546)

### DIFF
--- a/application/core/settings.py
+++ b/application/core/settings.py
@@ -96,6 +96,24 @@ class Settings(BaseSettings):
     # default (100) drives worker RSS to ~3 GB on a mid-size PDF.
     DOCLING_PIPELINE_QUEUE_MAX_SIZE: int = 2
     VECTOR_STORE: str = "faiss"  #  "faiss" or "elasticsearch" or "qdrant" or "milvus" or "lancedb" or "pgvector"
+    # FAISS ANN index type for newly built indexes. Existing on-disk indexes
+    # load as-is (flat or hnsw). "hnsw" enables Hierarchical Navigable Small
+    # World approximate nearest-neighbor search; "flat" keeps exact L2 search.
+    FAISS_INDEX_TYPE: str = "hnsw"  # "hnsw" or "flat"
+    # HNSW graph degree (M) and build/search dynamic candidate lists.
+    # M=16 / ef_construction=200 are solid defaults for document retrieval;
+    # raise ef_search for higher recall at query time (more latency).
+    FAISS_HNSW_M: int = 16
+    FAISS_HNSW_EF_CONSTRUCTION: int = 200
+    FAISS_HNSW_EF_SEARCH: int = 64
+    # pgvector index type for the documents table vector column.
+    # "hnsw" (default) supports incremental inserts and empty-table creation;
+    # "ivfflat" keeps the legacy lists-based index.
+    PGVECTOR_INDEX_TYPE: str = "hnsw"  # "hnsw" or "ivfflat"
+    PGVECTOR_HNSW_M: int = 16
+    PGVECTOR_HNSW_EF_CONSTRUCTION: int = 64
+    PGVECTOR_HNSW_EF_SEARCH: int = 40
+    PGVECTOR_IVFFLAT_LISTS: int = 100
     # Allow-list of retriever keys an agent may use. Values must match the
     # ``RetrieverCreator.retrievers`` registry keys (``classic`` / ``default``),
     # NOT the legacy ``classic_rag`` label which never matched the registry.

--- a/application/vectorstore/faiss.py
+++ b/application/vectorstore/faiss.py
@@ -1,13 +1,19 @@
+import logging
 import os
 import tempfile
 import io
+from typing import Any, List, Optional, Sequence
 
+import faiss
+from langchain_community.docstore.in_memory import InMemoryDocstore
 from langchain_community.vectorstores import FAISS
 
 from application.core.settings import settings
 from application.parser.schema.base import Document
 from application.vectorstore.base import BaseVectorStore
 from application.storage.storage_creator import StorageCreator
+
+logger = logging.getLogger(__name__)
 
 
 def get_vectorstore(path: str) -> str:
@@ -40,6 +46,78 @@ def get_vectorstore(path: str) -> str:
     return candidate
 
 
+def _resolve_index_type() -> str:
+    """Return the configured FAISS index type (``hnsw`` or ``flat``)."""
+    index_type = (settings.FAISS_INDEX_TYPE or "hnsw").strip().lower()
+    if index_type not in {"hnsw", "flat"}:
+        raise ValueError(
+            f"Unsupported FAISS_INDEX_TYPE={index_type!r}; expected 'hnsw' or 'flat'"
+        )
+    return index_type
+
+
+def build_faiss_index(dimension: int) -> Any:
+    """Create a FAISS index for the configured algorithm.
+
+    Args:
+        dimension: Embedding dimensionality of vectors that will be stored.
+
+    Returns:
+        A FAISS index instance (``IndexHNSWFlat`` or ``IndexFlatL2``).
+    """
+    if dimension <= 0:
+        raise ValueError(f"Embedding dimension must be positive, got {dimension}")
+
+    index_type = _resolve_index_type()
+    if index_type == "flat":
+        return faiss.IndexFlatL2(dimension)
+
+    m = max(1, int(settings.FAISS_HNSW_M))
+    ef_construction = max(1, int(settings.FAISS_HNSW_EF_CONSTRUCTION))
+    ef_search = max(1, int(settings.FAISS_HNSW_EF_SEARCH))
+
+    # IndexHNSWFlat stores full vectors and builds an HNSW graph for ANN search.
+    index = faiss.IndexHNSWFlat(dimension, m)
+    index.hnsw.efConstruction = ef_construction
+    index.hnsw.efSearch = ef_search
+    logger.info(
+        "Built FAISS HNSW index dim=%s M=%s efConstruction=%s efSearch=%s",
+        dimension,
+        m,
+        ef_construction,
+        ef_search,
+    )
+    return index
+
+
+def _is_hnsw_index(index: Any) -> bool:
+    """Return True when ``index`` is a FAISS HNSW index.
+
+    Uses ``isinstance`` / type name rather than ``hasattr(..., "hnsw")`` so
+    unit-test ``Mock`` objects are not treated as HNSW (Mocks auto-create
+    attributes on access).
+    """
+    if index is None:
+        return False
+    if isinstance(index, faiss.IndexHNSWFlat):
+        return True
+    # Cover SWIG proxy type-name variants without treating Mock as HNSW.
+    name = getattr(type(index), "__name__", "")
+    return name == "IndexHNSWFlat"
+
+
+def apply_hnsw_search_params(index: Any) -> None:
+    """Apply runtime ``efSearch`` to a loaded HNSW index when present.
+
+    Args:
+        index: FAISS index loaded from storage or newly created.
+    """
+    if not _is_hnsw_index(index):
+        return
+    ef_search = max(1, int(settings.FAISS_HNSW_EF_SEARCH))
+    index.hnsw.efSearch = ef_search
+
+
 class FaissStore(BaseVectorStore):
     def __init__(self, source_id: str, embeddings_key: str, docs_init=None):
         super().__init__()
@@ -50,7 +128,7 @@ class FaissStore(BaseVectorStore):
 
         try:
             if docs_init:
-                self.docsearch = FAISS.from_documents(docs_init, self.embeddings)
+                self.docsearch = self._create_from_documents(docs_init)
             else:
                 with tempfile.TemporaryDirectory() as temp_dir:
                     faiss_path = f"{self.path}/index.faiss"
@@ -78,13 +156,85 @@ class FaissStore(BaseVectorStore):
                     self.docsearch = FAISS.load_local(
                         temp_dir, self.embeddings, allow_dangerous_deserialization=True
                     )
+                    apply_hnsw_search_params(self.docsearch.index)
         except Exception as e:
             raise Exception(f"Error loading FAISS index: {str(e)}")
 
         self.assert_embedding_dimensions(self.embeddings)
 
+    def _embedding_dimension(self, docs: Optional[Sequence] = None) -> int:
+        """Resolve embedding dimension from the model or a sample document."""
+        dimension = getattr(self.embeddings, "dimension", None)
+        if dimension:
+            return int(dimension)
+        if docs:
+            sample = docs[0]
+            text = getattr(sample, "page_content", None)
+            if text is None and hasattr(sample, "text"):
+                text = sample.text
+            if text is None:
+                text = str(sample)
+            return len(self.embeddings.embed_query(text))
+        raise ValueError(
+            "Cannot determine embedding dimension without embeddings.dimension "
+            "or seed documents"
+        )
+
+    def _create_from_documents(self, docs: Sequence) -> FAISS:
+        """Build a FAISS store from documents using the configured index type.
+
+        Args:
+            docs: Seed documents (LangChain ``Document`` instances).
+
+        Returns:
+            A populated LangChain ``FAISS`` vector store.
+        """
+        index_type = _resolve_index_type()
+        if index_type == "flat":
+            # Preserve historical exact-search path.
+            return FAISS.from_documents(docs, self.embeddings)
+
+        dimension = self._embedding_dimension(docs)
+        index = build_faiss_index(dimension)
+        store = FAISS(
+            embedding_function=self.embeddings,
+            index=index,
+            docstore=InMemoryDocstore(),
+            index_to_docstore_id={},
+        )
+        if docs:
+            store.add_documents(list(docs))
+        return store
+
+    def _rebuild_without_ids(self, ids_to_delete: Sequence[str]) -> None:
+        """Rebuild the FAISS index excluding the given docstore ids.
+
+        HNSW indexes do not support ``remove_ids``; the standard workaround is
+        to soft-omit vectors by rebuilding from the remaining docstore entries.
+        """
+        delete_set = set(ids_to_delete)
+        remaining_docs = []
+        remaining_ids: List[str] = []
+        docstore_dict = getattr(self.docsearch.docstore, "_dict", {}) or {}
+        for doc_id, doc in docstore_dict.items():
+            if doc_id not in delete_set:
+                remaining_docs.append(doc)
+                remaining_ids.append(doc_id)
+
+        dimension = self.docsearch.index.d
+        index = build_faiss_index(dimension)
+        store = FAISS(
+            embedding_function=self.embeddings,
+            index=index,
+            docstore=InMemoryDocstore(),
+            index_to_docstore_id={},
+        )
+        if remaining_docs:
+            store.add_documents(remaining_docs, ids=remaining_ids)
+        self.docsearch = store
+
     def search(self, *args, **kwargs):
-        # FAISS has no relevance-threshold knob; drop it so the per-source
+        # FAISS has no relevance-threshold knobs; drop it so the per-source
         # score_threshold is safely ignored rather than crashing the forward.
         kwargs.pop("score_threshold", None)
         return self.docsearch.similarity_search(*args, **kwargs)
@@ -125,6 +275,15 @@ class FaissStore(BaseVectorStore):
         return True
 
     def delete_index(self, *args, **kwargs):
+        """Delete vectors by docstore id.
+
+        HNSW does not support in-place removal, so those indexes are rebuilt
+        without the deleted ids. Flat indexes use FAISS native ``remove_ids``.
+        """
+        ids = args[0] if args else kwargs.get("ids")
+        if ids is not None and _is_hnsw_index(self.docsearch.index):
+            self._rebuild_without_ids(list(ids))
+            return True
         return self.docsearch.delete(*args, **kwargs)
 
     def assert_embedding_dimensions(self, embeddings):
@@ -164,8 +323,6 @@ class FaissStore(BaseVectorStore):
         doc_id = self.docsearch.add_documents([doc])
         self._save_to_storage()
         return doc_id
-
-
 
     def delete_chunk(self, chunk_id):
         """Delete a chunk and save to storage."""

--- a/application/vectorstore/pgvector.py
+++ b/application/vectorstore/pgvector.py
@@ -92,12 +92,31 @@ class PGVectorStore(BaseVectorStore):
             """
             cursor.execute(create_table_query)
             
-            # Create index for vector similarity search
-            index_query = f"""
-            CREATE INDEX IF NOT EXISTS {self._table_name}_{self._vector_column}_idx 
-            ON {self._table_name} USING ivfflat ({self._vector_column} vector_cosine_ops)
-            WITH (lists = 100);
-            """
+            # Create ANN index for vector similarity search.
+            # HNSW is the default: better incremental inserts, works on empty
+            # tables, and matches the FAISS HNSW path. IVFFlat remains available
+            # via PGVECTOR_INDEX_TYPE=ivfflat. Index names differ so upgrades
+            # from IVFFlat do not collide with CREATE INDEX IF NOT EXISTS.
+            index_type = (getattr(settings, "PGVECTOR_INDEX_TYPE", "hnsw") or "hnsw").strip().lower()
+            if index_type == "hnsw":
+                m = max(2, int(getattr(settings, "PGVECTOR_HNSW_M", 16)))
+                ef_construction = max(4, int(getattr(settings, "PGVECTOR_HNSW_EF_CONSTRUCTION", 64)))
+                index_query = f"""
+                CREATE INDEX IF NOT EXISTS {self._table_name}_{self._vector_column}_hnsw_idx
+                ON {self._table_name} USING hnsw ({self._vector_column} vector_cosine_ops)
+                WITH (m = {m}, ef_construction = {ef_construction});
+                """
+            elif index_type == "ivfflat":
+                lists = max(1, int(getattr(settings, "PGVECTOR_IVFFLAT_LISTS", 100)))
+                index_query = f"""
+                CREATE INDEX IF NOT EXISTS {self._table_name}_{self._vector_column}_idx
+                ON {self._table_name} USING ivfflat ({self._vector_column} vector_cosine_ops)
+                WITH (lists = {lists});
+                """
+            else:
+                raise ValueError(
+                    f"Unsupported PGVECTOR_INDEX_TYPE={index_type!r}; expected 'hnsw' or 'ivfflat'"
+                )
             cursor.execute(index_query)
             
             # Create index for source_id filtering
@@ -145,6 +164,12 @@ class PGVectorStore(BaseVectorStore):
         cursor = conn.cursor()
 
         try:
+            index_type = (getattr(settings, "PGVECTOR_INDEX_TYPE", "hnsw") or "hnsw").strip().lower()
+            if index_type == "hnsw":
+                # Session-local search width; higher → better recall, more latency.
+                ef_search = max(1, int(getattr(settings, "PGVECTOR_HNSW_EF_SEARCH", 40)))
+                cursor.execute("SET LOCAL hnsw.ef_search = %s", (ef_search,))
+
             # Use cosine distance for similarity search with proper vector formatting
             search_query = f"""
             SELECT {self._text_column}, {self._metadata_column},

--- a/tests/vectorstore/test_faiss.py
+++ b/tests/vectorstore/test_faiss.py
@@ -1,7 +1,21 @@
 import io
+import os
 from unittest.mock import Mock, patch
 
 import pytest
+
+
+def _configure_settings(mock_settings, embeddings_name="test_model", index_type="flat"):
+    """Apply vector-store settings used by FaissStore unit tests.
+
+    Existing tests default to ``flat`` so they exercise the historical
+    ``FAISS.from_documents`` path. HNSW-specific tests override ``index_type``.
+    """
+    mock_settings.EMBEDDINGS_NAME = embeddings_name
+    mock_settings.FAISS_INDEX_TYPE = index_type
+    mock_settings.FAISS_HNSW_M = 16
+    mock_settings.FAISS_HNSW_EF_CONSTRUCTION = 200
+    mock_settings.FAISS_HNSW_EF_SEARCH = 64
 
 
 @pytest.fixture
@@ -50,7 +64,7 @@ class TestFaissStoreInit:
     )
     @patch("application.vectorstore.faiss.settings")
     def test_init_with_docs(self, mock_settings, mock_get_emb, mock_faiss, mock_storage_creator):
-        mock_settings.EMBEDDINGS_NAME = "test_model"
+        _configure_settings(mock_settings)
         mock_emb = Mock(dimension=3)
         mock_get_emb.return_value = mock_emb
         mock_ds = Mock()
@@ -74,7 +88,7 @@ class TestFaissStoreInit:
     def test_init_missing_index_files(
         self, mock_settings, mock_get_emb, mock_faiss, mock_storage_creator
     ):
-        mock_settings.EMBEDDINGS_NAME = "test_model"
+        _configure_settings(mock_settings)
         mock_emb = Mock(dimension=3)
         mock_get_emb.return_value = mock_emb
         mock_storage = Mock()
@@ -99,7 +113,7 @@ class TestFaissStoreSearch:
     def test_search_delegates_to_docsearch(
         self, mock_settings, mock_get_emb, mock_faiss, mock_storage_creator
     ):
-        mock_settings.EMBEDDINGS_NAME = "test_model"
+        _configure_settings(mock_settings)
         mock_emb = Mock(dimension=3)
         mock_get_emb.return_value = mock_emb
         mock_ds = Mock()
@@ -127,7 +141,7 @@ class TestFaissStoreSearch:
     ):
         # FAISS has no relevance-threshold knob; the per-source score_threshold
         # must be safely dropped, not forwarded (which would crash langchain).
-        mock_settings.EMBEDDINGS_NAME = "test_model"
+        _configure_settings(mock_settings)
         mock_get_emb.return_value = Mock(dimension=3)
         mock_ds = Mock()
         mock_ds.index = Mock(d=3)
@@ -156,7 +170,7 @@ class TestFaissStoreAddTexts:
     def test_add_texts_delegates(
         self, mock_settings, mock_get_emb, mock_faiss, mock_storage_creator
     ):
-        mock_settings.EMBEDDINGS_NAME = "test_model"
+        _configure_settings(mock_settings)
         mock_emb = Mock(dimension=3)
         mock_get_emb.return_value = mock_emb
         mock_ds = Mock()
@@ -182,7 +196,7 @@ class TestFaissStoreGetChunks:
     )
     @patch("application.vectorstore.faiss.settings")
     def test_get_chunks(self, mock_settings, mock_get_emb, mock_faiss, mock_storage_creator):
-        mock_settings.EMBEDDINGS_NAME = "test_model"
+        _configure_settings(mock_settings)
         mock_emb = Mock(dimension=3)
         mock_get_emb.return_value = mock_emb
 
@@ -212,7 +226,7 @@ class TestFaissStoreGetChunks:
     )
     @patch("application.vectorstore.faiss.settings")
     def test_get_chunks_empty(self, mock_settings, mock_get_emb, mock_faiss, mock_storage_creator):
-        mock_settings.EMBEDDINGS_NAME = "test_model"
+        _configure_settings(mock_settings)
         mock_emb = Mock(dimension=3)
         mock_get_emb.return_value = mock_emb
         mock_ds = Mock()
@@ -239,7 +253,7 @@ class TestFaissStoreSaveLocal:
     def test_save_local_with_path(
         self, mock_settings, mock_get_emb, mock_faiss, mock_storage_creator
     ):
-        mock_settings.EMBEDDINGS_NAME = "test_model"
+        _configure_settings(mock_settings)
         mock_emb = Mock(dimension=3)
         mock_get_emb.return_value = mock_emb
         mock_ds = Mock()
@@ -275,7 +289,7 @@ class TestFaissStoreDeleteIndex:
     def test_delete_index_delegates(
         self, mock_settings, mock_get_emb, mock_faiss, mock_storage_creator
     ):
-        mock_settings.EMBEDDINGS_NAME = "test_model"
+        _configure_settings(mock_settings)
         mock_emb = Mock(dimension=3)
         mock_get_emb.return_value = mock_emb
         mock_ds = Mock()
@@ -302,8 +316,9 @@ class TestFaissStoreAssertEmbeddingDimensions:
     def test_dimension_mismatch_raises(
         self, mock_settings, mock_get_emb, mock_faiss, mock_storage_creator
     ):
-        mock_settings.EMBEDDINGS_NAME = (
-            "huggingface_sentence-transformers/all-mpnet-base-v2"
+        _configure_settings(
+            mock_settings,
+            embeddings_name="huggingface_sentence-transformers/all-mpnet-base-v2",
         )
         mock_emb = Mock(dimension=768)
         mock_get_emb.return_value = mock_emb
@@ -327,8 +342,9 @@ class TestFaissStoreAssertEmbeddingDimensions:
     def test_missing_dimension_attr_raises(
         self, mock_settings, mock_get_emb, mock_faiss, mock_storage_creator
     ):
-        mock_settings.EMBEDDINGS_NAME = (
-            "huggingface_sentence-transformers/all-mpnet-base-v2"
+        _configure_settings(
+            mock_settings,
+            embeddings_name="huggingface_sentence-transformers/all-mpnet-base-v2",
         )
         mock_emb = Mock(spec=[])  # No dimension attribute
         mock_get_emb.return_value = mock_emb
@@ -353,7 +369,7 @@ class TestFaissStoreDeleteChunk:
     )
     @patch("application.vectorstore.faiss.settings")
     def test_delete_chunk(self, mock_settings, mock_get_emb, mock_faiss, mock_storage_creator):
-        mock_settings.EMBEDDINGS_NAME = "test_model"
+        _configure_settings(mock_settings)
         mock_emb = Mock(dimension=3)
         mock_get_emb.return_value = mock_emb
         mock_ds = Mock()
@@ -378,7 +394,7 @@ class TestGetVectorstore:
     def test_with_path(self):
         from application.vectorstore.faiss import get_vectorstore
 
-        assert get_vectorstore("abc123") == "indexes/abc123"
+        assert get_vectorstore("abc123") == os.path.join("indexes", "abc123")
 
     def test_without_path(self):
         from application.vectorstore.faiss import get_vectorstore
@@ -389,7 +405,9 @@ class TestGetVectorstore:
     def test_with_nested_path(self):
         from application.vectorstore.faiss import get_vectorstore
 
-        assert get_vectorstore("user/source123") == "indexes/user/source123"
+        assert get_vectorstore("user/source123") == os.path.join(
+            "indexes", "user", "source123"
+        )
 
     @pytest.mark.parametrize(
         "malicious_path",
@@ -411,7 +429,9 @@ class TestGetVectorstore:
     def test_allows_mongodb_style_ids(self):
         from application.vectorstore.faiss import get_vectorstore
 
-        assert get_vectorstore("65e8f6a8a7a96b1bdad4154f") == "indexes/65e8f6a8a7a96b1bdad4154f"
+        assert get_vectorstore("65e8f6a8a7a96b1bdad4154f") == os.path.join(
+            "indexes", "65e8f6a8a7a96b1bdad4154f"
+        )
 
 
 @pytest.mark.unit
@@ -426,7 +446,7 @@ class TestFaissStoreAddChunk:
     def test_add_chunk_with_metadata(
         self, mock_settings, mock_get_emb, mock_faiss, mock_storage_creator
     ):
-        mock_settings.EMBEDDINGS_NAME = "test_model"
+        _configure_settings(mock_settings)
         mock_emb = Mock(dimension=3)
         mock_get_emb.return_value = mock_emb
         mock_ds = Mock()
@@ -457,7 +477,7 @@ class TestFaissStoreAddChunk:
     def test_add_chunk_default_metadata(
         self, mock_settings, mock_get_emb, mock_faiss, mock_storage_creator
     ):
-        mock_settings.EMBEDDINGS_NAME = "test_model"
+        _configure_settings(mock_settings)
         mock_emb = Mock(dimension=3)
         mock_get_emb.return_value = mock_emb
         mock_ds = Mock()
@@ -489,7 +509,7 @@ class TestFaissStoreSaveLocalNoPath:
     def test_save_local_without_path(
         self, mock_settings, mock_get_emb, mock_faiss, mock_storage_creator
     ):
-        mock_settings.EMBEDDINGS_NAME = "test_model"
+        _configure_settings(mock_settings)
         mock_emb = Mock(dimension=3)
         mock_get_emb.return_value = mock_emb
         mock_ds = Mock()
@@ -523,8 +543,9 @@ class TestFaissStoreAssertEmbeddingDimensionsMatch:
     def test_dimension_match_passes(
         self, mock_settings, mock_get_emb, mock_faiss, mock_storage_creator
     ):
-        mock_settings.EMBEDDINGS_NAME = (
-            "huggingface_sentence-transformers/all-mpnet-base-v2"
+        _configure_settings(
+            mock_settings,
+            embeddings_name="huggingface_sentence-transformers/all-mpnet-base-v2",
         )
         mock_emb = Mock(dimension=768)
         mock_get_emb.return_value = mock_emb
@@ -549,7 +570,10 @@ class TestFaissStoreAssertEmbeddingDimensionsMatch:
     def test_non_huggingface_skips_dimension_check(
         self, mock_settings, mock_get_emb, mock_faiss, mock_storage_creator
     ):
-        mock_settings.EMBEDDINGS_NAME = "openai_text-embedding-ada-002"
+        _configure_settings(
+            mock_settings,
+            embeddings_name="openai_text-embedding-ada-002",
+        )
         mock_emb = Mock(dimension=1536)
         mock_get_emb.return_value = mock_emb
         mock_ds = Mock()
@@ -562,3 +586,167 @@ class TestFaissStoreAssertEmbeddingDimensionsMatch:
         # Should not raise since embedding name is not the huggingface one
         store = FaissStore(source_id="t", embeddings_key="k", docs_init=[Mock()])
         assert store is not None
+
+
+@pytest.mark.unit
+class TestFaissHnswIndex:
+    """HNSW-specific construction, search params, and delete-via-rebuild."""
+
+    @patch("application.vectorstore.faiss.StorageCreator")
+    @patch("application.vectorstore.faiss.FAISS")
+    @patch("application.vectorstore.faiss.build_faiss_index")
+    @patch("application.vectorstore.faiss.InMemoryDocstore")
+    @patch.object(
+        __import__("application.vectorstore.base", fromlist=["BaseVectorStore"]).BaseVectorStore,
+        "_get_embeddings",
+    )
+    @patch("application.vectorstore.faiss.settings")
+    def test_init_with_docs_uses_hnsw_index(
+        self,
+        mock_settings,
+        mock_get_emb,
+        mock_docstore,
+        mock_build_index,
+        mock_faiss,
+        mock_storage_creator,
+    ):
+        _configure_settings(mock_settings, index_type="hnsw")
+        mock_emb = Mock(dimension=3)
+        mock_get_emb.return_value = mock_emb
+        mock_index = Mock()
+        mock_index.d = 3
+        mock_build_index.return_value = mock_index
+        mock_store = Mock()
+        mock_store.index = mock_index
+        mock_faiss.return_value = mock_store
+        mock_storage_creator.get_storage.return_value = Mock()
+
+        from application.vectorstore.faiss import FaissStore
+
+        store = FaissStore(source_id="t", embeddings_key="k", docs_init=[Mock()])
+
+        mock_build_index.assert_called_once_with(3)
+        mock_faiss.assert_called_once()
+        mock_store.add_documents.assert_called_once()
+        mock_faiss.from_documents.assert_not_called()
+        assert store.docsearch is mock_store
+
+    @patch("application.vectorstore.faiss.StorageCreator")
+    @patch("application.vectorstore.faiss.FAISS")
+    @patch("application.vectorstore.faiss.apply_hnsw_search_params")
+    @patch.object(
+        __import__("application.vectorstore.base", fromlist=["BaseVectorStore"]).BaseVectorStore,
+        "_get_embeddings",
+    )
+    @patch("application.vectorstore.faiss.settings")
+    def test_load_local_applies_ef_search(
+        self,
+        mock_settings,
+        mock_get_emb,
+        mock_apply_ef,
+        mock_faiss,
+        mock_storage_creator,
+    ):
+        _configure_settings(mock_settings, index_type="hnsw")
+        mock_get_emb.return_value = Mock(dimension=3)
+        mock_storage = Mock()
+        mock_storage.file_exists.return_value = True
+        mock_storage.get_file.return_value = io.BytesIO(b"fake")
+        mock_storage_creator.get_storage.return_value = mock_storage
+        mock_ds = Mock()
+        mock_ds.index = Mock(d=3)
+        mock_faiss.load_local.return_value = mock_ds
+
+        from application.vectorstore.faiss import FaissStore
+
+        FaissStore(source_id="t", embeddings_key="k")
+        mock_apply_ef.assert_called_once_with(mock_ds.index)
+
+    @patch("application.vectorstore.faiss.StorageCreator")
+    @patch("application.vectorstore.faiss.FAISS")
+    @patch("application.vectorstore.faiss.build_faiss_index")
+    @patch("application.vectorstore.faiss.InMemoryDocstore")
+    @patch.object(
+        __import__("application.vectorstore.base", fromlist=["BaseVectorStore"]).BaseVectorStore,
+        "_get_embeddings",
+    )
+    @patch("application.vectorstore.faiss.settings")
+    def test_hnsw_delete_rebuilds_without_id(
+        self,
+        mock_settings,
+        mock_get_emb,
+        mock_docstore,
+        mock_build_index,
+        mock_faiss,
+        mock_storage_creator,
+    ):
+        _configure_settings(mock_settings, index_type="hnsw")
+        mock_get_emb.return_value = Mock(dimension=3)
+        mock_storage_creator.get_storage.return_value = Mock()
+
+        keep_doc = Mock(page_content="keep", metadata={})
+        drop_doc = Mock(page_content="drop", metadata={})
+
+        faiss = pytest.importorskip("faiss")
+        hnsw_index = faiss.IndexHNSWFlat(3, 16)
+        hnsw_index.hnsw.efConstruction = 200
+        hnsw_index.hnsw.efSearch = 64
+
+        original = Mock()
+        original.index = hnsw_index
+        original.docstore._dict = {"keep": keep_doc, "drop": drop_doc}
+        original.delete = Mock(side_effect=AssertionError("native delete must not run"))
+
+        rebuilt = Mock()
+        rebuilt.index = Mock(d=3)
+        mock_build_index.return_value = Mock(d=3)
+        mock_faiss.side_effect = [original, rebuilt]
+
+        from application.vectorstore.faiss import FaissStore
+
+        store = FaissStore(source_id="t", embeddings_key="k", docs_init=[Mock()])
+        store.docsearch = original
+
+        store.delete_index(["drop"])
+
+        mock_build_index.assert_called()
+        rebuilt.add_documents.assert_called_once()
+        args, kwargs = rebuilt.add_documents.call_args
+        assert args[0] == [keep_doc]
+        assert kwargs.get("ids") == ["keep"]
+        assert store.docsearch is rebuilt
+
+    def test_build_faiss_index_hnsw_sets_params(self):
+        faiss = pytest.importorskip("faiss")
+        with patch("application.vectorstore.faiss.settings") as mock_settings:
+            _configure_settings(mock_settings, index_type="hnsw")
+            mock_settings.FAISS_HNSW_M = 16
+            mock_settings.FAISS_HNSW_EF_CONSTRUCTION = 200
+            mock_settings.FAISS_HNSW_EF_SEARCH = 64
+
+            from application.vectorstore.faiss import build_faiss_index
+
+            index = build_faiss_index(8)
+            assert isinstance(index, faiss.IndexHNSWFlat)
+            assert index.d == 8
+            assert index.hnsw.efConstruction == 200
+            assert index.hnsw.efSearch == 64
+
+    def test_build_faiss_index_flat(self):
+        faiss = pytest.importorskip("faiss")
+        with patch("application.vectorstore.faiss.settings") as mock_settings:
+            _configure_settings(mock_settings, index_type="flat")
+
+            from application.vectorstore.faiss import build_faiss_index
+
+            index = build_faiss_index(4)
+            assert isinstance(index, faiss.IndexFlatL2)
+            assert index.d == 4
+
+    def test_build_faiss_index_rejects_unknown_type(self):
+        with patch("application.vectorstore.faiss.settings") as mock_settings:
+            mock_settings.FAISS_INDEX_TYPE = "ivf"
+            from application.vectorstore.faiss import build_faiss_index
+
+            with pytest.raises(ValueError, match="Unsupported FAISS_INDEX_TYPE"):
+                build_faiss_index(4)

--- a/tests/vectorstore/test_pgvector.py
+++ b/tests/vectorstore/test_pgvector.py
@@ -28,6 +28,11 @@ def _make_store(
         mock_get_emb.return_value = mock_emb
         mock_settings.EMBEDDINGS_NAME = "test_model"
         mock_settings.PGVECTOR_CONNECTION_STRING = connection_string
+        mock_settings.PGVECTOR_INDEX_TYPE = "hnsw"
+        mock_settings.PGVECTOR_HNSW_M = 16
+        mock_settings.PGVECTOR_HNSW_EF_CONSTRUCTION = 64
+        mock_settings.PGVECTOR_HNSW_EF_SEARCH = 40
+        mock_settings.PGVECTOR_IVFFLAT_LISTS = 100
 
         from application.vectorstore.pgvector import PGVectorStore
 
@@ -95,6 +100,9 @@ class TestPGVectorStoreSearch:
         assert len(results) == 2
         assert results[0].page_content == "hello world"
         assert results[0].metadata == {"source": "test.txt"}
+        # HNSW search width is applied per query.
+        set_local = mock_cursor.execute.call_args_list[0]
+        assert "hnsw.ef_search" in set_local.args[0]
 
     def test_search_returns_empty_on_error(self):
         store, mock_conn, mock_cursor, _ = _make_store()
@@ -184,6 +192,30 @@ class TestPGVectorStoreKeywordSearch:
         )
         assert "documents_text_fts_idx" in executed
         assert "gin(to_tsvector('english'" in executed
+
+    def test_ensure_table_exists_creates_hnsw_index_by_default(self):
+        store, mock_conn, mock_cursor, _ = _make_store()
+        store._ensure_table_exists()
+
+        executed = " ".join(
+            str(call.args[0]) for call in mock_cursor.execute.call_args_list
+        )
+        assert "USING hnsw" in executed
+        assert "documents_embedding_hnsw_idx" in executed
+        assert "ef_construction" in executed
+
+    def test_ensure_table_exists_can_use_ivfflat(self):
+        store, mock_conn, mock_cursor, _ = _make_store()
+        with patch("application.vectorstore.pgvector.settings") as mock_settings:
+            mock_settings.PGVECTOR_INDEX_TYPE = "ivfflat"
+            mock_settings.PGVECTOR_IVFFLAT_LISTS = 100
+            store._ensure_table_exists()
+
+        executed = " ".join(
+            str(call.args[0]) for call in mock_cursor.execute.call_args_list
+        )
+        assert "USING ivfflat" in executed
+        assert "documents_embedding_idx" in executed
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Use IndexHNSWFlat for newly built FAISS indexes (configurable flat fallback) and HNSW for pgvector, with rebuild-on-delete for FAISS HNSW since remove_ids is unsupported. Tunables cover M, ef_construction, and ef_search.

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  Feature — approximate nearest-neighbor (ANN) indexing via HNSW for faster vector search.

- **Why was this change needed?** (You can also link to an open issue here)

  Exact FAISS flat search and pgvector IVFFlat do not scale as well for larger indexes. HNSW is a standard graph-based ANN structure that improves retrieval latency while keeping strong recall. Closes #2546.

- **Other information**:

  - **FAISS (default store):** new indexes use `IndexHNSWFlat` (`FAISS_INDEX_TYPE=hnsw`, default). Set `FAISS_INDEX_TYPE=flat` for exact L2. Existing on-disk indexes load as-is; `efSearch` is applied when the loaded index is HNSW.
  - **Deletes:** FAISS HNSW does not support `remove_ids`; delete rebuilds the index without the removed ids.
  - **pgvector:** default index is HNSW (`PGVECTOR_INDEX_TYPE=hnsw`); IVFFlat remains available. Search sets `SET LOCAL hnsw.ef_search`.
  - **Tunables:** `FAISS_HNSW_M` (16), `FAISS_HNSW_EF_CONSTRUCTION` (200), `FAISS_HNSW_EF_SEARCH` (64), plus matching `PGVECTOR_HNSW_*` settings.
  - **Tests:** unit coverage for HNSW build, load-time efSearch, delete-via-rebuild, and pgvector HNSW/IVFFlat index creation.
  - Backend-only change (no UI screenshots).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

- [x] Unit tests
- [x] Manual tests

**Test Configuration**:
* Python: 3.11
* Focused suite: `tests/vectorstore/test_faiss.py` and `tests/vectorstore/test_pgvector.py` (69 passed)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have already covered my code with unit tests
- [x] I have made corresponding changes to the documentation (N/A — settings are documented in `settings.py`)
- [x] I have added an explanation of my changes

## Related issues

Closes #2546