### PR TITLE
Add STT-specific OpenAI endpoint settings

### DIFF
--- a/application/core/settings.py
+++ b/application/core/settings.py
@@ -233,6 +233,8 @@ class Settings(BaseSettings):
     TTS_PROVIDER: str = "google_tts"  # google_tts or elevenlabs
     ELEVENLABS_API_KEY: Optional[str] = None
     STT_PROVIDER: str = "openai"  # openai or faster_whisper
+    OPENAI_STT_API_KEY: Optional[str] = None
+    OPENAI_STT_BASE_URL: Optional[str] = None
     OPENAI_STT_MODEL: str = "gpt-4o-mini-transcribe"
     STT_LANGUAGE: Optional[str] = None
     STT_MAX_FILE_SIZE_MB: int = 50

--- a/application/stt/openai_stt.py
+++ b/application/stt/openai_stt.py
@@ -14,8 +14,18 @@ class OpenAISTT(BaseSTT):
         base_url: Optional[str] = None,
         model: Optional[str] = None,
     ):
-        self.api_key = api_key or settings.OPENAI_API_KEY or settings.API_KEY
-        self.base_url = base_url or settings.OPENAI_BASE_URL or "https://api.openai.com/v1"
+        self.api_key = (
+            api_key
+            or settings.OPENAI_STT_API_KEY
+            or settings.OPENAI_API_KEY
+            or settings.API_KEY
+        )
+        self.base_url = (
+            base_url
+            or settings.OPENAI_STT_BASE_URL
+            or settings.OPENAI_BASE_URL
+            or "https://api.openai.com/v1"
+        )
         self.model = model or settings.OPENAI_STT_MODEL
         self.client = OpenAI(api_key=self.api_key, base_url=self.base_url)
 

--- a/docs/content/Deploying/DocsGPT-Settings.mdx
+++ b/docs/content/Deploying/DocsGPT-Settings.mdx
@@ -187,6 +187,8 @@ The settings below control speech-to-text behaviour for both voice input and aud
 | --- | --- | --- |
 | `STT_PROVIDER` | Speech-to-text backend provider. | `openai`, `faster_whisper` |
 | `OPENAI_STT_MODEL` | OpenAI transcription model used when `STT_PROVIDER=openai`. | `gpt-4o-mini-transcribe` |
+| `OPENAI_STT_BASE_URL` | Optional OpenAI-compatible transcription endpoint used only by the OpenAI STT provider. Leave unset to reuse `OPENAI_BASE_URL` or OpenAI's default API. | `http://127.0.0.1:8000/v1`, unset |
+| `OPENAI_STT_API_KEY` | Optional API key used only by the OpenAI STT provider. Leave unset to reuse `OPENAI_API_KEY` or `API_KEY`. | `EMPTY`, unset |
 | `STT_LANGUAGE` | Optional language hint passed to the provider. Leave unset for auto-detection when supported. | `en`, `es`, unset |
 | `STT_MAX_FILE_SIZE_MB` | Maximum file size accepted by the synchronous `/api/stt` endpoint. | `50` |
 | `STT_ENABLE_TIMESTAMPS` | Include timestamp segments in the normalized transcript response and stored parser metadata. | `true`, `false` |
@@ -205,6 +207,26 @@ STT_ENABLE_DIARIZATION=false
 ```
 
 If you already use `API_KEY` for OpenAI, DocsGPT can reuse that key for transcription. Set `OPENAI_API_KEY` only when you want a dedicated key.
+
+### Example: Local FunASR or SenseVoice Server
+
+FunASR can expose an OpenAI-compatible `/v1/audio/transcriptions` endpoint.
+Use the STT-specific endpoint settings when your chat model and transcription
+server are different services.
+
+```bash
+funasr-server --model iic/SenseVoiceSmall --host 127.0.0.1 --port 8000
+```
+
+```env
+STT_PROVIDER=openai
+OPENAI_STT_BASE_URL=http://127.0.0.1:8000/v1
+OPENAI_STT_API_KEY=EMPTY
+OPENAI_STT_MODEL=iic/SenseVoiceSmall
+STT_LANGUAGE=
+STT_ENABLE_TIMESTAMPS=false
+STT_ENABLE_DIARIZATION=false
+```
 
 ### Example: Local `faster_whisper`
 

--- a/tests/stt/test_openai_stt.py
+++ b/tests/stt/test_openai_stt.py
@@ -12,6 +12,8 @@ class TestOpenAISTTInit:
     @patch("application.stt.openai_stt.OpenAI")
     @patch("application.stt.openai_stt.settings")
     def test_init_defaults_from_settings(self, mock_settings, mock_openai_cls):
+        mock_settings.OPENAI_STT_API_KEY = None
+        mock_settings.OPENAI_STT_BASE_URL = None
         mock_settings.OPENAI_API_KEY = "sk-from-settings"
         mock_settings.API_KEY = "sk-fallback"
         mock_settings.OPENAI_BASE_URL = "https://custom.api.com/v1"
@@ -32,6 +34,8 @@ class TestOpenAISTTInit:
     @patch("application.stt.openai_stt.OpenAI")
     @patch("application.stt.openai_stt.settings")
     def test_init_explicit_params_override_settings(self, mock_settings, mock_openai_cls):
+        mock_settings.OPENAI_STT_API_KEY = "sk-stt-settings"
+        mock_settings.OPENAI_STT_BASE_URL = "https://stt-settings.example/v1"
         mock_settings.OPENAI_API_KEY = "sk-settings"
         mock_settings.API_KEY = None
         mock_settings.OPENAI_BASE_URL = None
@@ -51,7 +55,31 @@ class TestOpenAISTTInit:
 
     @patch("application.stt.openai_stt.OpenAI")
     @patch("application.stt.openai_stt.settings")
+    def test_init_uses_stt_specific_settings(self, mock_settings, mock_openai_cls):
+        mock_settings.OPENAI_STT_API_KEY = "funasr-token"
+        mock_settings.OPENAI_STT_BASE_URL = "http://127.0.0.1:8000/v1"
+        mock_settings.OPENAI_API_KEY = "sk-chat-key"
+        mock_settings.API_KEY = "sk-fallback"
+        mock_settings.OPENAI_BASE_URL = "https://chat.example/v1"
+        mock_settings.OPENAI_STT_MODEL = "iic/SenseVoiceSmall"
+
+        from application.stt.openai_stt import OpenAISTT
+
+        stt = OpenAISTT()
+
+        assert stt.api_key == "funasr-token"
+        assert stt.base_url == "http://127.0.0.1:8000/v1"
+        assert stt.model == "iic/SenseVoiceSmall"
+        mock_openai_cls.assert_called_once_with(
+            api_key="funasr-token",
+            base_url="http://127.0.0.1:8000/v1",
+        )
+
+    @patch("application.stt.openai_stt.OpenAI")
+    @patch("application.stt.openai_stt.settings")
     def test_init_falls_back_to_api_key(self, mock_settings, mock_openai_cls):
+        mock_settings.OPENAI_STT_API_KEY = None
+        mock_settings.OPENAI_STT_BASE_URL = None
         mock_settings.OPENAI_API_KEY = None
         mock_settings.API_KEY = "sk-fallback-key"
         mock_settings.OPENAI_BASE_URL = None
@@ -66,6 +94,8 @@ class TestOpenAISTTInit:
     @patch("application.stt.openai_stt.OpenAI")
     @patch("application.stt.openai_stt.settings")
     def test_init_default_base_url(self, mock_settings, mock_openai_cls):
+        mock_settings.OPENAI_STT_API_KEY = None
+        mock_settings.OPENAI_STT_BASE_URL = None
         mock_settings.OPENAI_API_KEY = "sk-test"
         mock_settings.API_KEY = None
         mock_settings.OPENAI_BASE_URL = None
@@ -84,6 +114,8 @@ class TestOpenAISTTTranscribe:
     @patch("application.stt.openai_stt.OpenAI")
     @patch("application.stt.openai_stt.settings")
     def test_transcribe_basic(self, mock_settings, mock_openai_cls):
+        mock_settings.OPENAI_STT_API_KEY = None
+        mock_settings.OPENAI_STT_BASE_URL = None
         mock_settings.OPENAI_API_KEY = "sk-test"
         mock_settings.API_KEY = None
         mock_settings.OPENAI_BASE_URL = None
@@ -118,6 +150,8 @@ class TestOpenAISTTTranscribe:
     @patch("application.stt.openai_stt.OpenAI")
     @patch("application.stt.openai_stt.settings")
     def test_transcribe_with_language(self, mock_settings, mock_openai_cls):
+        mock_settings.OPENAI_STT_API_KEY = None
+        mock_settings.OPENAI_STT_BASE_URL = None
         mock_settings.OPENAI_API_KEY = "sk-test"
         mock_settings.API_KEY = None
         mock_settings.OPENAI_BASE_URL = None
@@ -150,6 +184,8 @@ class TestOpenAISTTTranscribe:
     @patch("application.stt.openai_stt.OpenAI")
     @patch("application.stt.openai_stt.settings")
     def test_transcribe_with_timestamps(self, mock_settings, mock_openai_cls):
+        mock_settings.OPENAI_STT_API_KEY = None
+        mock_settings.OPENAI_STT_BASE_URL = None
         mock_settings.OPENAI_API_KEY = "sk-test"
         mock_settings.API_KEY = None
         mock_settings.OPENAI_BASE_URL = None
@@ -189,6 +225,8 @@ class TestOpenAISTTTranscribe:
     @patch("application.stt.openai_stt.OpenAI")
     @patch("application.stt.openai_stt.settings")
     def test_transcribe_no_segments_key(self, mock_settings, mock_openai_cls):
+        mock_settings.OPENAI_STT_API_KEY = None
+        mock_settings.OPENAI_STT_BASE_URL = None
         mock_settings.OPENAI_API_KEY = "sk-test"
         mock_settings.API_KEY = None
         mock_settings.OPENAI_BASE_URL = None
@@ -217,6 +255,8 @@ class TestOpenAISTTTranscribe:
     @patch("application.stt.openai_stt.OpenAI")
     @patch("application.stt.openai_stt.settings")
     def test_transcribe_language_fallback_to_param(self, mock_settings, mock_openai_cls):
+        mock_settings.OPENAI_STT_API_KEY = None
+        mock_settings.OPENAI_STT_BASE_URL = None
         mock_settings.OPENAI_API_KEY = "sk-test"
         mock_settings.API_KEY = None
         mock_settings.OPENAI_BASE_URL = None


### PR DESCRIPTION
## Summary

- Add STT-specific OpenAI-compatible endpoint settings: `OPENAI_STT_BASE_URL` and `OPENAI_STT_API_KEY`.
- Keep backward compatibility by falling back to `OPENAI_BASE_URL`, `OPENAI_API_KEY`, and `API_KEY` when STT-specific settings are unset.
- Document a local FunASR/SenseVoice server setup that works through the existing `STT_PROVIDER=openai` transcription path.

## Why

DocsGPT already has voice input and audio file ingestion through the STT abstraction. This change lets deployments point transcription at a local OpenAI-compatible FunASR/SenseVoice server without also moving the chat LLM provider endpoint.

Closes #2515.

## Validation

```bash
VENV=/cpfs_speech/user/zhifu.gzf/.cache/funasr-ops/docsgpt-stt-venv
"$VENV/bin/python" -m pytest -q tests/stt/test_openai_stt.py tests/stt/test_stt_creator.py tests/parser/file/test_audio_parser.py
"$VENV/bin/python" -m py_compile application/stt/openai_stt.py application/core/settings.py application/parser/file/audio_parser.py
git diff --check
```

Result: 23 passed.
