### PR TITLE
fix: normalize PostgreSQL URI schemes case-insensitively

### DIFF
--- a/docsgpt/core/db_uri.py
+++ b/docsgpt/core/db_uri.py
@@ -41,8 +41,8 @@ def _rewrite_uri_prefixes(v, rewrites):
     if not v or v.lower() == "none":
         return None
     for prefix, target in rewrites:
-        if v.startswith(prefix):
-            return target + v[len(prefix):]
+        if v[: len(prefix)].lower() == prefix:
+            return target + v[len(prefix) :]
     return v
 
 

--- a/tests/core/test_db_uri.py
+++ b/tests/core/test_db_uri.py
@@ -37,6 +37,11 @@ class TestNormalizePostgresUri:
                 "postgresql://u:p@h:5432/d",
                 "postgresql+psycopg://u:p@h:5432/d",
             ),
+            # URI schemes are case-insensitive, so normalize them too.
+            (
+                "POSTGRESQL://u:p@h:5432/d",
+                "postgresql+psycopg://u:p@h:5432/d",
+            ),
             # Legacy psycopg2 dialect is silently upgraded — psycopg2 is
             # no longer in requirements.txt, so there's no way it can work
             # as-is, and rewriting is friendlier than failing.
@@ -106,6 +111,10 @@ class TestNormalizePgvectorConnectionString:
             # Operators hit this when they copy POSTGRES_URI → PGVECTOR_CONNECTION_STRING.
             (
                 "postgresql+psycopg://u:p@h:5432/d",
+                "postgresql://u:p@h:5432/d",
+            ),
+            (
+                "POSTGRESQL+PSYCOPG://u:p@h:5432/d",
                 "postgresql://u:p@h:5432/d",
             ),
             (


### PR DESCRIPTION
Fixes #2694.

Recognized PostgreSQL URI schemes are now normalized case-insensitively while preserving the authority, path, and query substring. This prevents valid uppercase inputs such as `POSTGRESQL://...` and `POSTGRESQL+PSYCOPG://...` from reaching SQLAlchemy or libpq with an unsupported driver string.

Tests:
- `python -m pytest --confcutdir=tests/core --no-cov tests/core/test_db_uri.py -q` (28 passed)
- `ruff check application/core/db_uri.py tests/core/test_db_uri.py`
- `ruff format --check application/core/db_uri.py tests/core/test_db_uri.py`
- SQLAlchemy dialect smoke test for normalized uppercase URI

No UI surface changed; validation is automated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - URI normalization now recognizes database connection prefixes regardless of letter casing.
  - Uppercase PostgreSQL connection schemes are correctly rewritten to their supported formats.

- **Tests**
  - Added coverage for uppercase PostgreSQL and PostgreSQL driver prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->