### PR TITLE
Validate 'text' field in POST /api/attachments/tts before use

### DIFF
--- a/application/api/user/attachments/routes.py
+++ b/application/api/user/attachments/routes.py
@@ -775,8 +775,13 @@ class TextToSpeech(Resource):
     @api.expect(tts_model)
     @api.doc(description="Synthesize audio speech from text")
     def post(self):
-        data = request.get_json()
-        text = data["text"]
+        data = request.get_json(silent=True) or {}
+        text = data.get("text", "")
+        if not isinstance(text, str) or not text.strip():
+            return make_response(
+                jsonify({"success": False, "message": "Field 'text' must be a non-empty string"}),
+                400,
+            )
         try:
             tts_instance = TTSCreator.create_tts(settings.TTS_PROVIDER)
             audio_base64, detected_language = tts_instance.text_to_speech(text)


### PR DESCRIPTION
Fixes #2627

## Problem

`TextToSpeech.post()` called `request.get_json()` and then immediately indexed `data["text"]` without checking whether the body was valid JSON or whether the key existed. A request with an empty body or a body that omits `"text"` raised a `KeyError` (or `TypeError` for a `None` body) which the surrounding `except Exception` clause caught and returned as `{"success": false}` with HTTP 400 and no message — leaving the caller with no indication of what went wrong.

## Fix

- Use `request.get_json(silent=True) or {}` so a missing or malformed body yields an empty dict instead of `None`.
- Use `data.get("text", "")` to avoid `KeyError`.
- Explicitly validate that `text` is a non-empty string and return a 400 with `{"success": false, "message": "Field 'text' must be a non-empty string"}` before reaching the TTS provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `/tts` request validation for missing or malformed JSON.
  * Requests with missing or invalid text now return a clear 400 error instead of causing a server error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->