### PR TITLE
Fix request validation for POST /api/user/attachments/tts

### DIFF
--- a/application/api/user/attachments/routes.py
+++ b/application/api/user/attachments/routes.py
@@ -680,8 +680,18 @@ class TextToSpeech(Resource):
     @api.expect(tts_model)
     @api.doc(description="Synthesize audio speech from text")
     def post(self):
-        data = request.get_json()
-        text = data["text"]
+        data = request.get_json(silent=True) or {}
+        text = data.get("text")
+        if not isinstance(text, str) or not text.strip():
+            return make_response(
+                jsonify(
+                    {
+                        "success": False,
+                        "message": "Field 'text' must be a non-empty string",
+                    }
+                ),
+                400,
+            )
         try:
             tts_instance = TTSCreator.create_tts(settings.TTS_PROVIDER)
             audio_base64, detected_language = tts_instance.text_to_speech(text)
@@ -696,5 +706,11 @@ class TextToSpeech(Resource):
                 200,
             )
         except Exception as err:
-            current_app.logger.error(f"Error synthesizing audio: {err}", exc_info=True)
-            return make_response(jsonify({"success": False}), 400)
+            current_app.logger.error(
+                   f"Error synthesizing audio: {err}",
+                   exc_info=True,
+            )
+            return make_response(
+                   jsonify({"success": False}),
+                   400,
+                )

--- a/tests/api/user/attachments/test_routes.py
+++ b/tests/api/user/attachments/test_routes.py
@@ -1634,6 +1634,85 @@ class TestTextToSpeech:
             assert _get_response_status(response) == 400
             assert _get_response_json(response)["success"] is False
 
+    def test_tts_rejects_missing_text(self, flask_app):
+        from application.api.user.attachments.routes import TextToSpeech
+
+        app = Flask(__name__)
+
+        with app.test_request_context(
+             "/api/tts",
+             method="POST",
+            json={},
+        ):
+             resource = TextToSpeech()
+             response = resource.post()
+
+             assert _get_response_status(response) == 400
+             assert _get_response_json(response) == {
+                  "success": False,
+                "message": "Field 'text' must be a non-empty string",
+             }
+
+
+    def test_tts_rejects_empty_text(self, flask_app):
+        from application.api.user.attachments.routes import TextToSpeech
+
+        app = Flask(__name__)
+
+        with app.test_request_context(
+              "/api/tts",
+               method="POST",
+            json={"text": ""},
+         ):
+             resource = TextToSpeech()
+             response = resource.post()
+
+             assert _get_response_status(response) == 400
+             assert _get_response_json(response) == {
+                 "success": False,
+                 "message": "Field 'text' must be a non-empty string",
+             }
+
+
+    def test_tts_rejects_whitespace_text(self, flask_app):
+         from application.api.user.attachments.routes import TextToSpeech
+
+         app = Flask(__name__)
+
+         with app.test_request_context(
+            "/api/tts",
+             method="POST",
+             json={"text": "     "},
+         ):
+             resource = TextToSpeech()
+             response = resource.post()
+
+             assert _get_response_status(response) == 400
+             assert _get_response_json(response) == {
+                 "success": False,
+                 "message": "Field 'text' must be a non-empty string",
+             }
+
+
+    def test_tts_rejects_non_string_text(self, flask_app):
+        from application.api.user.attachments.routes import TextToSpeech
+
+        app = Flask(__name__)
+
+        with app.test_request_context(
+            "/api/tts",
+            method="POST",
+            json={"text": 123},
+     ):
+            resource = TextToSpeech()
+            response = resource.post()
+
+            assert _get_response_status(response) == 400
+            assert _get_response_json(response) == {
+                "success": False,
+                "message": "Field 'text' must be a non-empty string",
+             }
+ 
 
 # =====================================================================
 # Coverage gap tests  (lines 136, 256, 330, 337, 443, 457, 560, 590)


### PR DESCRIPTION
## Summary

This PR improves request validation for the `POST /api/user/attachments/tts` endpoint.

### Changes
- Use `request.get_json(silent=True) or {}`
- Validate that `text` is a non-empty string
- Return a clear `400 Bad Request` response with an informative message for invalid payloads
- Add unit tests covering:
  - Missing `text`
  - Empty `text`
  - Whitespace-only `text`
  - Non-string `text`

### Testing

- Added new unit tests.
- All tests pass locally (`84 passed`).