### PR TITLE
Fix case-sensitive PostgreSQL URI scheme matching in db_uri normalizers

### DIFF
--- a/application/core/db_uri.py
+++ b/application/core/db_uri.py
@@ -32,6 +32,10 @@ def _rewrite_uri_prefixes(v, rewrites):
     through so downstream consumers (SQLAlchemy, libpq) can produce
     their own error messages rather than us silently eating a
     misconfiguration.
+
+    URI schemes are case-insensitive (RFC 3986 §3.1), so comparison is
+    performed against the lower-cased value while the original casing of
+    the remainder of the URI is preserved.
     """
     if v is None:
         return None
@@ -41,7 +45,7 @@ def _rewrite_uri_prefixes(v, rewrites):
     if not v or v.lower() == "none":
         return None
     for prefix, target in rewrites:
-        if v.startswith(prefix):
+        if v.lower().startswith(prefix):
             return target + v[len(prefix):]
     return v
 


### PR DESCRIPTION
Fixes #2694

## Problem

`_rewrite_uri_prefixes` compared the operator-supplied URI against lowercase prefixes using a case-sensitive `startswith()`. Per RFC 3986 §3.1, URI schemes are case-insensitive, so a value such as `POSTGRESQL://user:pass@host/db` or `PostgreSQL+psycopg://...` was returned unchanged. SQLAlchemy then raised `NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:POSTGRESQL` with no hint that the issue was casing.

## Fix

Change the prefix comparison to `v.lower().startswith(prefix)`. The length slice `v[len(prefix):]` is still correct because the prefix strings and their lowercase equivalents have the same length, so the host/path/query part of the original URI is preserved verbatim.

Unknown schemes continue to pass through unchanged so downstream drivers can produce their own error messages.

## Testing

```python
from application.core.db_uri import normalize_postgres_uri, normalize_pgvector_connection_string

# Previously returned POSTGRESQL://... unchanged → SQLAlchemy NoSuchModuleError
assert normalize_postgres_uri("POSTGRESQL://user:pass@host/db") == "postgresql+psycopg://user:pass@host/db"
assert normalize_postgres_uri("PostgreSQL://user:pass@host/db") == "postgresql+psycopg://user:pass@host/db"

# Mixed-case dialect prefix
assert normalize_pgvector_connection_string("POSTGRESQL+PSYCOPG://user:pass@host/db") == "postgresql://user:pass@host/db"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - URI prefix matching is now case-insensitive.
  - Rewritten URIs preserve the original casing of the remaining URI text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->