### PR TITLE
Make ElevenLabs voice ID and language configurable via environment variables

### DIFF
--- a/application/core/settings.py
+++ b/application/core/settings.py
@@ -270,6 +270,8 @@ class Settings(BaseSettings):
 
     TTS_PROVIDER: str = "google_tts"  # google_tts or elevenlabs
     ELEVENLABS_API_KEY: Optional[str] = None
+    ELEVENLABS_VOICE_ID: str = "nPczCjzI2devNBz1zQrb"
+    ELEVENLABS_LANGUAGE: str = "en"
     STT_PROVIDER: str = "openai"  # openai or faster_whisper
     OPENAI_STT_MODEL: str = "gpt-4o-mini-transcribe"
     STT_LANGUAGE: Optional[str] = None

--- a/application/tts/elevenlabs.py
+++ b/application/tts/elevenlabs.py
@@ -14,9 +14,8 @@ class ElevenlabsTTS(BaseTTS):
     
 
     def text_to_speech(self, text):
-        lang = "en"
         audio = self.client.text_to_speech.convert(
-            voice_id="nPczCjzI2devNBz1zQrb",             
+            voice_id=settings.ELEVENLABS_VOICE_ID,
             model_id="eleven_multilingual_v2",
             text=text,
             output_format="mp3_44100_128"
@@ -28,4 +27,4 @@ class ElevenlabsTTS(BaseTTS):
 
         # Encode to base64
         audio_base64 = base64.b64encode(audio_bytes).decode("utf-8")
-        return audio_base64, lang
+        return audio_base64, settings.ELEVENLABS_LANGUAGE


### PR DESCRIPTION
Fixes #2562

## Problem

`elevenlabs.py` hardcoded the voice ID (`nPczCjzI2devNBz1zQrb`) and always returned the synthesis language as the fixed string `"en"`. Operators who need a different voice or language had to edit source code. Every other ElevenLabs config value (`ELEVENLABS_API_KEY`) is already env-configurable, so this inconsistency was surprising.

## Changes

**`application/core/settings.py`**
- Added `ELEVENLABS_VOICE_ID: str = "nPczCjzI2devNBz1zQrb"` — existing value kept as the default, so no behaviour change for current deployments.
- Added `ELEVENLABS_LANGUAGE: str = "en"` — replaces the previously dead `lang = "en"` local variable.

**`application/tts/elevenlabs.py`**
- `voice_id` now reads `settings.ELEVENLABS_VOICE_ID` instead of the hardcoded string.
- The returned language now reads `settings.ELEVENLABS_LANGUAGE` instead of the fixed `"en"` string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options for selecting the ElevenLabs voice and language used for text-to-speech.
  * Text-to-speech now uses the configured voice and language settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->