### PR TITLE
Log a warning when STT_ENABLE_DIARIZATION is set but unsupported

### DIFF
--- a/application/stt/faster_whisper_stt.py
+++ b/application/stt/faster_whisper_stt.py
@@ -1,7 +1,10 @@
+import logging
 from pathlib import Path
 from typing import Dict, Optional
 
 from application.stt.base import BaseSTT
+
+logger = logging.getLogger(__name__)
 
 
 class FasterWhisperSTT(BaseSTT):
@@ -39,7 +42,11 @@ class FasterWhisperSTT(BaseSTT):
         timestamps: bool = False,
         diarize: bool = False,
     ) -> Dict[str, object]:
-        _ = diarize
+        if diarize:
+            logger.warning(
+                "faster-whisper STT does not support speaker diarization; "
+                "STT_ENABLE_DIARIZATION has no effect for this provider."
+            )
         model = self._get_model()
         segments_iter, info = model.transcribe(
             str(file_path),

--- a/application/stt/openai_stt.py
+++ b/application/stt/openai_stt.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -8,6 +9,8 @@ from application.stt.base import BaseSTT
 
 # Placeholder sent to OpenAI-compatible backends that require no credentials.
 NO_API_KEY = "sk-no-key"
+
+logger = logging.getLogger(__name__)
 
 
 class OpenAISTT(BaseSTT):
@@ -32,7 +35,11 @@ class OpenAISTT(BaseSTT):
         timestamps: bool = False,
         diarize: bool = False,
     ) -> Dict[str, Any]:
-        _ = diarize
+        if diarize:
+            logger.warning(
+                "OpenAI STT does not support speaker diarization; "
+                "STT_ENABLE_DIARIZATION has no effect for this provider."
+            )
         request: Dict[str, Any] = {
             "file": file_path,
             "model": self.model,


### PR DESCRIPTION
Fixes #2563

## Problem

`STT_ENABLE_DIARIZATION` is wired through the full call chain correctly, but both concrete STT providers (`OpenAISTT` and `FasterWhisperSTT`) silently discarded the flag:

```python
_ = diarize  # no-op in both providers
```

An operator who sets `STT_ENABLE_DIARIZATION=true` receives no diarization and no indication that the setting has no effect for their chosen provider.

## Fix

Replace `_ = diarize` in both providers with a conditional `logger.warning()` that fires only when `diarize=True` is passed. The message names the provider so operators know which one to address. Both providers add a module-level `logger = logging.getLogger(__name__)` following the pattern already used elsewhere in the codebase.

The fix is purely additive — no existing behaviour changes when `diarize=False` (the default).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added warnings when speaker diarization is requested with speech-to-text providers that do not support it.
  * Clarified that the diarization setting has no effect for these providers, preventing silent configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->