### PR TITLE
Validate request body in POST /api/user/attachments/tts

### DIFF
--- a/application/api/user/attachments/routes.py
+++ b/application/api/user/attachments/routes.py
@@ -775,8 +775,18 @@ class TextToSpeech(Resource):
     @api.expect(tts_model)
     @api.doc(description="Synthesize audio speech from text")
     def post(self):
-        data = request.get_json()
-        text = data["text"]
+        data = request.get_json(silent=True) or {}
+        text = data.get("text")
+        if not text or not isinstance(text, str):
+            return make_response(
+                jsonify(
+                    {
+                        "success": False,
+                        "message": "Field 'text' must be a non-empty string",
+                    }
+                ),
+                400,
+            )
         try:
             tts_instance = TTSCreator.create_tts(settings.TTS_PROVIDER)
             audio_base64, detected_language = tts_instance.text_to_speech(text)


### PR DESCRIPTION
Fixes #2627

## Problem

The `TextToSpeech.post()` handler called `request.get_json()` and then immediately accessed `data["text"]` without any null check. Sending an empty body, wrong `Content-Type`, or a payload without the `text` key produced an unhandled exception that Flask caught and returned as a bare `{"success": false}` 400 — no message, no indication of what was wrong.

## Fix

- Use `request.get_json(silent=True) or {}` so a missing body or non-JSON content-type never returns `None`.
- Validate that `text` is a non-empty string before passing it to the TTS provider.
- Return `{"success": false, "message": "Field 'text' must be a non-empty string"}` with HTTP 400 for invalid input, consistent with the validation style used elsewhere in the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved text-to-speech request validation.
  - Missing or invalid text now returns a clear 400 validation response instead of causing an error.
  - Valid text-to-speech requests continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->