### PR TITLE
feat(llm): add OrcaRouter as a named provider

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -10,6 +10,7 @@ INTERNAL_KEY=<internal key for worker-to-backend authentication>
 # GROQ_API_KEY=<your-groq-api-key>
 # NOVITA_API_KEY=<your-novita-api-key>
 # OPEN_ROUTER_API_KEY=<your-openrouter-api-key>
+# ORCAROUTER_API_KEY=<your-orcarouter-api-key>
 
 # Remote Embeddings (Optional - for using a remote embeddings API instead of local SentenceTransformer)
 # When set, the app will use the remote API and won't load SentenceTransformer (saves RAM)

--- a/application/core/model_settings.py
+++ b/application/core/model_settings.py
@@ -16,6 +16,7 @@ class ModelProvider(str, Enum):
     OPENAI = "openai"
     OPENAI_COMPATIBLE = "openai_compatible"
     OPENROUTER = "openrouter"
+    ORCAROUTER = "orcarouter"
     ANTHROPIC = "anthropic"
     GROQ = "groq"
     GOOGLE = "google"

--- a/application/core/models/orcarouter.yaml
+++ b/application/core/models/orcarouter.yaml
@@ -1,0 +1,22 @@
+provider: orcarouter
+defaults:
+  supports_tools: true
+  supports_structured_output: true
+  attachments: [image]
+  context_window: 128000
+
+models:
+  - id: orcarouter/auto
+    display_name: OrcaRouter Auto
+    description: Auto-routed frontier model through the OrcaRouter gateway (zero-trust security on every call)
+    context_window: 262000
+
+  - id: orcarouter/deepseek-v4-pro
+    display_name: DeepSeek V4 Pro (via OrcaRouter)
+    description: Frontier 1M-context reasoning model routed through OrcaRouter
+    context_window: 1048576
+
+  - id: orcarouter/gemini-3.1-flash-lite
+    display_name: Gemini 3.1 Flash Lite (via OrcaRouter)
+    description: Low-cost fast model routed through OrcaRouter
+    context_window: 1048576

--- a/application/core/settings.py
+++ b/application/core/settings.py
@@ -183,6 +183,7 @@ class Settings(BaseSettings):
     GROQ_API_KEY: Optional[str] = None
     HUGGINGFACE_API_KEY: Optional[str] = None
     OPEN_ROUTER_API_KEY: Optional[str] = None
+    ORCAROUTER_API_KEY: Optional[str] = None
     NOVITA_API_KEY: Optional[str] = None
 
     OPENAI_API_BASE: Optional[str] = None  # azure openai api base url

--- a/application/llm/orcarouter.py
+++ b/application/llm/orcarouter.py
@@ -1,0 +1,17 @@
+from application.core.settings import settings
+from application.llm.openai import OpenAILLM
+
+ORCAROUTER_BASE_URL = "https://api.orcarouter.ai/v1"
+
+
+class OrcaRouterLLM(OpenAILLM):
+    provider_name = "orcarouter"
+
+    def __init__(self, api_key=None, user_api_key=None, base_url=None, *args, **kwargs):
+        super().__init__(
+            api_key=api_key or settings.ORCAROUTER_API_KEY or settings.API_KEY,
+            user_api_key=user_api_key,
+            base_url=base_url or ORCAROUTER_BASE_URL,
+            *args,
+            **kwargs,
+        )

--- a/application/llm/providers/__init__.py
+++ b/application/llm/providers/__init__.py
@@ -21,6 +21,7 @@ from application.llm.providers.novita import NovitaProvider
 from application.llm.providers.openai import OpenAIProvider
 from application.llm.providers.openai_compatible import OpenAICompatibleProvider
 from application.llm.providers.openrouter import OpenRouterProvider
+from application.llm.providers.orcarouter import OrcaRouterProvider
 
 # Order here is the order the registry iterates providers (and therefore
 # the order ``/api/models`` reports them). Match the historical order
@@ -35,6 +36,7 @@ ALL_PROVIDERS: List[Provider] = [
     GoogleProvider(),
     GroqProvider(),
     OpenRouterProvider(),
+    OrcaRouterProvider(),
     NovitaProvider(),
     HuggingFaceProvider(),
     LlamaCppProvider(),

--- a/application/llm/providers/orcarouter.py
+++ b/application/llm/providers/orcarouter.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from application.llm.orcarouter import OrcaRouterLLM
+from application.llm.providers._apikey_or_llm_name import (
+    filter_models_by_llm_name,
+    get_api_key,
+)
+from application.llm.providers.base import Provider
+
+
+class OrcaRouterProvider(Provider):
+    name = "orcarouter"
+    llm_class = OrcaRouterLLM
+
+    def get_api_key(self, settings) -> Optional[str]:
+        return get_api_key(settings, self.name, settings.ORCAROUTER_API_KEY)
+
+    def filter_yaml_models(self, settings, models):
+        return filter_models_by_llm_name(
+            settings, self.name, settings.ORCAROUTER_API_KEY, models
+        )

--- a/docs/content/Deploying/DocsGPT-Settings.mdx
+++ b/docs/content/Deploying/DocsGPT-Settings.mdx
@@ -102,7 +102,7 @@ In this case, even though you are using Ollama locally, `LLM_PROVIDER` is set to
 
 DocsGPT ships with a built-in catalog of models for the providers it
 supports out of the box (OpenAI, Anthropic, Google, Groq, OpenRouter,
-Novita, Hugging Face, DocsGPT). To add **your own
+OrcaRouter, Novita, Hugging Face, DocsGPT). To add **your own
 models** without forking the repo — for example, a Mistral or Together
 account, a self-hosted vLLM endpoint, or any other OpenAI-compatible
 API — point `MODELS_CONFIG_DIR` at a directory of YAML files.

--- a/docs/content/Models/cloud-providers.mdx
+++ b/docs/content/Models/cloud-providers.mdx
@@ -30,6 +30,7 @@ DocsGPT offers direct, streamlined support for the following cloud LLM providers
 | Anthropic (Claude)           | `anthropic`    | `claude-3-5-sonnet-20241022`|
 | Groq                         | `groq`         | `llama-3.3-70b-versatile`   |
 | OpenRouter                   | `openrouter`   | (See OpenRouter docs)       |
+| OrcaRouter                   | `orcarouter`   | `orcarouter/auto`           |
 | Novita AI                    | `novita`       | (See Novita docs)           |
 | HuggingFace Inference API    | `huggingface`  | `meta-llama/Llama-3.1-8B-Instruct` |
 
@@ -53,6 +54,18 @@ OPENAI_BASE_URL=https://api.deepseek.com/v1 # DeepSeek's OpenAI API URL
 ```
 
 Remember to consult the documentation of your chosen OpenAI-compatible cloud provider for their specific API endpoint, required model names, and authentication methods.
+
+### Connecting to OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible gateway that routes to frontier models (Claude, GPT, Gemini, DeepSeek, and more) through a single API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+DocsGPT ships a named `orcarouter` provider and model catalog. Set `ORCAROUTER_API_KEY` and the models appear in the in-app picker automatically:
+
+```
+LLM_PROVIDER=orcarouter
+ORCAROUTER_API_KEY=sk-orca-... # Your OrcaRouter API key
+LLM_NAME=orcarouter/auto # Default OrcaRouter gateway model
+```
 
 ### Dedicated `openai_compatible` provider (bring-your-own-model)
 

--- a/tests/core/test_model_registry_yaml.py
+++ b/tests/core/test_model_registry_yaml.py
@@ -51,6 +51,11 @@ EXPECTED_IDS = {
         "deepseek/deepseek-v3.2",
         "anthropic/claude-sonnet-4.6",
     },
+    "orcarouter": {
+        "orcarouter/auto",
+        "orcarouter/deepseek-v4-pro",
+        "orcarouter/gemini-3.1-flash-lite",
+    },
     "novita": {
         "deepseek/deepseek-v4-pro",
         "moonshotai/kimi-k2.6",
@@ -75,6 +80,7 @@ def _make_settings(**overrides):
     s.GOOGLE_API_KEY = None
     s.GROQ_API_KEY = None
     s.OPEN_ROUTER_API_KEY = None
+    s.ORCAROUTER_API_KEY = None
     s.NOVITA_API_KEY = None
     s.HUGGINGFACE_API_KEY = None
     s.LLM_PROVIDER = ""
@@ -228,6 +234,13 @@ class TestRegistryPermutations:
         ids = {m.id for m in reg.get_all_models()}
         assert ids == EXPECTED_IDS["openrouter"] | EXPECTED_IDS["docsgpt"]
 
+    def test_orcarouter_only(self):
+        s = _make_settings(ORCAROUTER_API_KEY="orca-test")
+        with patch("application.core.settings.settings", s):
+            reg = ModelRegistry()
+        ids = {m.id for m in reg.get_all_models()}
+        assert ids == EXPECTED_IDS["orcarouter"] | EXPECTED_IDS["docsgpt"]
+
     def test_novita_only(self):
         s = _make_settings(NOVITA_API_KEY="n-test")
         with patch("application.core.settings.settings", s):
@@ -257,6 +270,7 @@ class TestRegistryPermutations:
             GOOGLE_API_KEY="x",
             GROQ_API_KEY="x",
             OPEN_ROUTER_API_KEY="x",
+            ORCAROUTER_API_KEY="x",
             NOVITA_API_KEY="x",
             HUGGINGFACE_API_KEY="x",
             OPENAI_API_BASE="x",

--- a/tests/core/test_model_settings.py
+++ b/tests/core/test_model_settings.py
@@ -34,6 +34,7 @@ class TestModelProvider:
         assert ModelProvider.HUGGINGFACE == "huggingface"
         assert ModelProvider.NOVITA == "novita"
         assert ModelProvider.OPENROUTER == "openrouter"
+        assert ModelProvider.ORCAROUTER == "orcarouter"
         assert ModelProvider.LLAMA_CPP == "llama.cpp"
 
 

--- a/tests/core/test_model_utils.py
+++ b/tests/core/test_model_utils.py
@@ -110,6 +110,16 @@ class TestGetApiKeyForProvider:
             assert get_api_key_for_provider("openrouter") == "sk-or"
 
     @pytest.mark.unit
+    def test_orcarouter_key(self):
+        with patch("application.core.settings.settings") as mock_settings:
+            mock_settings.ORCAROUTER_API_KEY = "sk-orca"
+            mock_settings.API_KEY = "sk-fallback"
+
+            from application.core.model_utils import get_api_key_for_provider
+
+            assert get_api_key_for_provider("orcarouter") == "sk-orca"
+
+    @pytest.mark.unit
     def test_novita_key(self):
         with patch("application.core.settings.settings") as mock_settings:
             mock_settings.NOVITA_API_KEY = "sk-novita"

--- a/tests/llm/test_base.py
+++ b/tests/llm/test_base.py
@@ -404,6 +404,7 @@ class TestProviderNameRegistry:
         from application.llm.llama_cpp import LlamaCpp
         from application.llm.novita import NovitaLLM
         from application.llm.open_router import OpenRouterLLM
+        from application.llm.orcarouter import OrcaRouterLLM
         from application.llm.openai import OpenAILLM
 
         assert OpenAILLM.provider_name == "openai"
@@ -412,6 +413,7 @@ class TestProviderNameRegistry:
         assert GroqLLM.provider_name == "groq"
         assert NovitaLLM.provider_name == "novita"
         assert OpenRouterLLM.provider_name == "openrouter"
+        assert OrcaRouterLLM.provider_name == "orcarouter"
         assert DocsGPTAPILLM.provider_name == "docsgpt"
         assert LlamaCpp.provider_name == "llama_cpp"
 

--- a/tests/test_remaining_coverage.py
+++ b/tests/test_remaining_coverage.py
@@ -237,6 +237,20 @@ class TestOpenRouterLLM:
 
 
 # ---------------------------------------------------------------------------
+# application/llm/orcarouter.py  (line 9)
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestOrcaRouterLLM:
+    def test_init_uses_orcarouter_base_url(self):
+        """Cover line 9: OrcaRouterLLM.__init__ delegates to OpenAILLM."""
+        from application.llm.orcarouter import ORCAROUTER_BASE_URL, OrcaRouterLLM
+
+        # Verify the class exists and has the correct base URL constant
+        assert ORCAROUTER_BASE_URL == "https://api.orcarouter.ai/v1"
+        assert issubclass(OrcaRouterLLM, object)
+
+
+# ---------------------------------------------------------------------------
 # application/llm/groq.py  (line 9)
 # ---------------------------------------------------------------------------
 @pytest.mark.unit


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature — adds [OrcaRouter](https://www.orcarouter.ai) as a first-class named LLM provider, mirroring the existing OpenRouter integration.

- **Why was this change needed?** (You can also link to an open issue here)

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible gateway that routes to frontier models (Claude, GPT, Gemini, DeepSeek, and more) through a single API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Adding it as a named provider (rather than requiring users to hand-roll an `openai_compatible` YAML) makes DocsGPT users one `ORCAROUTER_API_KEY` away from the OrcaRouter catalog in the in-app model picker, with `LLM_PROVIDER=orcarouter` also supported.

- **What changed?**

- `application/llm/orcarouter.py` — `OrcaRouterLLM` (OpenAILLM subclass) with `base_url https://api.orcarouter.ai/v1`, key resolution `ORCAROUTER_API_KEY` → `API_KEY`.
- `application/llm/providers/orcarouter.py` — `OrcaRouterProvider` plugin, registered in `ALL_PROVIDERS` / `PROVIDERS_BY_NAME`.
- `ModelProvider.ORCAROUTER` enum + `ORCAROUTER_API_KEY` setting + `.env-template` entry.
- `application/core/models/orcarouter.yaml` — built-in model catalog (`orcarouter/auto` and friends) surfaced in `/api/models` once the key is set.
- Docs: provider table + a short "Connecting to OrcaRouter" section in `cloud-providers.mdx`; supported-provider list in `DocsGPT-Settings.mdx`.
- Tests: registry permutation, API-key resolution, provider-name pinning, enum, and LLM coverage block.

- **Validation**

- `python3 -m pytest -o addopts=''` on the touched test files: 171 passed, 49 pre-existing environment failures identical to clean `main` (missing heavy deps like `faiss`/`docling`).
- New tests (`test_orcarouter_only`, `test_orcarouter_key`, `TestOrcaRouterLLM`, provider-name pin, enum) — all pass.
- Registry loads the 3 `orcarouter` models; `LLMCreator.create_llm("orcarouter", ...)` dispatches `OrcaRouterLLM` with the correct base URL.
- Live check with a real OrcaRouter key: `POST https://api.orcarouter.ai/v1/chat/completions` (model `orcarouter/auto`) returned HTTP 200.

- **Other information**:

Disclosure: I'm an engineer on the OrcaRouter team.
