### PR TITLE
fix: validate payload in tts endpoint to prevent KeyError

### DIFF
--- a/application/api/user/attachments/routes.py
+++ b/application/api/user/attachments/routes.py
@@ -680,8 +680,20 @@ class TextToSpeech(Resource):
     @api.expect(tts_model)
     @api.doc(description="Synthesize audio speech from text")
     def post(self):
-        data = request.get_json()
-        text = data["text"]
+        data = request.get_json(silent=True) or {}
+        text = data.get("text", "")
+
+        if not isinstance(text, str) or not text.strip():
+            return make_response(
+                jsonify(
+                    {
+                        "success": False,
+                        "message": "Field 'text' must be a non-empty string",
+                    }
+                ),
+                400,
+            )
+
         try:
             tts_instance = TTSCreator.create_tts(settings.TTS_PROVIDER)
             audio_base64, detected_language = tts_instance.text_to_speech(text)


### PR DESCRIPTION
## Summary
- Added robust input validation to the `/api/attachments/tts` endpoint.
- Prevented potential `KeyError` and unhandled server crashes when an empty or malformed JSON payload is sent.
- Utilized `request.get_json(silent=True)` for safe parsing and verified that the `text` field is a non-empty string.


Closes #2629