### PR TITLE
fix: warn when STT diarization is requested but unsupported

### DIFF
--- a/application/stt/faster_whisper_stt.py
+++ b/application/stt/faster_whisper_stt.py
@@ -1,7 +1,10 @@
+import logging
 from pathlib import Path
 from typing import Dict, Optional
 
 from application.stt.base import BaseSTT
+
+logger = logging.getLogger(__name__)
 
 
 class FasterWhisperSTT(BaseSTT):
@@ -39,7 +42,11 @@ class FasterWhisperSTT(BaseSTT):
         timestamps: bool = False,
         diarize: bool = False,
     ) -> Dict[str, object]:
-        _ = diarize
+        if diarize:
+            logger.warning(
+                "Speaker diarization is not supported by the faster_whisper STT "
+                "provider; STT_ENABLE_DIARIZATION has no effect."
+            )
         model = self._get_model()
         segments_iter, info = model.transcribe(
             str(file_path),

--- a/application/stt/openai_stt.py
+++ b/application/stt/openai_stt.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -5,6 +6,8 @@ from openai import OpenAI
 
 from application.core.settings import settings
 from application.stt.base import BaseSTT
+
+logger = logging.getLogger(__name__)
 
 
 class OpenAISTT(BaseSTT):
@@ -26,7 +29,11 @@ class OpenAISTT(BaseSTT):
         timestamps: bool = False,
         diarize: bool = False,
     ) -> Dict[str, Any]:
-        _ = diarize
+        if diarize:
+            logger.warning(
+                "Speaker diarization is not supported by the OpenAI STT provider; "
+                "STT_ENABLE_DIARIZATION has no effect."
+            )
         request: Dict[str, Any] = {
             "file": file_path,
             "model": self.model,

--- a/tests/stt/test_faster_whisper.py
+++ b/tests/stt/test_faster_whisper.py
@@ -191,7 +191,7 @@ class TestFasterWhisperSTTTranscribe:
         # Empty text stripped should not be included in text_parts
         assert result["text"] == ""
 
-    def test_transcribe_diarize_is_ignored(self):
+    def test_transcribe_diarize_emits_warning(self, caplog):
         stt, mock_model = self._make_stt_with_mock_model()
 
         info = MagicMock()
@@ -200,13 +200,34 @@ class TestFasterWhisperSTTTranscribe:
 
         mock_model.transcribe.return_value = (iter([]), info)
 
-        # diarize param should be accepted but ignored
-        result = stt.transcribe(
-            Path("/tmp/audio.wav"),
-            diarize=True,
-        )
+        with caplog.at_level("WARNING"):
+            result = stt.transcribe(
+                Path("/tmp/audio.wav"),
+                diarize=True,
+            )
 
         assert result["provider"] == "faster_whisper"
+        assert any(
+            "diarization is not supported by the faster_whisper STT provider"
+            in record.message
+            for record in caplog.records
+        )
+
+    def test_transcribe_diarize_false_emits_no_warning(self, caplog):
+        stt, mock_model = self._make_stt_with_mock_model()
+
+        info = MagicMock()
+        info.language = "en"
+        info.duration = 1.0
+
+        mock_model.transcribe.return_value = (iter([]), info)
+
+        with caplog.at_level("WARNING"):
+            stt.transcribe(Path("/tmp/audio.wav"), diarize=False)
+
+        assert not any(
+            "diarization is not supported" in record.message for record in caplog.records
+        )
 
     def test_transcribe_missing_attrs_use_none(self):
         stt, mock_model = self._make_stt_with_mock_model()

--- a/tests/stt/test_openai_stt.py
+++ b/tests/stt/test_openai_stt.py
@@ -243,6 +243,76 @@ class TestOpenAISTTTranscribe:
 
         assert result["language"] == "de"
 
+    @patch("application.stt.openai_stt.OpenAI")
+    @patch("application.stt.openai_stt.settings")
+    def test_transcribe_diarize_emits_warning(self, mock_settings, mock_openai_cls, caplog):
+        mock_settings.OPENAI_API_KEY = "sk-test"
+        mock_settings.API_KEY = None
+        mock_settings.OPENAI_BASE_URL = None
+        mock_settings.OPENAI_STT_MODEL = "whisper-1"
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "text": "Hello",
+            "language": "en",
+            "duration": 1.0,
+            "segments": [],
+        }
+        mock_client.audio.transcriptions.create.return_value = mock_response
+
+        from application.stt.openai_stt import OpenAISTT
+
+        stt = OpenAISTT()
+
+        file_path = Path("/tmp/test_audio.wav")
+        with patch("builtins.open", mock_open(read_data=b"audio_data")):
+            with caplog.at_level("WARNING"):
+                stt.transcribe(file_path, diarize=True)
+
+        assert any(
+            "diarization is not supported by the OpenAI STT provider"
+            in record.message
+            for record in caplog.records
+        )
+
+    @patch("application.stt.openai_stt.OpenAI")
+    @patch("application.stt.openai_stt.settings")
+    def test_transcribe_diarize_false_emits_no_warning(
+        self, mock_settings, mock_openai_cls, caplog
+    ):
+        mock_settings.OPENAI_API_KEY = "sk-test"
+        mock_settings.API_KEY = None
+        mock_settings.OPENAI_BASE_URL = None
+        mock_settings.OPENAI_STT_MODEL = "whisper-1"
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "text": "Hello",
+            "language": "en",
+            "duration": 1.0,
+            "segments": [],
+        }
+        mock_client.audio.transcriptions.create.return_value = mock_response
+
+        from application.stt.openai_stt import OpenAISTT
+
+        stt = OpenAISTT()
+
+        file_path = Path("/tmp/test_audio.wav")
+        with patch("builtins.open", mock_open(read_data=b"audio_data")):
+            with caplog.at_level("WARNING"):
+                stt.transcribe(file_path, diarize=False)
+
+        assert not any(
+            "diarization is not supported" in record.message for record in caplog.records
+        )
+
 
 @pytest.mark.unit
 class TestOpenAISTTToDict:


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
  - Bug fix: warn when diarization is requested but unsupported

- **Why was this change needed?**
  - Fixes #2563 — STT_ENABLE_DIARIZATION was silently discarded with no operator feedback

- **Other information**:
  - Both OpenAI and faster_whisper providers now log a warning when diarize=True

## Test plan
- [x] `pytest tests/stt/test_openai_stt.py tests/stt/test_faster_whisper.py -v -k diarize`