### PR TITLE
fix(rag): replace print statement with logging.info in classic_rag.py

### DIFF
--- a/application/retriever/classic_rag.py
+++ b/application/retriever/classic_rag.py
@@ -144,7 +144,7 @@ class ClassicRAG(BaseRetriever):
                 model=getattr(self.llm, "model_id", None) or self.model_id,
                 messages=messages,
             )
-            print(f"Rephrased query: {rephrased_query}")
+            logging.info(f"Rephrased query: {rephrased_query}")
             return rephrased_query if rephrased_query else self.original_question
         except Exception as e:
             logging.error(f"Error rephrasing query: {e}", exc_info=True)


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
Refactoring / Bug fix

- **Why was this change needed?**
Raw `print()` statements bypass the central logging pipeline, preventing log aggregators and monitoring systems from capturing warning and info events in production environments.

Fixes #2561

- **Other information**:
- **`application/security/encryption.py`**: Replaced `print()` calls in exception handlers (`encrypt_credentials` and `decrypt_credentials`) with `logger.warning()`, using Python's standard `logging` module to avoid circular import issues.
- **`application/retriever/classic_rag.py`**: Replaced the `print()` statement in `_rephrase_query()` with `logging.info()`.