### PR TITLE
docs: fix react-widget README package name, API port, and doc typos

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,10 +13,10 @@ git clone https://github.com/arc53/DocsGPT.git
 cd DocsGPT/docs
 ```
 
-The docs folder contains the markdown files that make up the documentation. The majority of the files are in the pages directory. Some notable files in this folder include:
+The docs folder contains the markdown files that make up the documentation. The majority of the files are in the content directory. Some notable files in this folder include:
 
-`index.mdx`: The main documentation file.
-`_app.js`: This file is used to customize the default Next.js application shell.
+`content/index.mdx`: The main documentation file.
+`app/layout.jsx`: This file is used to customize the default Next.js application shell.
 `theme.config.jsx`: This file is for configuring the Nextra theme for the documentation.
 
 ### 3. Verify that you have Node.js and npm installed in your system. You can check by running:

--- a/docs/content/Extensions/chat-widget.mdx
+++ b/docs/content/Extensions/chat-widget.mdx
@@ -94,7 +94,7 @@ Then, in a `<script type="module">` block, use the `renderDocsGPTWidget` functio
       title: 'Get AI assistance',
       description: "DocsGPT's AI Chatbot is here to help",
       heroTitle: 'Welcome to DocsGPT!',
-      heroDescription: 'This chatbot is utilises GenAI, please review important information.',
+      heroDescription: 'This chatbot is built with DocsGPT and utilises GenAI, please review important information using sources.',
       theme:"dark",
       buttonIcon:"https://your-icon",
       buttonBg:"#222327"

--- a/docs/content/Guides/How-to-use-different-LLM.mdx
+++ b/docs/content/Guides/How-to-use-different-LLM.mdx
@@ -15,7 +15,7 @@ Setting up local language models for your app can significantly enhance its capa
 ### For cloud version LLM change:
 <Steps >
 ### Step 1
-Visit the chat screen and you will be to see the default LLM selected.
+Visit the chat screen and you will be able to see the default LLM selected.
 ### Step 2
 Click on it and you will get a drop down of various LLM's available to choose.
 ### Step 3

--- a/extensions/react-widget/README.md
+++ b/extensions/react-widget/README.md
@@ -13,7 +13,7 @@ npm install  docsgpt
 ### React
 
 ```javascript
-    import { DocsGPTWidget } from "docsgpt-react";
+    import { DocsGPTWidget } from "docsgpt";
 
     const App = () => {
       return <DocsGPTWidget />;
@@ -23,7 +23,7 @@ npm install  docsgpt
 To link the widget to your api and your documents you can pass parameters to the <DocsGPTWidget /> component.
 
 ```javascript
-    import { DocsGPTWidget } from "docsgpt-react";
+    import { DocsGPTWidget } from "docsgpt";
 
     const App = () => {
       return <DocsGPTWidget
@@ -84,7 +84,7 @@ To link the widget to your api and your documents you can pass parameters to the
         <script type="module">
           window.onload = function() {
             renderDocsGPTWidget('app', {
-              apiHost: 'http://localhost:7001',
+              apiHost: 'http://localhost:7091',
               apiKey:"",
               avatar: 'https://d3dg1063dc54p9.cloudfront.net/cute-docsgpt.png',
               title: 'Get AI assistance',
@@ -109,7 +109,7 @@ The `SearchBar` component is an interactive search bar designed to provide searc
 
 ### Importing the Component
 ```tsx
-import { SearchBar } from "docsgpt-react";
+import { SearchBar } from "docsgpt";
 ```
 
 ---

--- a/frontend/src/locale/en.json
+++ b/frontend/src/locale/en.json
@@ -532,7 +532,7 @@
         "needsAuth": "Needs Auth",
         "configured": "Configured"
       },
-      "deleteWarning": "Are you sure you want to delete the tool \"{{toolName}}\" ?",
+      "deleteWarning": "Are you sure you want to delete the tool \"{{toolName}}\"?",
       "unsavedChanges": "You have unsaved changes that will be lost if you leave without saving.",
       "leaveWithoutSaving": "Leave without Saving",
       "saveAndLeave": "Save and Leave",
@@ -799,7 +799,7 @@
         "preparing": "Preparing upload",
         "parsing": "Parsing files…",
         "embedding": "Embedding…",
-        "tokenLimit": "Over the token limit, please consider uploading smaller document",
+        "tokenLimit": "Over the token limit, please consider uploading a smaller document",
         "expandDetails": "Expand upload details",
         "collapseDetails": "Collapse upload details",
         "dismiss": "Dismiss upload toast",


### PR DESCRIPTION
## Summary
- `extensions/react-widget/README.md` imports from `docsgpt-react`, but the package published from that directory is `docsgpt` (`package.json`), and the README's own install command is `npm install docsgpt`. Following the README as written fails at build time.
- Same README's self-hosted example uses `apiHost: 'http://localhost:7001'`; the backend listens on **7091** (`application/app.py` `app.run(..., port=7091)`, `API_URL` in `application/core/settings.py`, and `docs/content/Extensions/chat-widget.mdx` documents 7091).
- `chat-widget.mdx`: `'This chatbot is utilises GenAI…'` -> use the actual default heroDescription from `DocsGPTWidget.tsx`.
- `docs/README.md`: describes the removed `pages/` directory and `_app.js`; the current layout is `content/` + `app/layout.jsx`.
- Small grammar fixes in a guide and two user-facing `en.json` strings (space before `?`; "uploading smaller document" -> "a smaller document"). `en.json` validated as JSON after the edit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup guidance to reflect the current documentation structure and file locations.
  * Corrected wording in the LLM configuration guide and aligned the chat widget examples.
  * Updated React widget examples to use the current package name and API host value.

* **User Interface**
  * Improved English-language messages for tool deletion confirmation and document upload limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->