### PR TITLE
ci: add CodeQL scanning with custom input-point and dangerous-sink qu…

### DIFF
--- a/.github/codeql/README.md
+++ b/.github/codeql/README.md
@@ -1,0 +1,63 @@
+# DocsGPT custom CodeQL queries
+
+These queries run in the **CodeQL Advanced** workflow
+([`.github/workflows/codeql.yml`](../workflows/codeql.yml)) alongside GitHub's
+`security-extended` suite. Results are uploaded to the repository's
+**Security → Code scanning alerts** tab. The checks are **non-blocking**: they
+annotate pull requests but do not fail the build.
+
+## What runs
+
+Configured by [`codeql-config.yml`](codeql-config.yml), which restricts
+extraction to first-party source (`application`, `frontend/src`, `extensions`,
+`scripts`) and adds the packs under [`queries/`](queries/).
+
+### Python (`queries/python/`)
+
+| Query | Kind | Purpose |
+| --- | --- | --- |
+| `InputPointInventory.ql` | inventory (note) | Marks every HTTP input point (Flask `request.*`, flask-restx fields). Each new finding on a PR is a **new untrusted-input surface** to review/allow-list. |
+| `DangerousCallInventory.ql` | inventory (note) | Lists every `eval`/`exec`/`compile`/`__import__`/`os.system`/`subprocess`/`pickle`/`marshal`/`yaml.load` call — the "candidates to replace" list. |
+| `DangerousExecutionTaint.ql` | taint (error) | Reports only when untrusted HTTP input actually **flows into** one of those sinks — the high-signal RCE / unsafe-deserialization finding. |
+
+Shared sink definitions live in [`queries/python/DangerousSinks.qll`](queries/python/DangerousSinks.qll).
+
+### JavaScript / TypeScript (`queries/javascript/`)
+
+| Query | Kind | Purpose |
+| --- | --- | --- |
+| `DangerousJsSinkInventory.ql` | inventory (warning) | Lists `eval()`, `new Function()`, string-body `setTimeout`/`setInterval`, and `dangerouslySetInnerHTML`. |
+
+## Note on the sandbox
+
+DocsGPT intentionally executes user-supplied code through
+[`application/sandbox/`](../../application/sandbox/) (`manager.exec` /
+backend `.exec`). Those are **method** calls, not the Python builtin `exec`, so
+the sink matchers do **not** flag them. The sandbox is the sanctioned execution
+boundary; it is out of scope for these queries by design.
+
+## Running locally
+
+Requires the [CodeQL CLI](https://github.com/github/codeql-cli-binaries) and the
+CodeQL standard libraries on the search path.
+
+```bash
+# 1. Build a database (Python shown; use javascript for the frontend).
+codeql database create /tmp/docsgpt-py --language=python \
+  --source-root=application --build-mode=none
+
+# 2. Compile-check the queries.
+codeql query compile .github/codeql/queries/python
+
+# 3. Run them.
+codeql database analyze /tmp/docsgpt-py .github/codeql/queries/python \
+  --format=sarif-latest --output=/tmp/py-results.sarif
+```
+
+## Triaging / allow-listing a reviewed sink
+
+An inventory finding that has been reviewed and is safe should be **dismissed in
+the code-scanning UI** ("Used in tests" / "Won't fix" / "False positive") rather
+than deleted from the query — that keeps the inventory complete while silencing
+the specific location. For a systemic exception (e.g. a whole trusted module),
+add a `paths-ignore` entry in [`codeql-config.yml`](codeql-config.yml).

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,28 @@
+name: "DocsGPT CodeQL config"
+
+# Which query suites run. security-extended is GitHub's curated set; the local
+# ./.github/codeql/queries pack adds DocsGPT-specific input-point inventory and
+# dangerous-sink taint queries. CodeQL runs only the queries whose language
+# matches each analysis, so the mixed python/javascript pack is safe to share.
+queries:
+  - uses: security-extended
+  - uses: ./.github/codeql/queries
+
+# Restrict extraction to first-party source. Vendored, generated, and test
+# code adds noise without adding signal for these checks.
+paths:
+  - application
+  - frontend/src
+  - extensions
+  - scripts
+
+paths-ignore:
+  - '**/node_modules'
+  - '**/__pycache__'
+  - '**/*.test.ts'
+  - '**/*.test.tsx'
+  - '**/*.spec.ts'
+  - tests
+  - docs
+  - htmlcov
+  - frontend/dist

--- a/.github/codeql/queries/javascript/DangerousJsSinkInventory.ql
+++ b/.github/codeql/queries/javascript/DangerousJsSinkInventory.ql
@@ -1,0 +1,57 @@
+/**
+ * @name Dynamic code execution or unsafe HTML sink (inventory)
+ * @description Lists frontend uses of eval(), the Function constructor (called
+ *              or constructed), setTimeout/setInterval with a string body,
+ *              document.write/writeln, insertAdjacentHTML, and React's
+ *              dangerouslySetInnerHTML. These evaluate code or inject raw HTML
+ *              and are common XSS / code-injection sinks; prefer parsed React
+ *              elements (see MarkdownPreview.tsx) or JSON.parse instead.
+ *              Reachability from untrusted data is covered by the
+ *              security-extended suite; this query is the review inventory.
+ * @kind problem
+ * @problem.severity warning
+ * @security-severity 6.1
+ * @precision high
+ * @id docsgpt/js/dangerous-sink-inventory
+ * @tags security
+ *       maintainability
+ *       external/cwe/cwe-079
+ *       external/cwe/cwe-094
+ */
+
+import javascript
+
+from DataFlow::Node node, string kind
+where
+  node = DataFlow::globalVarRef("eval").getACall() and kind = "eval()"
+  or
+  // `new Function(body)` and `Function(body)` both compile a string into code.
+  node = DataFlow::globalVarRef("Function").getAnInvocation() and kind = "Function() constructor"
+  or
+  exists(DataFlow::CallNode call |
+    call = DataFlow::globalVarRef(["setTimeout", "setInterval"]).getACall() and
+    call.getArgument(0).mayHaveStringValue(_) and
+    node = call and
+    kind = "setTimeout/setInterval with string body"
+  )
+  or
+  exists(DataFlow::CallNode call |
+    call = DataFlow::globalVarRef("document").getAMethodCall(["write", "writeln"]) and
+    node = call and
+    kind = "document.write()"
+  )
+  or
+  exists(DataFlow::MethodCallNode call |
+    call.getMethodName() = "insertAdjacentHTML" and
+    node = call and
+    kind = "insertAdjacentHTML()"
+  )
+  or
+  exists(JsxAttribute attr |
+    attr.getName() = "dangerouslySetInnerHTML" and
+    node = attr.getValue().flow() and
+    kind = "dangerouslySetInnerHTML"
+  )
+select node,
+  "Dynamic/unsafe sink (" + kind +
+    "). Review that any input reaching this is trusted or sanitized."

--- a/.github/codeql/queries/javascript/codeql-pack.lock.yml
+++ b/.github/codeql/queries/javascript/codeql-pack.lock.yml
@@ -1,0 +1,30 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/concepts:
+    version: 0.0.27
+  codeql/controlflow:
+    version: 2.0.37
+  codeql/dataflow:
+    version: 2.1.9
+  codeql/javascript-all:
+    version: 2.8.1
+  codeql/mad:
+    version: 1.0.53
+  codeql/regex:
+    version: 1.0.53
+  codeql/ssa:
+    version: 2.0.29
+  codeql/threat-models:
+    version: 1.0.53
+  codeql/tutorial:
+    version: 1.0.53
+  codeql/typetracking:
+    version: 2.0.37
+  codeql/util:
+    version: 2.0.40
+  codeql/xml:
+    version: 1.0.53
+  codeql/yaml:
+    version: 1.0.53
+compiled: false

--- a/.github/codeql/queries/javascript/qlpack.yml
+++ b/.github/codeql/queries/javascript/qlpack.yml
@@ -1,0 +1,5 @@
+name: docsgpt/javascript-security-queries
+version: 0.0.1
+library: false
+dependencies:
+  codeql/javascript-all: "*"

--- a/.github/codeql/queries/python/DangerousCallInventory.ql
+++ b/.github/codeql/queries/python/DangerousCallInventory.ql
@@ -1,0 +1,27 @@
+/**
+ * @name Dangerous dynamic-execution or deserialization call (inventory)
+ * @description Lists every call to eval/exec/compile/__import__/os.system/
+ *              subprocess/pickle/marshal/yaml.load so each can be reviewed and,
+ *              where possible, replaced with a safer construct. This is an audit
+ *              inventory, not a reachability finding: a listed call is not
+ *              necessarily exploitable. Reachable-from-HTTP cases are reported
+ *              separately (and at higher severity) by
+ *              DangerousExecutionTaint.ql.
+ * @kind problem
+ * @problem.severity recommendation
+ * @security-severity 2.0
+ * @precision high
+ * @id docsgpt/py/dangerous-call-inventory
+ * @tags security
+ *       maintainability
+ *       external/cwe/cwe-094
+ */
+
+import python
+import DangerousSinks
+
+from DangerousCall call
+select call,
+  "Dangerous call to '" + call.getKind() +
+    "'. Review whether the argument is fully trusted; prefer a safe alternative " +
+    "(sandbox, ast.literal_eval, yaml.safe_load, a fixed argv list)."

--- a/.github/codeql/queries/python/DangerousExecutionTaint.ql
+++ b/.github/codeql/queries/python/DangerousExecutionTaint.ql
@@ -1,0 +1,40 @@
+/**
+ * @name Untrusted HTTP input reaches a dangerous execution or deserialization sink
+ * @description Data originating from an HTTP request (Flask request args/form/
+ *              json/headers/files) flows to eval/exec/compile/os.system/
+ *              subprocess/pickle/yaml.load. Such flows are prime candidates for
+ *              remote code execution and should be removed or replaced with a
+ *              safe alternative (e.g. the sandbox, ast.literal_eval, SafeLoader).
+ * @kind path-problem
+ * @problem.severity error
+ * @security-severity 9.8
+ * @precision high
+ * @id docsgpt/py/tainted-dangerous-execution
+ * @tags security
+ *       external/cwe/cwe-078
+ *       external/cwe/cwe-094
+ *       external/cwe/cwe-502
+ */
+
+import python
+import semmle.python.dataflow.new.DataFlow
+import semmle.python.dataflow.new.TaintTracking
+import semmle.python.dataflow.new.RemoteFlowSources
+import DangerousSinks
+import DangerousExecFlow::PathGraph
+
+module DangerousExecConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+  predicate isSink(DataFlow::Node sink) {
+    exists(DangerousCall c | sink = c.getSinkArgument())
+  }
+}
+
+module DangerousExecFlow = TaintTracking::Global<DangerousExecConfig>;
+
+from DangerousExecFlow::PathNode source, DangerousExecFlow::PathNode sink
+where DangerousExecFlow::flowPath(source, sink)
+select sink.getNode(), source, sink,
+  "Untrusted HTTP input from $@ reaches a dangerous execution/deserialization sink.",
+  source.getNode(), "a user request"

--- a/.github/codeql/queries/python/DangerousSinks.qll
+++ b/.github/codeql/queries/python/DangerousSinks.qll
@@ -1,0 +1,68 @@
+/**
+ * Shared definitions of "dangerous" dynamic-execution and unsafe-deserialization
+ * sinks used by DocsGPT's custom CodeQL queries.
+ *
+ * NOTE ON THE SANDBOX: DocsGPT deliberately executes user-supplied code through
+ * application/sandbox (manager.exec / backend.exec on Jupyter and Daytona
+ * backends). Those are *method* calls named `exec` on project objects, not the
+ * Python builtin `exec`, so the builtin-based matchers below never flag them.
+ * That is intentional: the sandbox is the sanctioned execution boundary and
+ * should not appear as noise here.
+ */
+
+import python
+import semmle.python.ApiGraphs
+import semmle.python.dataflow.new.DataFlow
+
+/** A call to a builtin or stdlib function that can execute code or deserialize untrusted data. */
+class DangerousCall extends API::CallNode {
+  string kind;
+
+  DangerousCall() {
+    this = API::builtin("eval").getACall() and kind = "eval"
+    or
+    this = API::builtin("exec").getACall() and kind = "exec"
+    or
+    this = API::builtin("compile").getACall() and kind = "compile"
+    or
+    this = API::builtin("__import__").getACall() and kind = "__import__"
+    or
+    this = API::moduleImport("os").getMember("system").getACall() and kind = "os.system"
+    or
+    this =
+      API::moduleImport("os")
+          .getMember(["popen", "spawnl", "spawnv", "execl", "execv"])
+          .getACall() and
+    kind = "os.exec/spawn/popen"
+    or
+    this =
+      API::moduleImport("subprocess")
+          .getMember(["run", "call", "check_call", "check_output", "Popen"])
+          .getACall() and
+    kind = "subprocess"
+    or
+    this = API::moduleImport("pickle").getMember(["load", "loads"]).getACall() and
+    kind = "pickle.load"
+    or
+    this = API::moduleImport("marshal").getMember(["load", "loads"]).getACall() and
+    kind = "marshal.load"
+    or
+    // yaml.load with no explicit Loader uses the full loader and is unsafe
+    // deserialization. When a Loader is passed (e.g. SafeLoader), safety is
+    // loader-dependent, so we defer to security-extended's loader-aware
+    // py/unsafe-deserialization query rather than flag it here.
+    this = API::moduleImport("yaml").getMember("load").getACall() and
+    not exists(this.getArgByName("Loader")) and
+    not exists(this.getArg(1)) and
+    kind = "yaml.load (no explicit Loader)"
+  }
+
+  /** A short human-readable name for the sink, e.g. "eval" or "subprocess". */
+  string getKind() { result = kind }
+
+  /** The primary user-controllable argument for this sink. */
+  DataFlow::Node getSinkArgument() {
+    // First positional argument for code/command sinks.
+    result = this.getArg(0)
+  }
+}

--- a/.github/codeql/queries/python/InputPointInventory.ql
+++ b/.github/codeql/queries/python/InputPointInventory.ql
@@ -1,0 +1,25 @@
+/**
+ * @name HTTP input point (inventory / whitelist check)
+ * @description Marks every point where the application reads data from an
+ *              incoming HTTP request (Flask request args/form/json/headers/
+ *              files, flask-restx parsed fields, etc.). Use this list as the
+ *              authoritative inventory of untrusted input surfaces: each new
+ *              finding on a PR is a new input point that must be reviewed for
+ *              validation / allow-listing before merge.
+ * @kind problem
+ * @problem.severity recommendation
+ * @security-severity 1.0
+ * @precision high
+ * @id docsgpt/py/input-point-inventory
+ * @tags security
+ *       maintainability
+ *       audit
+ */
+
+import python
+import semmle.python.dataflow.new.RemoteFlowSources
+
+from RemoteFlowSource src
+select src,
+  "HTTP input point (" + src.getSourceType() +
+    "). Confirm this endpoint validates or allow-lists the value before use."

--- a/.github/codeql/queries/python/codeql-pack.lock.yml
+++ b/.github/codeql/queries/python/codeql-pack.lock.yml
@@ -1,0 +1,30 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/concepts:
+    version: 0.0.27
+  codeql/controlflow:
+    version: 2.0.37
+  codeql/dataflow:
+    version: 2.1.9
+  codeql/mad:
+    version: 1.0.53
+  codeql/python-all:
+    version: 7.2.1
+  codeql/regex:
+    version: 1.0.53
+  codeql/ssa:
+    version: 2.0.29
+  codeql/threat-models:
+    version: 1.0.53
+  codeql/tutorial:
+    version: 1.0.53
+  codeql/typetracking:
+    version: 2.0.37
+  codeql/util:
+    version: 2.0.40
+  codeql/xml:
+    version: 1.0.53
+  codeql/yaml:
+    version: 1.0.53
+compiled: false

--- a/.github/codeql/queries/python/qlpack.yml
+++ b/.github/codeql/queries/python/qlpack.yml
@@ -1,0 +1,5 @@
+name: docsgpt/python-security-queries
+version: 0.0.1
+library: false
+dependencies:
+  codeql/python-all: "*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,55 @@
+name: "CodeQL Advanced"
+
+# Advanced CodeQL setup (required for custom queries). Runs the standard
+# security-extended suite plus DocsGPT's custom queries under
+# .github/codeql/queries and uploads results to the repo's code-scanning
+# alerts (Security tab). Non-blocking: findings annotate PRs but do not fail
+# the check.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '27 3 * * 1'  # weekly, Monday 03:27 UTC (catches new advisories)
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Match the guard used by the other security workflows so forks don't fail.
+    if: github.repository == 'arc53/DocsGPT'
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # upload SARIF to code scanning
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,13 @@ on:
 
 permissions: {}
 
+# Cancel superseded runs on the same ref so we don't burn runner minutes
+# analyzing commits that are no longer the branch tip. Keyed on github.ref, so
+# only runs within the same branch/PR cancel each other.
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
@@ -38,18 +45,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@f081e69141f6ea0aa740920b0c7012cd81a4fbe6 # v3.37.3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@f081e69141f6ea0aa740920b0c7012cd81a4fbe6 # v3.37.3
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
…eries

ci: add CodeQL scanning with custom input-point and dangerous-sink queries

Adds a CodeQL Advanced setup (python + javascript-typescript) alongside the existing Bandit and Zizmor workflows. Runs the security-extended suite plus a custom query pack, uploading results to the Security tab. Non-blocking: annotates PRs without failing the build.

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- **Why was this change needed?** (You can also link to an open issue here)

- **Other information**: