### PR TITLE
fix(mcp): complete OAuth against path-scoped PRM resources and tolerate schemas without properties

### DIFF
--- a/application/agents/tool_executor.py
+++ b/application/agents/tool_executor.py
@@ -672,10 +672,25 @@ class ToolExecutor:
         return result
 
     def _build_tool_parameters(self, action: Dict) -> Dict:
+        """Build the JSON Schema advertised to the LLM for one action.
+
+        Property entries that are not mappings are skipped: a stored tool may
+        carry a schema this method cannot translate, and dropping the entry is
+        preferable to failing the whole turn.
+
+        Args:
+            action: The stored action document.
+
+        Returns:
+            A JSON Schema object with the LLM-filled properties.
+        """
         params = {"type": "object", "properties": {}, "required": []}
         for param_type in ["query_params", "headers", "body", "parameters"]:
-            if param_type in action and action[param_type].get("properties"):
+            block = action.get(param_type)
+            if isinstance(block, dict) and isinstance(block.get("properties"), dict):
                 for k, v in action[param_type]["properties"].items():
+                    if not isinstance(v, dict):
+                        continue
                     if v.get("filled_by_llm", True):
                         params["properties"][k] = {
                             key: value for key, value in v.items() if key not in ("filled_by_llm", "value", "required")

--- a/application/agents/tools/mcp_tool.py
+++ b/application/agents/tools/mcp_tool.py
@@ -32,6 +32,23 @@ logger = logging.getLogger(__name__)
 _mcp_clients_cache = {}
 
 
+def _is_json_schema_object(schema: Dict) -> bool:
+    """Tell a JSON Schema apart from a bare map of property definitions.
+
+    Some MCP servers send ``inputSchema`` as a flat ``{name: definition}`` map
+    instead of a JSON Schema. A real schema declares ``type`` as a string
+    (``"object"``), whereas in a flat map a ``type`` key would hold a property
+    definition, i.e. a mapping.
+
+    Args:
+        schema: The raw ``inputSchema`` mapping reported by the server.
+
+    Returns:
+        True when the mapping looks like a JSON Schema object.
+    """
+    return isinstance(schema.get("type"), str) or "$schema" in schema
+
+
 class MCPTool(Tool):
     """
     MCP Tool
@@ -563,11 +580,13 @@ class MCPTool(Tool):
 
             if input_schema:
                 if isinstance(input_schema, dict):
-                    if "properties" in input_schema:
+                    if "properties" in input_schema or _is_json_schema_object(input_schema):
+                        properties = input_schema.get("properties")
+                        required = input_schema.get("required")
                         parameters_schema = {
                             "type": input_schema.get("type", "object"),
-                            "properties": input_schema.get("properties", {}),
-                            "required": input_schema.get("required", []),
+                            "properties": properties if isinstance(properties, dict) else {},
+                            "required": required if isinstance(required, list) else [],
                         }
 
                         for key in ["additionalProperties", "description"]:
@@ -713,14 +732,22 @@ class DocsGPTOAuth(OAuthClientProvider):
             **(additional_client_metadata or {}),
         )
 
+        # Tokens stay keyed by origin: ``MCPAuthStatus`` and ``DBTokenStorage``
+        # both look sessions up by ``scheme://netloc``.
         storage = DBTokenStorage(
             server_url=self.server_base_url,
             user_id=self.user_id,
             expected_redirect_uri=None if skip_redirect_validation else redirect_uri,
         )
 
+        # The full endpoint URL, not the origin: per RFC 8707 the SDK derives
+        # the resource indicator from ``server_url`` and requires it to sit at
+        # or below the ``resource`` published in the server's Protected
+        # Resource Metadata. The origin is a *parent* of a path-scoped
+        # resource, so passing it fails the check before the consent URL is
+        # ever issued.
         super().__init__(
-            server_url=self.server_base_url,
+            server_url=mcp_url,
             client_metadata=client_metadata,
             storage=storage,
             redirect_handler=self.redirect_handler,

--- a/application/api/user/tools/mcp.py
+++ b/application/api/user/tools/mcp.py
@@ -119,10 +119,12 @@ class TestMCPServerConfig(Resource):
             result = mcp_tool.test_connection()
 
             if result.get("requires_oauth"):
+                # ``task_id`` is what the client subscribes to for the
+                # authorization URL, so it has to survive the allowlist.
                 safe_result = {
                     k: v
                     for k, v in result.items()
-                    if k in ("success", "requires_oauth", "auth_url")
+                    if k in ("success", "requires_oauth", "auth_url", "task_id")
                 }
                 return make_response(jsonify(safe_result), 200)
 

--- a/application/api/user/tools/routes.py
+++ b/application/api/user/tools/routes.py
@@ -165,20 +165,33 @@ def _merge_secrets_on_update(new_config, existing_config, config_requirements, u
     return storage_config
 
 
-def transform_actions(actions_metadata):
+def transform_actions(actions_metadata: list[dict]) -> list[dict]:
     """Set default flags on action metadata for storage.
 
     Marks each action as active, sets ``filled_by_llm`` and ``value`` on every
     parameter property. Used by both the generic create_tool and MCP save routes.
+
+    Entries that are not mappings are left untouched: a third-party tool may
+    report a schema this function cannot annotate, and that must not fail the
+    whole save.
+
+    Args:
+        actions_metadata: Action documents as reported by the tool.
+
+    Returns:
+        The same action documents, annotated in place.
     """
     transformed = []
     for action in actions_metadata:
         action["active"] = True
-        if "parameters" in action:
-            props = action["parameters"].get("properties", {})
-            for param_details in props.values():
-                param_details["filled_by_llm"] = True
-                param_details["value"] = ""
+        if isinstance(action.get("parameters"), dict):
+            props = action["parameters"].get("properties")
+            if isinstance(props, dict):
+                for param_details in props.values():
+                    if not isinstance(param_details, dict):
+                        continue
+                    param_details["filled_by_llm"] = True
+                    param_details["value"] = ""
         transformed.append(action)
     return transformed
 

--- a/tests/agents/test_mcp_tool.py
+++ b/tests/agents/test_mcp_tool.py
@@ -447,6 +447,46 @@ class TestGetActionsMetadata:
         assert meta[0]["parameters"]["properties"] == {}
 
     @patch("application.agents.tools.mcp_tool.MCPTool._setup_client")
+    def test_schema_object_without_properties(self, mock_setup, mcp_config):
+        """``{"type": "object"}`` is a valid schema meaning "takes no arguments"."""
+        from application.agents.tools.mcp_tool import MCPTool
+
+        tool = MCPTool(mcp_config)
+        tool.available_tools = [
+            {
+                "name": "list_profiles",
+                "description": "Takes no arguments",
+                "inputSchema": {"type": "object"},
+            }
+        ]
+        meta = tool.get_actions_metadata()
+        assert meta[0]["parameters"]["properties"] == {}
+        assert meta[0]["parameters"]["required"] == []
+
+    @patch("application.agents.tools.mcp_tool.MCPTool._setup_client")
+    def test_schema_object_with_null_properties(self, mock_setup, mcp_config):
+        from application.agents.tools.mcp_tool import MCPTool
+
+        tool = MCPTool(mcp_config)
+        tool.available_tools = [
+            {"name": "noop", "inputSchema": {"type": "object", "properties": None}}
+        ]
+        meta = tool.get_actions_metadata()
+        assert meta[0]["parameters"]["properties"] == {}
+
+    @patch("application.agents.tools.mcp_tool.MCPTool._setup_client")
+    def test_legacy_flat_property_map(self, mock_setup, mcp_config):
+        """Servers sending a bare property map (no ``type``) keep working."""
+        from application.agents.tools.mcp_tool import MCPTool
+
+        tool = MCPTool(mcp_config)
+        tool.available_tools = [
+            {"name": "search", "inputSchema": {"query": {"type": "string"}}}
+        ]
+        meta = tool.get_actions_metadata()
+        assert meta[0]["parameters"]["properties"] == {"query": {"type": "string"}}
+
+    @patch("application.agents.tools.mcp_tool.MCPTool._setup_client")
     def test_config_requirements(self, mock_setup, mcp_config):
         from application.agents.tools.mcp_tool import MCPTool
 
@@ -519,3 +559,47 @@ class TestDBTokenStorage:
         key = storage.get_db_key()
         assert key["server_url"] == "https://mcp.example.com"
         assert key["user_id"] == "user1"
+
+
+@pytest.mark.unit
+class TestDocsGPTOAuthResourceUrl:
+    """RFC 8707: the OAuth resource must be the MCP endpoint, not its origin.
+
+    ``OAuthClientProvider._validate_resource_match`` requires the resource
+    derived from ``server_url`` to sit at or below the ``resource`` published
+    in the server's Protected Resource Metadata. Passing only the origin makes
+    it a *parent* of the advertised resource, which the check rejects.
+    """
+
+    @staticmethod
+    def _build(mcp_url: str):
+        from application.agents.tools.mcp_tool import DocsGPTOAuth
+
+        return DocsGPTOAuth(
+            mcp_url=mcp_url,
+            redirect_uri="https://docsgpt.example.com/api/mcp_oauth_callback",
+            user_id="user1",
+        )
+
+    def test_provider_server_url_keeps_endpoint_path(self):
+        provider = self._build("https://mcp.example.com/mcp")
+        assert str(provider.context.server_url) == "https://mcp.example.com/mcp"
+
+    def test_token_storage_still_keyed_by_origin(self):
+        """Token rows stay keyed by origin so ``MCPAuthStatus`` lookups match."""
+        provider = self._build("https://mcp.example.com/mcp")
+        assert provider.server_base_url == "https://mcp.example.com"
+        assert provider.context.storage.server_url == "https://mcp.example.com"
+
+    def test_resource_match_accepts_path_scoped_metadata(self):
+        from mcp.shared.auth_utils import (
+            check_resource_allowed,
+            resource_url_from_server_url,
+        )
+
+        provider = self._build("https://mcp.example.com/mcp")
+        derived = resource_url_from_server_url(provider.context.server_url)
+        assert check_resource_allowed(
+            requested_resource=derived,
+            configured_resource="https://mcp.example.com/mcp",
+        )

--- a/tests/agents/test_tool_executor.py
+++ b/tests/agents/test_tool_executor.py
@@ -493,6 +493,31 @@ class TestToolExecutorPrepare:
         assert "filled_by_llm" not in result["properties"]["query"]
         assert "value" not in result["properties"]["query"]
 
+    def test_build_tool_parameters_skips_non_dict_properties(self):
+        """A stored schema leaked into ``properties`` must not break the turn."""
+        executor = ToolExecutor()
+        action = {
+            "parameters": {
+                "properties": {
+                    "type": "object",
+                    "query": {"type": "string", "filled_by_llm": True},
+                }
+            }
+        }
+
+        result = executor._build_tool_parameters(action)
+        assert result["properties"] == {"query": {"type": "string"}}
+
+    def test_build_tool_parameters_skips_non_dict_param_block(self):
+        executor = ToolExecutor()
+        action = {"parameters": "object"}
+
+        assert executor._build_tool_parameters(action) == {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        }
+
 
 @pytest.mark.unit
 class TestCheckPause:

--- a/tests/api/user/test_tools_mcp_pg.py
+++ b/tests/api/user/test_tools_mcp_pg.py
@@ -243,6 +243,38 @@ class TestTestMCPServerConfig:
         assert response.status_code == 200
         assert response.json["requires_oauth"] is True
 
+    def test_oauth_required_passes_through_task_id(self, app):
+        """The frontend only opens the consent popup when ``task_id`` is present."""
+        from application.api.user.tools.mcp import TestMCPServerConfig
+
+        fake_tool = MagicMock()
+        fake_tool.test_connection.return_value = {
+            "success": False,
+            "requires_oauth": True,
+            "task_id": "celery-task-1",
+            "message": "OAuth authorization required.",
+            "tools_count": 0,
+        }
+
+        with patch(
+            "application.api.user.tools.mcp.MCPTool",
+            return_value=fake_tool,
+        ), app.test_request_context(
+            "/api/mcp_server/test", method="POST",
+            json={
+                "config": {
+                    "transport_type": "http",
+                    "server_url": "https://example.com/mcp",
+                    "auth_type": "oauth",
+                },
+            },
+        ):
+            from flask import request
+            request.decoded_token = {"sub": "u"}
+            response = TestMCPServerConfig().post()
+        assert response.status_code == 200
+        assert response.json["task_id"] == "celery-task-1"
+
     def test_unexpected_exception_returns_500(self, app):
         from application.api.user.tools.mcp import TestMCPServerConfig
 

--- a/tests/api/user/test_tools_routes.py
+++ b/tests/api/user/test_tools_routes.py
@@ -376,6 +376,29 @@ class TestTransformActions:
 
         assert transform_actions([]) == []
 
+    def test_ignores_non_dict_properties(self):
+        """A schema whose ``properties`` is not a mapping must not raise."""
+        from application.api.user.tools.routes import transform_actions
+
+        actions = [{"name": "noop", "parameters": {"type": "object", "properties": None}}]
+        result = transform_actions(actions)
+        assert result[0]["active"] is True
+
+    def test_ignores_non_dict_param_details(self):
+        """Malformed property values are skipped instead of raising TypeError."""
+        from application.api.user.tools.routes import transform_actions
+
+        actions = [
+            {
+                "name": "list_profiles",
+                "parameters": {"properties": {"type": "object", "query": {"type": "string"}}},
+            }
+        ]
+        result = transform_actions(actions)
+        props = result[0]["parameters"]["properties"]
+        assert props["type"] == "object"
+        assert props["query"]["filled_by_llm"] is True
+
 
 # ---------------------------------------------------------------------------
 # Route: AvailableTools


### PR DESCRIPTION
- **What kind of change does this PR introduce?** Bug fix, backend only, plus tests.

- **Why was this change needed?** Refs #2702 — an MCP server whose OAuth Protected
  Resource Metadata advertises a path-scoped `resource` cannot be connected at all, and
  the first two failures show no message in the UI.

- **Other information**: details below.

## Summary

Connecting an MCP server whose OAuth Protected Resource Metadata advertises a
path-scoped `resource` (Grafana Cloud MCP, `https://mcp.grafana.com/mcp`) fails at
several independent points on the same path. Each is only reachable once the previous
one is fixed, so they are fixed together.

This covers defects 1–4 of the issue. Defect 5 — `_test_oauth_connection` returning
success without a `task_id` once a token is stored, while `MCPServerSave` hard-requires
one — is left out on purpose: it changes the save route's contract and deserves its own
discussion. The issue stays open for it, hence `Refs` rather than `Fixes`.

## Changes

**`application/agents/tools/mcp_tool.py`**

- `DocsGPTOAuth` now passes the full endpoint URL as `server_url` instead of the origin.
  The SDK derives the RFC 8707 resource indicator from that value and
  `_validate_resource_match` requires it to sit at or *below* the `resource` published
  in the server's PRM — `check_resource_allowed(requested_resource=derived,
  configured_resource=prm_resource)`. The origin is a *parent* of a path-scoped
  resource, so it fails the check before any authorization URL exists. Token storage
  keeps using the origin, because that is how `DBTokenStorage` and `MCPAuthStatus` key
  and look up sessions.
- `get_actions_metadata` no longer treats an `inputSchema` without `properties` as a
  flat property map. `{"type": "object"}` is a valid schema for a tool that takes no
  arguments; it was being stored as a property named `type` whose definition was the
  string `"object"`. The flat-map fallback is kept for servers that do not send a JSON
  Schema, selected by whether `type` holds a string. `properties: null` and
  `required: null` now normalise to `{}` / `[]`.

**`application/api/user/tools/mcp.py`**

- `/api/mcp_server/test` keeps `task_id` in the OAuth response. `_start_oauth_task`
  returns no `auth_url` (it arrives later over SSE), and `MCPServerModal` gates the
  whole OAuth branch on `result.requires_oauth && result.task_id`. Without it the
  client fell into the `else`, storing a result that has no `message`, so the modal
  rendered an empty red banner while the worker had already started the flow. The
  failure was completely silent in the UI.

**`application/api/user/tools/routes.py`** and **`application/agents/tool_executor.py`**

- `transform_actions` and `_build_tool_parameters` skip property entries that are not
  mappings, instead of writing into them (`TypeError` → 500 on save) and reading from
  them (`AttributeError` → "Please try again later" on the next chat turn). This also
  repairs tools already stored with the malformed schema, which the first fix alone
  cannot do.

No config, dependency or deployment changes. No API contract removed: the `/test`
response gains one field the client already expects.

## Tests

11 new tests, written failing first:

- `tests/agents/test_mcp_tool.py::TestDocsGPTOAuthResourceUrl` — the provider keeps the
  endpoint path, storage stays keyed by origin, and the derived resource satisfies
  `check_resource_allowed` against path-scoped PRM.
- `tests/agents/test_mcp_tool.py::TestGetActionsMetadata` — `{"type": "object"}`,
  `properties: null`, and a regression guard for the legacy flat property map.
- `tests/api/user/test_tools_mcp_pg.py` — `task_id` passthrough on the OAuth branch.
- `tests/api/user/test_tools_routes.py::TestTransformActions` — non-mapping
  `properties` and non-mapping property definitions.
- `tests/agents/test_tool_executor.py` — non-mapping property definition and
  non-mapping parameter block.

`ruff check .` clean with the CI-pinned 0.14.10. Full suite on Python 3.12 with
PostgreSQL 16: `main` 9518 passed / 2 failed, this branch 9529 passed / 2 failed. The
two failures are `test_code_executor_tool.py` mime inference, which fails on `main` in
the same container because the base image ships no `/etc/mime.types`.

## Verification

Run against `deployment/docker-compose.yaml` with `LLM_PROVIDER=docsgpt` and no API
key, pointed at `https://mcp.grafana.com/mcp`.

Before, on `main` at 618079a4:

```
POST /api/mcp_server/test -> 200 {"requires_oauth": true, "success": false}
worker: OAuthFlowError: Protected resource https://mcp.grafana.com/mcp
        does not match expected https://mcp.grafana.com
```

After, same stack, this branch:

```
POST /api/mcp_server/test -> 200 {"requires_oauth": true, "success": false,
                                  "task_id": "9c847f7b-…"}
worker: GET  /.well-known/oauth-protected-resource/mcp   200
        GET  /.well-known/oauth-authorization-server/mcp 200
        POST /mcp/oauth/register                         201
        Processed auth_url: …/oauth/authorize?…&resource=https%3A%2F%2Fmcp.grafana.com%2Fmcp…
```

Completing the Grafana consent screen then drives the rest:

```
worker: POST /mcp/oauth/token 200 · Saved tokens for https://mcp.grafana.com
        POST /mcp 200 (initialize) · 202 (notifications) · 200 (tools/list)
        mcp_oauth_task succeeded: {'success': True, 'tools': [...]}
UI:     "Connected — found 118 tools." · "Discovered Actions (118)"
POST /api/mcp_server/save -> 200 {"message": "MCP server created successfully! Discovered 118 tools.",
                                  "tools_count": 118}
```

![Connected, 118 tools discovered](https://raw.githubusercontent.com/davikondo-isissaude/DocsGPT/pr-assets/mcp-oauth/02-connected-118-tools-fix.png)

The save call had to carry the `oauth_task_id` of the completed authorization
explicitly, because of defect 5 above: by then a token was stored, so a fresh
*Test Connection* succeeded without issuing a new `task_id`.

The tool that used to break the save is now stored correctly, and every stored action
builds cleanly for the LLM:

```
list_investigation_profiles -> {"type": "object", "required": [], "properties": {}}
_build_tool_parameters over the 118 stored actions: 118 ok, 0 failures
```

Same three steps driven directly in the container, comparing the two revisions:

| step | `main` | this branch |
| --- | --- | --- |
| `get_actions_metadata` | `properties: {'type': 'object'}` | `properties: {}` |
| `transform_actions` | `TypeError: 'str' object does not support item assignment` | OK |
| `_build_tool_parameters` | `AttributeError: 'str' object has no attribute 'get'` | OK |

The fixes also ran in a Kubernetes deployment of `arc53/docsgpt:latest`, applied at
container start.
