### PR TITLE
fix(tts): em/en dashes silently fuse adjacent words in clean_text_for_tts

### DIFF
--- a/application/utils.py
+++ b/application/utils.py
@@ -498,6 +498,17 @@ def clean_text_for_tts(text: str) -> str:
     )  ## --- *** ___ rules
     text = re.sub(r"<[^>]*>", "", text)  ## <html> tags
 
+    # Normalize typographic punctuation LLMs commonly emit (em/en dashes,
+    # curly quotes, ellipsis) to ASCII *before* the non-ASCII strip below.
+    # Without this, e.g. an em dash between two words is deleted outright
+    # rather than replaced, silently fusing them together for the TTS
+    # engine: "great—really" -> "greatreally", "$10–20" -> "$1020".
+    text = text.replace("\u2014", ", ")  ## — em dash
+    text = text.replace("\u2013", "-")  ## – en dash
+    text = text.replace("\u2026", "...")  ## … ellipsis
+    text = text.replace("\u2018", "'").replace("\u2019", "'")  ## ‘ ’ smart single quotes
+    text = text.replace("\u201c", '"').replace("\u201d", '"')  ## “ ” smart double quotes
+
     # Remove non-ASCII (emojis, special Unicode)
 
     text = re.sub(r"[^\x20-\x7E\n\r\t]", "", text)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -675,6 +675,28 @@ class TestCleanTextForTts:
         result = clean_text_for_tts("_italic text_")
         assert "italic text" in result
 
+    @pytest.mark.unit
+    def test_em_dash_does_not_fuse_words(self):
+        result = clean_text_for_tts("This is great\u2014really useful.")
+        assert "greatreally" not in result
+        assert "great" in result and "really" in result
+
+    @pytest.mark.unit
+    def test_en_dash_does_not_fuse_numeric_range(self):
+        result = clean_text_for_tts("Prices range from $10\u201320.")
+        assert "1020" not in result
+        assert "10" in result and "20" in result
+
+    @pytest.mark.unit
+    def test_ellipsis_normalized_to_ascii_dots(self):
+        result = clean_text_for_tts("Ellipsis test\u2026 continues.")
+        assert "..." in result
+
+    @pytest.mark.unit
+    def test_smart_quotes_normalized_to_ascii(self):
+        result = clean_text_for_tts("It\u2019s a \u201csmart quote\u201d example.")
+        assert "It's a \"smart quote\" example." in result
+
 
 class TestLimitChatHistoryEdgeCases:
 


### PR DESCRIPTION
## Bug

`clean_text_for_tts()` in `application/utils.py` — used by the TTS
pipeline to sanitize assistant responses before speech synthesis — strips
all non-ASCII characters as its final cleanup step, **deleting** them
rather than replacing them:

    text = re.sub(r"[^\x20-\x7E\n\r\t]", "", text)

LLM responses frequently contain em dashes, en dashes, curly quotes, and
ellipses. Deleting one of these with no replacement silently fuses the
words or numbers on either side of it:

    clean_text_for_tts("This is great—really useful.")
    -> 'This is greatreally useful.'

    clean_text_for_tts("Prices range from $10–20.")
    -> 'Prices range from $1020.'   # numeric range becomes a wrong single number

This isn't an edge case - em/en dashes are common LLM output style,
including from the same providers DocsGPT itself supports.

## Fix

Normalize this typographic punctuation to ASCII equivalents *before* the
non-ASCII strip: em dash -> ', ', en dash -> '-', ellipsis -> '...',
curly quotes -> straight quotes.

**Scope note:** accented Latin letters (café, naïve) still lose their
diacritics after this fix - that's a real but separate, broader
multilingual-TTS question, not a one-line correctness bug, so I've left
it out to keep this PR narrowly scoped to the word-fusion defect.

## Tests

Added 4 regression tests to the existing `TestCleanTextForTts` class in
`tests/test_utils.py`, confirmed failing on `main` and passing with the
fix. All 19 pre-existing tests in that class still pass unmodified.

## Verification

Screenshot attached showing: the full `pytest tests/test_utils.py -k CleanTextForTts -v`
run (23 passed = 19 pre-existing + 4 new), plus the `ruff check` diff against
`main` (identical output, no new lint issues).

Note for reviewers: the Postgres-backed dev stack isn't required for this
particular selection — `TestCleanTextForTts` are pure unit tests that never
instantiate the `pytest-postgresql` fixtures, so `-k CleanTextForTts` runs
green without a live database.

This is a backend-only change with no UI surface, so I'm attaching the
terminal verification output in place of a UI screenshot/recording, per
the contributing guide's requirement.
