### PR TITLE
feat: add pre-execution MCP trust verification hook (#2501)

### DIFF
--- a/application/agents/tools/mcp_tool.py
+++ b/application/agents/tools/mcp_tool.py
@@ -26,6 +26,7 @@ from application.core.settings import settings
 from application.core.url_validation import SSRFError, validate_url
 from application.events.keys import stream_key
 from application.security.encryption import decrypt_credentials
+from application.security.mcp_trust import TrustContext, enforce_mcp_trust
 
 logger = logging.getLogger(__name__)
 
@@ -346,13 +347,28 @@ class MCPTool(Tool):
     def execute_action(self, action_name: str, **kwargs) -> Any:
         if not self.server_url:
             raise Exception("No MCP server configured")
-        if not self._client:
-            self._setup_client()
         cleaned_kwargs = {}
         for key, value in kwargs.items():
             if value == "" or value is None:
                 continue
             cleaned_kwargs[key] = value
+
+        # Pre-execution trust gate (opt-in / custom verifier). Blocks or warns
+        # before any network call to the MCP server — see issue #2501.
+        enforce_mcp_trust(
+            TrustContext(
+                server_uri=self.server_url,
+                tool_name="mcp_tool",
+                action_name=action_name,
+                arguments=cleaned_kwargs,
+                user_id=self.user_id,
+                transport_type=self.transport_type,
+                auth_type=self.auth_type,
+            )
+        )
+
+        if not self._client:
+            self._setup_client()
         try:
             result = self._run_async_operation(
                 "call_tool", action_name, **cleaned_kwargs

--- a/application/core/settings.py
+++ b/application/core/settings.py
@@ -142,6 +142,20 @@ class Settings(BaseSettings):
 
     API_URL: str = "http://localhost:7091"  # backend url for celery worker
     MCP_OAUTH_REDIRECT_URI: Optional[str] = None  # public callback URL for MCP OAuth
+    # Pre-execution MCP trust verification (issue #2501). Opt-in: when False,
+    # MCP tool calls behave as before. When True (or a custom verifier is
+    # registered via application.security.mcp_trust.set_trust_verifier), every
+    # MCP execute_action runs a trust check first.
+    MCP_TRUST_VERIFICATION_ENABLED: bool = False
+    # Comma-separated server URIs / hostnames allowed when verification is on.
+    # Matching is case-insensitive against full URI, origin, netloc, or host.
+    MCP_TRUST_ALLOWED_SERVERS: Optional[str] = None
+    # Comma-separated denylist (always enforced when verification is on).
+    MCP_TRUST_BLOCKED_SERVERS: Optional[str] = None
+    # How to treat TrustVerdict.WARNED: "proceed" (log only) or "block".
+    MCP_TRUST_ON_WARN: str = "proceed"
+    # If the custom/allowlist verifier raises, allow the call (True) or block.
+    MCP_TRUST_FAIL_OPEN: bool = True
     INTERNAL_KEY: Optional[str] = None  # internal api key for worker-to-backend auth
 
     API_KEY: Optional[str] = None  # LLM api key (used by LLM_PROVIDER)

--- a/application/security/mcp_trust.py
+++ b/application/security/mcp_trust.py
@@ -1,0 +1,363 @@
+"""Pre-execution trust verification for MCP tool calls.
+
+Provides an opt-in, pluggable hook that runs before DocsGPT invokes a remote
+MCP server action. Operators can:
+
+* leave verification disabled (default — existing behaviour),
+* enable a built-in URI/host allowlist via settings, and/or
+* register a custom :class:`TrustVerifier` at process start.
+
+See https://github.com/arc53/DocsGPT/issues/2501.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import threading
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, Optional, Protocol, runtime_checkable
+from urllib.parse import urlparse
+
+from application.core.settings import settings
+
+logger = logging.getLogger(__name__)
+
+
+class TrustVerdict(str, Enum):
+    """Outcome of a trust verification check."""
+
+    ALLOWED = "allowed"
+    BLOCKED = "blocked"
+    WARNED = "warned"
+
+
+@dataclass(frozen=True)
+class TrustResult:
+    """Result returned by a :class:`TrustVerifier`.
+
+    Attributes:
+        verdict: Whether the call may proceed.
+        reason: Human-readable explanation (logged / raised to the user).
+        details: Optional structured metadata for custom backends.
+    """
+
+    verdict: TrustVerdict
+    reason: str = ""
+    details: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TrustContext:
+    """Context passed to verifiers before an MCP tool call executes.
+
+    Attributes:
+        server_uri: MCP server URL (or empty for stdio-style configs).
+        tool_name: DocsGPT tool type name (typically ``mcp_tool``).
+        action_name: Remote MCP action about to run, when known.
+        arguments: Call arguments (may be empty/redacted by callers).
+        user_id: Authenticated user id when available.
+        transport_type: MCP transport (``http``, ``sse``, …).
+        auth_type: Configured auth mode (``none``, ``bearer``, ``oauth``, …).
+    """
+
+    server_uri: str
+    tool_name: str = "mcp_tool"
+    action_name: Optional[str] = None
+    arguments: Optional[Dict[str, Any]] = None
+    user_id: Optional[str] = None
+    transport_type: Optional[str] = None
+    auth_type: Optional[str] = None
+
+
+@runtime_checkable
+class TrustVerifier(Protocol):
+    """Pluggable trust verification backend.
+
+    Implementations may be sync or async; the framework awaits coroutines
+    automatically. Raise only for infrastructure failures — return a
+    :class:`TrustResult` for policy decisions.
+    """
+
+    def verify(self, context: TrustContext) -> Any:
+        """Evaluate trust for the given MCP call context.
+
+        Args:
+            context: Call metadata including the server URI.
+
+        Returns:
+            A :class:`TrustResult`, or an awaitable resolving to one.
+        """
+        ...
+
+
+_verifier_lock = threading.RLock()
+_custom_verifier: Optional[TrustVerifier] = None
+
+
+def set_trust_verifier(verifier: Optional[TrustVerifier]) -> None:
+    """Register (or clear) a process-wide custom trust verifier.
+
+    Args:
+        verifier: Custom backend, or ``None`` to clear and fall back to the
+            settings-driven allowlist (when enabled).
+    """
+    global _custom_verifier
+    with _verifier_lock:
+        _custom_verifier = verifier
+        if verifier is None:
+            logger.info("MCP trust verifier cleared")
+        else:
+            logger.info(
+                "MCP trust verifier registered: %s",
+                type(verifier).__name__,
+            )
+
+
+def get_trust_verifier() -> Optional[TrustVerifier]:
+    """Return the active verifier, or ``None`` when verification is off.
+
+    Preference order:
+        1. Custom verifier set via :func:`set_trust_verifier`
+        2. Built-in allowlist verifier when ``MCP_TRUST_VERIFICATION_ENABLED``
+        3. ``None`` (skip verification — fail open / legacy behaviour)
+    """
+    with _verifier_lock:
+        if _custom_verifier is not None:
+            return _custom_verifier
+    if getattr(settings, "MCP_TRUST_VERIFICATION_ENABLED", False):
+        return AllowlistTrustVerifier.from_settings()
+    return None
+
+
+class AllowlistTrustVerifier:
+    """Allowlist / denylist trust policy for MCP server URIs.
+
+    Matching is case-insensitive against:
+
+    * the full URI (scheme + netloc + path, trailing slash stripped),
+    * the netloc (``host:port``), and
+    * the bare hostname.
+
+    An empty allowlist with verification enabled does **not** block every
+    server (that would brick default installs); denylist entries still apply.
+    When the allowlist is non-empty, only matching servers are allowed.
+    """
+
+    def __init__(
+        self,
+        allowed: Optional[list[str]] = None,
+        blocked: Optional[list[str]] = None,
+    ):
+        self.allowed = {_normalize_entry(e) for e in (allowed or []) if e}
+        self.blocked = {_normalize_entry(e) for e in (blocked or []) if e}
+
+    @classmethod
+    def from_settings(cls) -> "AllowlistTrustVerifier":
+        """Build a verifier from ``MCP_TRUST_ALLOWED_SERVERS`` / blocked env."""
+        return cls(
+            allowed=_split_csv(getattr(settings, "MCP_TRUST_ALLOWED_SERVERS", None)),
+            blocked=_split_csv(getattr(settings, "MCP_TRUST_BLOCKED_SERVERS", None)),
+        )
+
+    def verify(self, context: TrustContext) -> TrustResult:
+        """Apply allowlist / denylist rules to ``context.server_uri``."""
+        uri = (context.server_uri or "").strip()
+        if not uri:
+            return TrustResult(
+                verdict=TrustVerdict.BLOCKED,
+                reason="MCP server URI is empty",
+            )
+
+        candidates = _uri_match_candidates(uri)
+
+        if self.blocked and candidates & self.blocked:
+            return TrustResult(
+                verdict=TrustVerdict.BLOCKED,
+                reason=f"MCP server URI is on the blocklist: {uri}",
+                details={"matched": sorted(candidates & self.blocked)},
+            )
+
+        if self.allowed:
+            if candidates & self.allowed:
+                return TrustResult(
+                    verdict=TrustVerdict.ALLOWED,
+                    reason="MCP server URI is on the allowlist",
+                    details={"matched": sorted(candidates & self.allowed)},
+                )
+            return TrustResult(
+                verdict=TrustVerdict.BLOCKED,
+                reason=f"MCP server URI is not on the allowlist: {uri}",
+                details={"candidates": sorted(candidates)},
+            )
+
+        # Enabled with no allowlist: allow but warn so operators notice.
+        return TrustResult(
+            verdict=TrustVerdict.WARNED,
+            reason=(
+                "MCP trust verification is enabled but no allowlist is configured; "
+                "allowing call. Set MCP_TRUST_ALLOWED_SERVERS or register a custom verifier."
+            ),
+        )
+
+
+class MCPTrustBlockedError(Exception):
+    """Raised when pre-execution trust verification blocks an MCP call."""
+
+    def __init__(self, result: TrustResult, server_uri: str = ""):
+        self.result = result
+        self.server_uri = server_uri
+        message = result.reason or "MCP trust verification blocked this call"
+        if server_uri:
+            message = f"{message} (server={server_uri})"
+        super().__init__(message)
+
+
+def verify_mcp_trust(context: TrustContext) -> TrustResult:
+    """Run the active trust verifier for ``context``.
+
+    Returns:
+        :class:`TrustResult`. When no verifier is configured, returns
+        ``ALLOWED`` without side effects.
+
+    Notes:
+        Verifier exceptions are fail-open by default
+        (``MCP_TRUST_FAIL_OPEN=True``) so a broken custom backend does not
+        take down every MCP call; set fail-open to false for fail-closed.
+    """
+    verifier = get_trust_verifier()
+    if verifier is None:
+        return TrustResult(
+            verdict=TrustVerdict.ALLOWED,
+            reason="MCP trust verification disabled",
+        )
+
+    try:
+        raw = verifier.verify(context)
+        if inspect.isawaitable(raw):
+            result = _run_awaitable(raw)
+        else:
+            result = raw
+    except Exception as exc:
+        fail_open = bool(getattr(settings, "MCP_TRUST_FAIL_OPEN", True))
+        logger.exception(
+            "MCP trust verifier raised (fail_open=%s) for server=%s",
+            fail_open,
+            context.server_uri,
+        )
+        if fail_open:
+            return TrustResult(
+                verdict=TrustVerdict.WARNED,
+                reason=f"trust verifier error (fail-open): {exc}",
+                details={"error": type(exc).__name__},
+            )
+        return TrustResult(
+            verdict=TrustVerdict.BLOCKED,
+            reason=f"trust verifier error (fail-closed): {exc}",
+            details={"error": type(exc).__name__},
+        )
+
+    if not isinstance(result, TrustResult):
+        logger.error(
+            "MCP trust verifier returned %s, expected TrustResult; blocking",
+            type(result).__name__,
+        )
+        return TrustResult(
+            verdict=TrustVerdict.BLOCKED,
+            reason="trust verifier returned an invalid result type",
+        )
+    return result
+
+
+def enforce_mcp_trust(context: TrustContext) -> TrustResult:
+    """Verify trust and enforce block / warn policy.
+
+    Args:
+        context: MCP call context.
+
+    Returns:
+        The :class:`TrustResult` when the call may proceed.
+
+    Raises:
+        MCPTrustBlockedError: When the verdict is ``BLOCKED``, or ``WARNED``
+            and ``MCP_TRUST_ON_WARN`` is ``block``.
+    """
+    result = verify_mcp_trust(context)
+
+    if result.verdict == TrustVerdict.ALLOWED:
+        return result
+
+    if result.verdict == TrustVerdict.WARNED:
+        logger.warning(
+            "MCP trust warning server=%s action=%s reason=%s",
+            context.server_uri,
+            context.action_name,
+            result.reason,
+        )
+        on_warn = (getattr(settings, "MCP_TRUST_ON_WARN", "proceed") or "proceed").strip().lower()
+        if on_warn == "block":
+            raise MCPTrustBlockedError(result, server_uri=context.server_uri)
+        return result
+
+    # BLOCKED
+    logger.warning(
+        "MCP trust blocked server=%s action=%s reason=%s",
+        context.server_uri,
+        context.action_name,
+        result.reason,
+    )
+    raise MCPTrustBlockedError(result, server_uri=context.server_uri)
+
+
+def _run_awaitable(awaitable: Any) -> Any:
+    """Run an async verifier result from a sync call path."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(awaitable)
+
+    # Already inside an event loop (e.g. ASGI worker path that somehow
+    # calls sync MCPTool): spin a short-lived loop on a worker thread.
+    import concurrent.futures
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(asyncio.run, awaitable).result()
+
+
+def _split_csv(raw: Optional[str]) -> list[str]:
+    if not raw:
+        return []
+    return [part.strip() for part in str(raw).split(",") if part.strip()]
+
+
+def _normalize_entry(entry: str) -> str:
+    return entry.strip().rstrip("/").lower()
+
+
+def _uri_match_candidates(uri: str) -> set[str]:
+    """Return normalized forms of ``uri`` used for allowlist matching."""
+    normalized = _normalize_entry(uri)
+    candidates = {normalized}
+    try:
+        parsed = urlparse(uri if "://" in uri else f"//{uri}", scheme="")
+        netloc = (parsed.netloc or parsed.path.split("/")[0] or "").lower()
+        if netloc:
+            candidates.add(netloc)
+            host = netloc.split("@")[-1]
+            # strip port
+            if host.startswith("["):
+                # IPv6 literal
+                end = host.find("]")
+                hostname = host[: end + 1] if end != -1 else host
+            else:
+                hostname = host.rsplit(":", 1)[0]
+            if hostname:
+                candidates.add(hostname.lower())
+        if parsed.scheme and parsed.netloc:
+            origin = f"{parsed.scheme.lower()}://{parsed.netloc.lower()}".rstrip("/")
+            candidates.add(origin)
+    except Exception:
+        logger.debug("Failed to parse MCP server URI for trust matching: %s", uri)
+    return candidates

--- a/tests/security/test_mcp_trust.py
+++ b/tests/security/test_mcp_trust.py
@@ -1,0 +1,261 @@
+"""Tests for MCP pre-execution trust verification (issue #2501)."""
+
+from unittest.mock import patch
+
+import pytest
+
+from application.security.mcp_trust import (
+    AllowlistTrustVerifier,
+    MCPTrustBlockedError,
+    TrustContext,
+    TrustResult,
+    TrustVerdict,
+    enforce_mcp_trust,
+    get_trust_verifier,
+    set_trust_verifier,
+    verify_mcp_trust,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_custom_verifier():
+    """Isolate process-wide verifier state between tests."""
+    set_trust_verifier(None)
+    yield
+    set_trust_verifier(None)
+
+
+def _ctx(uri="https://mcp.example.com/sse", action="search", **kwargs):
+    return TrustContext(
+        server_uri=uri,
+        action_name=action,
+        user_id="user-1",
+        **kwargs,
+    )
+
+
+@pytest.mark.unit
+class TestAllowlistTrustVerifier:
+    def test_empty_allowlist_warns(self):
+        verifier = AllowlistTrustVerifier(allowed=[], blocked=[])
+        result = verifier.verify(_ctx())
+        assert result.verdict == TrustVerdict.WARNED
+        assert "no allowlist" in result.reason.lower()
+
+    def test_allowlist_exact_uri(self):
+        verifier = AllowlistTrustVerifier(
+            allowed=["https://mcp.example.com/sse"],
+        )
+        result = verifier.verify(_ctx("https://mcp.example.com/sse"))
+        assert result.verdict == TrustVerdict.ALLOWED
+
+    def test_allowlist_matches_hostname(self):
+        verifier = AllowlistTrustVerifier(allowed=["mcp.example.com"])
+        result = verifier.verify(_ctx("https://mcp.example.com/v1"))
+        assert result.verdict == TrustVerdict.ALLOWED
+
+    def test_allowlist_blocks_unknown(self):
+        verifier = AllowlistTrustVerifier(allowed=["trusted.example.com"])
+        result = verifier.verify(_ctx("https://evil.example.com"))
+        assert result.verdict == TrustVerdict.BLOCKED
+        assert "not on the allowlist" in result.reason
+
+    def test_blocklist_wins(self):
+        verifier = AllowlistTrustVerifier(
+            allowed=["evil.example.com"],
+            blocked=["evil.example.com"],
+        )
+        result = verifier.verify(_ctx("https://evil.example.com/mcp"))
+        assert result.verdict == TrustVerdict.BLOCKED
+        assert "blocklist" in result.reason
+
+    def test_empty_uri_blocked(self):
+        verifier = AllowlistTrustVerifier(allowed=["x"])
+        result = verifier.verify(_ctx(""))
+        assert result.verdict == TrustVerdict.BLOCKED
+
+
+@pytest.mark.unit
+class TestVerifyMcpTrust:
+    def test_disabled_allows(self):
+        with patch("application.security.mcp_trust.settings") as mock_settings:
+            mock_settings.MCP_TRUST_VERIFICATION_ENABLED = False
+            result = verify_mcp_trust(_ctx())
+        assert result.verdict == TrustVerdict.ALLOWED
+        assert "disabled" in result.reason.lower()
+
+    def test_enabled_uses_allowlist_from_settings(self):
+        with patch("application.security.mcp_trust.settings") as mock_settings:
+            mock_settings.MCP_TRUST_VERIFICATION_ENABLED = True
+            mock_settings.MCP_TRUST_ALLOWED_SERVERS = "good.example.com"
+            mock_settings.MCP_TRUST_BLOCKED_SERVERS = None
+            mock_settings.MCP_TRUST_FAIL_OPEN = True
+            set_trust_verifier(None)
+            result = verify_mcp_trust(_ctx("https://good.example.com/mcp"))
+            assert result.verdict == TrustVerdict.ALLOWED
+            blocked = verify_mcp_trust(_ctx("https://bad.example.com/mcp"))
+            assert blocked.verdict == TrustVerdict.BLOCKED
+
+    def test_custom_verifier_preferred(self):
+        class AlwaysBlock:
+            def verify(self, context):
+                return TrustResult(
+                    verdict=TrustVerdict.BLOCKED,
+                    reason="custom block",
+                )
+
+        set_trust_verifier(AlwaysBlock())
+        with patch("application.security.mcp_trust.settings") as mock_settings:
+            mock_settings.MCP_TRUST_VERIFICATION_ENABLED = False
+            mock_settings.MCP_TRUST_FAIL_OPEN = True
+            result = verify_mcp_trust(_ctx())
+        assert result.verdict == TrustVerdict.BLOCKED
+        assert result.reason == "custom block"
+
+    def test_async_verifier_supported(self):
+        class AsyncAllow:
+            async def verify(self, context):
+                return TrustResult(
+                    verdict=TrustVerdict.ALLOWED,
+                    reason="async ok",
+                )
+
+        set_trust_verifier(AsyncAllow())
+        result = verify_mcp_trust(_ctx())
+        assert result.verdict == TrustVerdict.ALLOWED
+        assert result.reason == "async ok"
+
+    def test_verifier_exception_fail_open(self):
+        class Boom:
+            def verify(self, context):
+                raise RuntimeError("backend down")
+
+        set_trust_verifier(Boom())
+        with patch("application.security.mcp_trust.settings") as mock_settings:
+            mock_settings.MCP_TRUST_FAIL_OPEN = True
+            result = verify_mcp_trust(_ctx())
+        assert result.verdict == TrustVerdict.WARNED
+        assert "fail-open" in result.reason
+
+    def test_verifier_exception_fail_closed(self):
+        class Boom:
+            def verify(self, context):
+                raise RuntimeError("backend down")
+
+        set_trust_verifier(Boom())
+        with patch("application.security.mcp_trust.settings") as mock_settings:
+            mock_settings.MCP_TRUST_FAIL_OPEN = False
+            result = verify_mcp_trust(_ctx())
+        assert result.verdict == TrustVerdict.BLOCKED
+        assert "fail-closed" in result.reason
+
+    def test_invalid_result_type_blocked(self):
+        class Bad:
+            def verify(self, context):
+                return "yes"
+
+        set_trust_verifier(Bad())
+        result = verify_mcp_trust(_ctx())
+        assert result.verdict == TrustVerdict.BLOCKED
+        assert "invalid result" in result.reason
+
+
+@pytest.mark.unit
+class TestEnforceMcpTrust:
+    def test_allowed_returns_result(self):
+        set_trust_verifier(
+            type(
+                "V",
+                (),
+                {
+                    "verify": lambda self, ctx: TrustResult(
+                        verdict=TrustVerdict.ALLOWED, reason="ok"
+                    )
+                },
+            )()
+        )
+        result = enforce_mcp_trust(_ctx())
+        assert result.verdict == TrustVerdict.ALLOWED
+
+    def test_blocked_raises(self):
+        set_trust_verifier(
+            type(
+                "V",
+                (),
+                {
+                    "verify": lambda self, ctx: TrustResult(
+                        verdict=TrustVerdict.BLOCKED, reason="nope"
+                    )
+                },
+            )()
+        )
+        with pytest.raises(MCPTrustBlockedError, match="nope"):
+            enforce_mcp_trust(_ctx())
+
+    def test_warn_proceeds_by_default(self):
+        set_trust_verifier(
+            type(
+                "V",
+                (),
+                {
+                    "verify": lambda self, ctx: TrustResult(
+                        verdict=TrustVerdict.WARNED, reason="soft"
+                    )
+                },
+            )()
+        )
+        with patch("application.security.mcp_trust.settings") as mock_settings:
+            mock_settings.MCP_TRUST_ON_WARN = "proceed"
+            result = enforce_mcp_trust(_ctx())
+        assert result.verdict == TrustVerdict.WARNED
+
+    def test_warn_can_block(self):
+        set_trust_verifier(
+            type(
+                "V",
+                (),
+                {
+                    "verify": lambda self, ctx: TrustResult(
+                        verdict=TrustVerdict.WARNED, reason="soft"
+                    )
+                },
+            )()
+        )
+        with patch("application.security.mcp_trust.settings") as mock_settings:
+            mock_settings.MCP_TRUST_ON_WARN = "block"
+            with pytest.raises(MCPTrustBlockedError, match="soft"):
+                enforce_mcp_trust(_ctx())
+
+
+@pytest.mark.unit
+class TestGetTrustVerifier:
+    def test_none_when_disabled(self):
+        with patch("application.security.mcp_trust.settings") as mock_settings:
+            mock_settings.MCP_TRUST_VERIFICATION_ENABLED = False
+            assert get_trust_verifier() is None
+
+    def test_allowlist_when_enabled(self):
+        with patch("application.security.mcp_trust.settings") as mock_settings:
+            mock_settings.MCP_TRUST_VERIFICATION_ENABLED = True
+            mock_settings.MCP_TRUST_ALLOWED_SERVERS = "a.com"
+            mock_settings.MCP_TRUST_BLOCKED_SERVERS = None
+            verifier = get_trust_verifier()
+        assert isinstance(verifier, AllowlistTrustVerifier)
+
+
+@pytest.mark.unit
+class TestMcpToolTrustWiring:
+    """Regression: MCPTool.execute_action must call the trust gate pre-flight."""
+
+    def test_execute_action_source_enforces_trust(self):
+        from pathlib import Path
+
+        src = Path("application/agents/tools/mcp_tool.py").read_text(encoding="utf-8")
+        assert "from application.security.mcp_trust import" in src
+        assert "enforce_mcp_trust" in src
+        assert "TrustContext" in src
+        # Gate must sit inside execute_action, before call_tool.
+        execute_idx = src.index("def execute_action")
+        call_tool_idx = src.index('"call_tool"', execute_idx)
+        enforce_idx = src.index("enforce_mcp_trust", execute_idx)
+        assert execute_idx < enforce_idx < call_tool_idx


### PR DESCRIPTION
Add a configurable pre-execution trust verification hook for MCP tool calls so operators can block, warn, or allow remote MCP servers before any tool action runs.

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  Feature — pluggable security middleware for MCP tool execution.

- **Why was this change needed?** (You can also link to an open issue here)

  DocsGPT currently has no framework-level gate before MCP tool execution. A misconfigured or malicious MCP server could run arbitrary operations without a pre-flight trust check. As third-party MCP servers become more common, this is an important security surface. Closes #2501.

- **Other information**:

  - New module `application/security/mcp_trust.py` with:
    - `TrustVerifier` protocol (sync or async)
    - `TrustContext` / `TrustResult` / `TrustVerdict` (`allowed` | `blocked` | `warned`)
    - `set_trust_verifier()` for custom backends (allowlist API, SBOM, policy engine, etc.)
    - Built-in `AllowlistTrustVerifier` (URI/host allowlist + denylist)
    - `enforce_mcp_trust()` raises `MCPTrustBlockedError` when blocked
  - Wired into `MCPTool.execute_action` **before** any `call_tool` network call
  - **Opt-in by default** — existing workflows unchanged until configured
  - Settings:
    - `MCP_TRUST_VERIFICATION_ENABLED` (default `false`)
    - `MCP_TRUST_ALLOWED_SERVERS` / `MCP_TRUST_BLOCKED_SERVERS` (CSV)
    - `MCP_TRUST_ON_WARN` (`proceed` | `block`)
    - `MCP_TRUST_FAIL_OPEN` (default `true` — verifier errors do not hard-fail)
  - Unit tests in `tests/security/test_mcp_trust.py` (20 passed)
  - Backend-only change (no UI screenshots)

  Custom verifier example:

  ```python
  from application.security.mcp_trust import (
      TrustContext, TrustResult, TrustVerdict, set_trust_verifier,
  )

  class MyVerifier:
      def verify(self, context: TrustContext) -> TrustResult:
          return TrustResult(verdict=TrustVerdict.ALLOWED, reason="ok")

  set_trust_verifier(MyVerifier())

Type of change

• [ ] Bug fix (non-breaking change which fixes an issue)
• [x] New feature (non-breaking change which adds functionality)
• [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
• [ ] This change requires a documentation update

How has this been tested?

• [x] Unit tests
• [x] Manual tests

Test Configuration:
• Python: 3.11
• Suite: tests/security/test_mcp_trust.py (20 passed)

Checklist:

• [x] My code follows the style guidelines of this project
• [x] I have already covered my code with unit tests
• [x] I have made corresponding changes to the documentation (N/A — settings documented in settings.py)
• [x] I have added an explanation of my changes

Related issues

Closes #2501