### PR TITLE
Harden Compose database configuration

### DIFF
--- a/deployment/docker-compose-hub.yaml
+++ b/deployment/docker-compose-hub.yaml
@@ -22,7 +22,7 @@ services:
       - CELERY_BROKER_URL=redis://redis:6379/0
       - CELERY_RESULT_BACKEND=redis://redis:6379/1
       - CACHE_REDIS_URL=redis://redis:6379/2
-      - POSTGRES_URI=postgresql://docsgpt:docsgpt@postgres:5432/docsgpt
+      - POSTGRES_URI=postgresql://docsgpt:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres:5432/docsgpt
     ports:
       - "7091:7091"
     volumes:
@@ -48,7 +48,7 @@ services:
       - CELERY_RESULT_BACKEND=redis://redis:6379/1
       - API_URL=http://backend:7091
       - CACHE_REDIS_URL=redis://redis:6379/2
-      - POSTGRES_URI=postgresql://docsgpt:docsgpt@postgres:5432/docsgpt
+      - POSTGRES_URI=postgresql://docsgpt:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres:5432/docsgpt
     volumes:
       - ../application/indexes:/app/indexes
       - ../application/inputs:/app/inputs
@@ -68,17 +68,12 @@ services:
 
   redis:
     image: redis:6-alpine
-    ports:
-      - 6379:6379
-
   postgres:
     image: postgres:16-alpine
     environment:
       - POSTGRES_USER=docsgpt
-      - POSTGRES_PASSWORD=docsgpt
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
       - POSTGRES_DB=docsgpt
-    ports:
-      - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:

--- a/deployment/docker-compose.yaml
+++ b/deployment/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
       - CELERY_BROKER_URL=redis://redis:6379/0
       - CELERY_RESULT_BACKEND=redis://redis:6379/1
       - CACHE_REDIS_URL=redis://redis:6379/2
-      - POSTGRES_URI=postgresql://docsgpt:docsgpt@postgres:5432/docsgpt
+      - POSTGRES_URI=postgresql://docsgpt:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres:5432/docsgpt
     ports:
       - "7091:7091"
     volumes:
@@ -51,7 +51,7 @@ services:
       - CELERY_RESULT_BACKEND=redis://redis:6379/1
       - API_URL=http://backend:7091
       - CACHE_REDIS_URL=redis://redis:6379/2
-      - POSTGRES_URI=postgresql://docsgpt:docsgpt@postgres:5432/docsgpt
+      - POSTGRES_URI=postgresql://docsgpt:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres:5432/docsgpt
     volumes:
       - ../application/indexes:/app/indexes
       - ../application/inputs:/app/inputs
@@ -64,17 +64,12 @@ services:
 
   redis:
     image: redis:6-alpine
-    ports:
-      - 6379:6379
-
   postgres:
     image: postgres:16-alpine
     environment:
       - POSTGRES_USER=docsgpt
-      - POSTGRES_PASSWORD=docsgpt
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
       - POSTGRES_DB=docsgpt
-    ports:
-      - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:

--- a/setup.ps1
+++ b/setup.ps1
@@ -603,6 +603,8 @@ function Use-DocsPublicAPIEndpoint {
     
     Write-ColorText ".env file configured for DocsGPT Public API." -ForegroundColor "Green"
 
+    Ensure-PostgresPassword
+
     Prompt-AdvancedSettings
 
     # Start Docker if needed
@@ -714,6 +716,8 @@ function Serve-LocalOllama {
     
     Write-ColorText ".env file configured for Ollama ($($docker_compose_file_suffix.ToUpper()))." -ForegroundColor "Green"
     Write-ColorText "Note: MODEL_NAME is set to '$model_name'. You can change it later in the .env file." -ForegroundColor "Yellow"
+
+    Ensure-PostgresPassword
 
     Prompt-AdvancedSettings
 
@@ -880,6 +884,8 @@ function Connect-LocalInferenceEngine {
     Write-ColorText ".env file configured for $engine_name with OpenAI API format." -ForegroundColor "Green"
     Write-ColorText "Note: MODEL_NAME is set to '$model_name'. You can change it later in the .env file." -ForegroundColor "Yellow"
 
+    Ensure-PostgresPassword
+
     Prompt-AdvancedSettings
 
     # Start Docker if needed
@@ -1005,6 +1011,8 @@ function Connect-CloudAPIProvider {
 
     Write-ColorText ".env file configured for $provider_name." -ForegroundColor "Green"
 
+    Ensure-PostgresPassword
+
     Prompt-AdvancedSettings
 
     # Start Docker if needed
@@ -1036,6 +1044,22 @@ function Connect-CloudAPIProvider {
         Write-ColorText "Please ensure Docker Compose is installed and in your PATH." -ForegroundColor "Red"
         Write-ColorText "Refer to Docker documentation for installation instructions: https://docs.docker.com/compose/install/" -ForegroundColor "Red"
         exit 1
+    }
+}
+
+
+function Ensure-PostgresPassword {
+    if (-not (Select-String -Path $ENV_FILE -Pattern '^POSTGRES_PASSWORD=' -Quiet -ErrorAction SilentlyContinue)) {
+        $bytes = New-Object byte[] 32
+        $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+        try {
+            $rng.GetBytes($bytes)
+        }
+        finally {
+            $rng.Dispose()
+        }
+        $password = [System.BitConverter]::ToString($bytes).Replace("-", "").ToLowerInvariant()
+        "POSTGRES_PASSWORD=$password" | Add-Content -Path $ENV_FILE -Encoding utf8
     }
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -438,12 +438,23 @@ prompt_advanced_settings() {
     done
 }
 
+
+ensure_postgres_password() {
+    if ! grep -q "^POSTGRES_PASSWORD=" "$ENV_FILE" 2>/dev/null; then
+        local postgres_password
+        postgres_password=$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')
+        echo "POSTGRES_PASSWORD=$postgres_password" >> "$ENV_FILE"
+    fi
+}
+
 # 1) Use DocsGPT Public API Endpoint (simple and free)
 use_docs_public_api_endpoint() {
     echo -e "\n${NC}Setting up DocsGPT Public API Endpoint...${NC}"
     echo "LLM_PROVIDER=docsgpt" > "$ENV_FILE"
     echo "VITE_API_STREAMING=true" >> "$ENV_FILE"
     echo -e "${GREEN}.env file configured for DocsGPT Public API.${NC}"
+
+    ensure_postgres_password
 
     prompt_advanced_settings
 
@@ -517,6 +528,8 @@ serve_local_ollama() {
     echo "OPENAI_BASE_URL=http://ollama:11434/v1" >> "$ENV_FILE"
     echo "EMBEDDINGS_NAME=huggingface_sentence-transformers/all-mpnet-base-v2" >> "$ENV_FILE"
     echo -e "${GREEN}.env file configured for Ollama ($(echo "$docker_compose_file_suffix" | tr '[:lower:]' '[:upper:]')${NC}${GREEN}).${NC}"
+
+    ensure_postgres_password
 
     prompt_advanced_settings
 
@@ -632,6 +645,8 @@ connect_local_inference_engine() {
     echo -e "${GREEN}.env file configured for ${BOLD}${engine_name}${NC}${GREEN} with OpenAI API format.${NC}"
     echo -e "${YELLOW}Note: MODEL_NAME is set to '${BOLD}$model_name${NC}${YELLOW}'. You can change it later in the .env file.${NC}"
 
+    ensure_postgres_password
+
     prompt_advanced_settings
 
     check_and_start_docker
@@ -717,6 +732,8 @@ connect_cloud_api_provider() {
     echo "VITE_API_STREAMING=true" >> "$ENV_FILE"
 
     echo -e "${GREEN}.env file configured for ${BOLD}${provider_name}${NC}${GREEN}.${NC}"
+
+    ensure_postgres_password
 
     prompt_advanced_settings
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Security hardening / configuration fix.

## Why was this change needed?

The default Docker Compose configuration exposed Redis and PostgreSQL ports on the host and used a predictable database password. This can make accidentally internet-facing deployments unsafe.

## What changed?

- Removed default host exposure for Redis (`6379`) and PostgreSQL (`5432`)
- Replaced the fixed PostgreSQL password with a required environment variable
- Updated Linux and Windows setup scripts to generate a secure random `POSTGRES_PASSWORD`

## Validation

- Confirmed both Compose configurations no longer expose Redis or PostgreSQL ports
- Confirmed the hard-coded `docsgpt` database password was removed
- Confirmed both setup scripts generate the password before Docker starts