### PR TITLE
Fix RandomNumberGenerator.Fill incompatibility with Windows PowerShel…

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -434,7 +434,9 @@ function Configure-Auth {
             $jwt_key = Read-Host "Enter JWT secret key (leave empty to auto-generate)"
             if ([string]::IsNullOrEmpty($jwt_key)) {
                 $bytes = New-Object byte[] 32
-                [System.Security.Cryptography.RandomNumberGenerator]::Fill($bytes)
+                $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+                $rng.GetBytes($bytes)
+                $rng.Dispose()
                 $jwt_key = [System.BitConverter]::ToString($bytes).Replace("-", "").ToLower()
                 Write-ColorText "Auto-generated JWT secret key." -ForegroundColor "Yellow"
             }
@@ -446,7 +448,9 @@ function Configure-Auth {
             $jwt_key = Read-Host "Enter JWT secret key (leave empty to auto-generate)"
             if ([string]::IsNullOrEmpty($jwt_key)) {
                 $bytes = New-Object byte[] 32
-                [System.Security.Cryptography.RandomNumberGenerator]::Fill($bytes)
+                $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+                $rng.GetBytes($bytes)
+                $rng.Dispose()
                 $jwt_key = [System.BitConverter]::ToString($bytes).Replace("-", "").ToLower()
                 Write-ColorText "Auto-generated JWT secret key." -ForegroundColor "Yellow"
             }
@@ -547,7 +551,9 @@ function Ensure-InternalKey {
     $content = if (Test-Path $ENV_FILE) { Get-Content $ENV_FILE -Raw } else { "" }
     if ($content -notmatch "(?m)^INTERNAL_KEY=") {
         $bytes = New-Object byte[] 32
-        [System.Security.Cryptography.RandomNumberGenerator]::Fill($bytes)
+        $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+        $rng.GetBytes($bytes)
+        $rng.Dispose()
         $internal_key = ($bytes | ForEach-Object { $_.ToString("x2") }) -join ""
         "INTERNAL_KEY=$internal_key" | Add-Content -Path $ENV_FILE -Encoding utf8
     }


### PR DESCRIPTION
Fixes #2639

### What kind of change does this PR introduce?
Bug fix.

### Why was this change needed?
`setup.ps1` crashed on Windows PowerShell 5.1 (the default on Windows 11) with:

Method invocation failed because [System.Security.Cryptography.RandomNumberGenerator] does not contain a method named 'Fill'.

`RandomNumberGenerator.Fill()` was introduced in .NET 6 and is only available under PowerShell 7+ (.NET Core/.NET 6+). Windows PowerShell 5.1 runs on .NET Framework, which doesn't have this method, so the script failed immediately when generating the JWT secret key and internal key.

### Fix
Replaced all 3 occurrences of `[System.Security.Cryptography.RandomNumberGenerator]::Fill($bytes)` with the version-compatible pattern:
```powershell
$rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
$rng.GetBytes($bytes)
$rng.Dispose()
```
This produces identical cryptographically secure random bytes and works on both PowerShell 5.1 and 7+, so no PowerShell version restriction is needed.

### Testing
Tested on Windows PowerShell 5.1.26100.8875:
- **Before fix:** running `setup.ps1` → option 1 crashed at `Ensure-InternalKey` with the error below (screenshot/recording attached).
- 
<img width="1618" height="616" alt="Screenshot 2026-08-10 181413" src="https://github.com/user-attachments/assets/20a97ca4-96dd-4ee5-a559-3f77592102b9" />

https://github.com/user-attachments/assets/27729e30-53cd-4cda-94db-8a8e2045422e



- **After fix:** `setup.ps1` runs cleanly through the full setup flow (Public API Endpoint, Advanced Settings including Simple JWT auth) with no errors (screenshot/recording attached).


https://github.com/user-attachments/assets/e3a8bbd8-795e-4a2b-bf1c-81873dfa9716


### Other information
No other files were changed. This is a minimal, targeted fix scoped to the 3 affected call sites in `setup.ps1`.