### PR TITLE
docs: fix frontend eslint path typo and clarify compose file usage in…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Tech Stack Overview:
 ### 🌐 Frontend Contributions (⚛️ React, Vite)
 
 *   The updated Figma design can be found [here](https://www.figma.com/file/OXLtrl1EAy885to6S69554/DocsGPT?node-id=0%3A1&t=hjWVuxRg9yi5YkJ9-1).  Please try to follow the guidelines.
-*   **Coding Style:** We follow a strict coding style enforced by ESLint and Prettier. Please ensure your code adheres to the configuration provided in our repository's `fronetend/.eslintrc.js` file.  We recommend configuring your editor with ESLint and Prettier to help with this.
+*   **Coding Style:** We follow a strict coding style enforced by ESLint and Prettier. Please ensure your code adheres to the configuration provided in our repository's `frontend/.eslintrc.js` file.  We recommend configuring your editor with ESLint and Prettier to help with this.
 * **Component Structure:** Strive for small, reusable components.  Favor functional components and hooks over class components where possible.
 * **State Management** If you need to add stores, please use Redux.
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ docker compose -f deployment/docker-compose.yaml down
 (or use the specific `docker compose down` command shown after running the setup script).
 
 > [!Note]
-> For development environment setup instructions, please refer to the [Development Environment Guide](https://docs.docsgpt.cloud/Deploying/Development-Environment).
+> If you selected a different setup option (e.g. local build, Azure, or dev mode), use the matching compose file instead — check `deployment/` for `docker-compose-hub.yaml`, `docker-compose-local.yaml`, `docker-compose-dev.yaml`, or `docker-compose-azure.yaml`, and run `docker compose -f deployment/<file> down`. For development environment setup, see the [Development Environment Guide](https://docs.docsgpt.cloud/Deploying/Development-Environment).
 
 ## Contributing
 


### PR DESCRIPTION
## What
- Fixes broken path reference in CONTRIBUTING.md (`fronetend` → `frontend`)
- Clarifies README shutdown instructions to cover all deployment compose file variants

## Why
While setting up DocsGPT locally using the local-build option, I noticed the shutdown 
command in README only references the default `docker-compose.yaml`, with no mention of 
`docker-compose-hub.yaml`, `docker-compose-local.yaml`, `docker-compose-dev.yaml`, or 
`docker-compose-azure.yaml`. This could confuse contributors who set up DocsGPT using a 
different option, since running the wrong compose file for `down` may not correctly stop 
their containers.

## Type of change
- [x] Documentation update