### PR TITLE
fix: ElevenLabs voice_id is hardcoded, add ELEVENLABS_VOICE_ID and ELEVENLABS_LANGUAGE to settings

### DIFF
--- a/application/core/settings.py
+++ b/application/core/settings.py
@@ -232,6 +232,8 @@ class Settings(BaseSettings):
 
     TTS_PROVIDER: str = "google_tts"  # google_tts or elevenlabs
     ELEVENLABS_API_KEY: Optional[str] = None
+    ELEVENLABS_VOICE_ID: str = "nPczCjzI2devNBz1zQrb"
+    ELEVENLABS_LANGUAGE: str = "en"
     STT_PROVIDER: str = "openai"  # openai or faster_whisper
     OPENAI_STT_MODEL: str = "gpt-4o-mini-transcribe"
     STT_LANGUAGE: Optional[str] = None

--- a/application/tts/elevenlabs.py
+++ b/application/tts/elevenlabs.py
@@ -10,16 +10,15 @@ class ElevenlabsTTS(BaseTTS):
 
         self.client = ElevenLabs(
             api_key=settings.ELEVENLABS_API_KEY,
-            )
-    
+        )
 
     def text_to_speech(self, text):
-        lang = "en"
+        lang = settings.ELEVENLABS_LANGUAGE
         audio = self.client.text_to_speech.convert(
-            voice_id="nPczCjzI2devNBz1zQrb",             
+            voice_id=settings.ELEVENLABS_VOICE_ID,
             model_id="eleven_multilingual_v2",
             text=text,
-            output_format="mp3_44100_128"
+            output_format="mp3_44100_128",
         )
         audio_data = BytesIO()
         for chunk in audio:

--- a/tests/tts/test_elevenlabs_tts.py
+++ b/tests/tts/test_elevenlabs_tts.py
@@ -8,7 +8,11 @@ from application.tts.elevenlabs import ElevenlabsTTS
 def test_elevenlabs_text_to_speech_monkeypatched_client(monkeypatch):
     monkeypatch.setattr(
         "application.tts.elevenlabs.settings",
-        SimpleNamespace(ELEVENLABS_API_KEY="api-key"),
+        SimpleNamespace(
+            ELEVENLABS_API_KEY="api-key",
+            ELEVENLABS_VOICE_ID="nPczCjzI2devNBz1zQrb",
+            ELEVENLABS_LANGUAGE="en",
+        ),
     )
 
     created = {}
@@ -58,4 +62,50 @@ def test_elevenlabs_text_to_speech_monkeypatched_client(monkeypatch):
     ]
     assert lang == "en"
     assert base64.b64decode(audio_base64.encode()) == b"chunk-onechunk-two"
+
+
+def test_elevenlabs_text_to_speech_uses_configurable_voice_and_language(monkeypatch):
+    monkeypatch.setattr(
+        "application.tts.elevenlabs.settings",
+        SimpleNamespace(
+            ELEVENLABS_API_KEY="api-key",
+            ELEVENLABS_VOICE_ID="custom-voice-id",
+            ELEVENLABS_LANGUAGE="fr",
+        ),
+    )
+
+    class DummyClient:
+        def __init__(self, api_key):
+            self.convert_calls = []
+
+            class TextToSpeech:
+                def __init__(self, outer):
+                    self._outer = outer
+
+                def convert(self, *, voice_id, model_id, text, output_format):
+                    self._outer.convert_calls.append(
+                        {
+                            "voice_id": voice_id,
+                            "model_id": model_id,
+                            "text": text,
+                            "output_format": output_format,
+                        }
+                    )
+                    yield b"audio"
+
+            self.text_to_speech = TextToSpeech(self)
+
+    client_module = ModuleType("elevenlabs.client")
+    client_module.ElevenLabs = DummyClient
+    package_module = ModuleType("elevenlabs")
+    package_module.client = client_module
+
+    monkeypatch.setitem(sys.modules, "elevenlabs", package_module)
+    monkeypatch.setitem(sys.modules, "elevenlabs.client", client_module)
+
+    tts = ElevenlabsTTS()
+    _, lang = tts.text_to_speech("Bonjour")
+
+    assert tts.client.convert_calls[0]["voice_id"] == "custom-voice-id"
+    assert lang == "fr"
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
  - Bug fix: make ElevenLabs voice ID and language env-configurable

- **Why was this change needed?**
  - Fixes #2562 — voice_id was hardcoded with no way to change it without editing source

- **Other information**:
  - Defaults preserve backward compatibility (`nPczCjzI2devNBz1zQrb`, `en`)
  - Added unit test for custom voice/language settings

## Test plan
- [x] `pytest tests/tts/test_elevenlabs_tts.py -v`