### PR TITLE
Fix missing request body validation in POST /api/user/attachments/tts

### DIFF
--- a/application/api/user/attachments/routes.py
+++ b/application/api/user/attachments/routes.py
@@ -680,8 +680,18 @@ class TextToSpeech(Resource):
     @api.expect(tts_model)
     @api.doc(description="Synthesize audio speech from text")
     def post(self):
-        data = request.get_json()
-        text = data["text"]
+        data = request.get_json(silent=True) or {}
+        text = data.get("text")
+        if not isinstance(text, str) or not text.strip():
+            return make_response(
+                jsonify(
+                    {
+                        "success": False,
+                        "message": "Field 'text' must be a non-empty string",
+                    }
+                ),
+                400,
+            )
         try:
             tts_instance = TTSCreator.create_tts(settings.TTS_PROVIDER)
             audio_base64, detected_language = tts_instance.text_to_speech(text)

--- a/tests/api/user/attachments/test_routes.py
+++ b/tests/api/user/attachments/test_routes.py
@@ -1634,6 +1634,58 @@ class TestTextToSpeech:
             assert _get_response_status(response) == 400
             assert _get_response_json(response)["success"] is False
 
+    def test_tts_missing_body_returns_400_with_message(self, flask_app):
+        from application.api.user.attachments.routes import TextToSpeech
+
+        app = Flask(__name__)
+        with app.test_request_context("/api/tts", method="POST"):
+            resource = TextToSpeech()
+            response = resource.post()
+            payload = _get_response_json(response)
+            assert _get_response_status(response) == 400
+            assert payload["success"] is False
+            assert payload["message"] == "Field 'text' must be a non-empty string"
+
+    def test_tts_missing_text_field_returns_400_with_message(self, flask_app):
+        from application.api.user.attachments.routes import TextToSpeech
+
+        app = Flask(__name__)
+        with app.test_request_context("/api/tts", method="POST", json={}):
+            resource = TextToSpeech()
+            response = resource.post()
+            payload = _get_response_json(response)
+            assert _get_response_status(response) == 400
+            assert payload["success"] is False
+            assert payload["message"] == "Field 'text' must be a non-empty string"
+
+    def test_tts_empty_text_returns_400_with_message(self, flask_app):
+        from application.api.user.attachments.routes import TextToSpeech
+
+        app = Flask(__name__)
+        with app.test_request_context(
+            "/api/tts", method="POST", json={"text": "   "}
+        ):
+            resource = TextToSpeech()
+            response = resource.post()
+            payload = _get_response_json(response)
+            assert _get_response_status(response) == 400
+            assert payload["success"] is False
+            assert payload["message"] == "Field 'text' must be a non-empty string"
+
+    def test_tts_non_string_text_returns_400_with_message(self, flask_app):
+        from application.api.user.attachments.routes import TextToSpeech
+
+        app = Flask(__name__)
+        with app.test_request_context(
+            "/api/tts", method="POST", json={"text": 123}
+        ):
+            resource = TextToSpeech()
+            response = resource.post()
+            payload = _get_response_json(response)
+            assert _get_response_status(response) == 400
+            assert payload["success"] is False
+            assert payload["message"] == "Field 'text' must be a non-empty string"
+
 
 # =====================================================================
 # Coverage gap tests  (lines 136, 256, 330, 337, 443, 457, 560, 590)


### PR DESCRIPTION
Validate get_json() output before accessing "text" to avoid unhandled TypeError/KeyError on empty or malformed payloads, and return a 400 with a descriptive message instead.

Fixes #2627

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- **Why was this change needed?** (You can also link to an open issue here)

- **Other information**: