### PR TITLE
Validate text field in POST /api/user/attachments/tts

### DIFF
--- a/application/api/user/attachments/routes.py
+++ b/application/api/user/attachments/routes.py
@@ -775,8 +775,13 @@ class TextToSpeech(Resource):
     @api.expect(tts_model)
     @api.doc(description="Synthesize audio speech from text")
     def post(self):
-        data = request.get_json()
-        text = data["text"]
+        data = request.get_json(silent=True) or {}
+        text = data.get("text")
+        if not isinstance(text, str) or not text.strip():
+            return make_response(
+                jsonify({"success": False, "message": "Field 'text' must be a non-empty string"}),
+                400,
+            )
         try:
             tts_instance = TTSCreator.create_tts(settings.TTS_PROVIDER)
             audio_base64, detected_language = tts_instance.text_to_speech(text)


### PR DESCRIPTION
Fixes #2627

## Problem

`POST /api/user/attachments/tts` called `request.get_json()` and immediately subscripted the result:

```python
data = request.get_json()
text = data["text"]
```

Two failure modes:
1. If the request body is missing or `Content-Type` is not `application/json`, `get_json()` returns `None`, so `data["text"]` raises `TypeError`.
2. If the body is valid JSON but the `"text"` key is absent (e.g. `{}`), it raises `KeyError`.

Both exceptions were silently caught by the outer `except` block and returned as `{"success": false}` with no message, while the `KeyError` was also logged as an unhandled server error.

## Fix

- Use `request.get_json(silent=True) or {}` so a missing or malformed body returns an empty dict rather than `None`.
- Check that `text` is a non-empty string before calling the TTS provider; return a 400 with `{"success": false, "message": "Field 'text' must be a non-empty string"}` if it is not.

The rest of the endpoint logic is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text-to-speech request validation.
  * Invalid, missing, or malformed text input now returns a structured 400 error instead of causing a server failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->