### PR TITLE
Add HMAC-SHA256 integrity check to credential encryption

### DIFF
--- a/application/security/encryption.py
+++ b/application/security/encryption.py
@@ -1,4 +1,6 @@
 import base64
+import hashlib
+import hmac
 import json
 import logging
 import os
@@ -12,12 +14,15 @@ from application.core.settings import settings
 
 logger = logging.getLogger(__name__)
 
+# Version tag prepended to newly-encrypted blobs.
+# v1 blobs (no tag) remain decryptable for backward compatibility.
+_V2_TAG = b"\x02"
+
 
 def _derive_key(user_id: str, salt: bytes) -> bytes:
+    """Derive a 32-byte AES key (v1 legacy path)."""
     app_secret = settings.ENCRYPTION_SECRET_KEY
-
     password = f"{app_secret}#{user_id}".encode()
-
     kdf = PBKDF2HMAC(
         algorithm=hashes.SHA256(),
         length=32,
@@ -25,8 +30,22 @@ def _derive_key(user_id: str, salt: bytes) -> bytes:
         iterations=100000,
         backend=default_backend(),
     )
-
     return kdf.derive(password)
+
+
+def _derive_keys(user_id: str, salt: bytes) -> tuple:
+    """Derive separate 32-byte AES and HMAC keys (v2 path)."""
+    app_secret = settings.ENCRYPTION_SECRET_KEY
+    password = f"{app_secret}#{user_id}".encode()
+    kdf = PBKDF2HMAC(
+        algorithm=hashes.SHA256(),
+        length=64,
+        salt=salt,
+        iterations=100000,
+        backend=default_backend(),
+    )
+    material = kdf.derive(password)
+    return material[:32], material[32:]
 
 
 def encrypt_credentials(credentials: dict, user_id: str) -> str:
@@ -35,17 +54,18 @@ def encrypt_credentials(credentials: dict, user_id: str) -> str:
     try:
         salt = os.urandom(16)
         iv = os.urandom(16)
-        key = _derive_key(user_id, salt)
+        enc_key, mac_key = _derive_keys(user_id, salt)
 
         json_str = json.dumps(credentials)
-
-        cipher = Cipher(algorithms.AES(key), modes.CBC(iv), backend=default_backend())
+        cipher = Cipher(algorithms.AES(enc_key), modes.CBC(iv), backend=default_backend())
         encryptor = cipher.encryptor()
-
         padded_data = _pad_data(json_str.encode())
         encrypted_data = encryptor.update(padded_data) + encryptor.finalize()
 
-        result = salt + iv + encrypted_data
+        mac_input = salt + iv + encrypted_data
+        tag = hmac.new(mac_key, mac_input, digestmod=hashlib.sha256).digest()
+
+        result = _V2_TAG + salt + iv + tag + encrypted_data
         return base64.b64encode(result).decode()
     except Exception as e:
         logger.warning(f"Failed to encrypt credentials: {e}")
@@ -57,23 +77,46 @@ def decrypt_credentials(encrypted_data: str, user_id: str) -> dict:
         return {}
     try:
         data = base64.b64decode(encrypted_data.encode())
-
-        salt = data[:16]
-        iv = data[16:32]
-        encrypted_content = data[32:]
-
-        key = _derive_key(user_id, salt)
-
-        cipher = Cipher(algorithms.AES(key), modes.CBC(iv), backend=default_backend())
-        decryptor = cipher.decryptor()
-
-        decrypted_padded = decryptor.update(encrypted_content) + decryptor.finalize()
-        decrypted_data = _unpad_data(decrypted_padded)
-
-        return json.loads(decrypted_data.decode())
+        if data[:1] == _V2_TAG:
+            return _decrypt_v2(data[1:], user_id)
+        return _decrypt_v1(data, user_id)
     except Exception as e:
         logger.warning(f"Failed to decrypt credentials: {e}")
         return {}
+
+
+def _decrypt_v2(data: bytes, user_id: str) -> dict:
+    """Decrypt a v2 blob (AES-CBC + HMAC-SHA256)."""
+    salt = data[:16]
+    iv = data[16:32]
+    stored_tag = data[32:64]
+    encrypted_content = data[64:]
+
+    enc_key, mac_key = _derive_keys(user_id, salt)
+
+    expected_tag = hmac.new(
+        mac_key, salt + iv + encrypted_content, digestmod=hashlib.sha256
+    ).digest()
+    if not hmac.compare_digest(stored_tag, expected_tag):
+        raise ValueError("HMAC verification failed: credential data may be tampered")
+
+    cipher = Cipher(algorithms.AES(enc_key), modes.CBC(iv), backend=default_backend())
+    decryptor = cipher.decryptor()
+    decrypted_padded = decryptor.update(encrypted_content) + decryptor.finalize()
+    return json.loads(_unpad_data(decrypted_padded).decode())
+
+
+def _decrypt_v1(data: bytes, user_id: str) -> dict:
+    """Decrypt a legacy v1 blob (AES-CBC, no HMAC)."""
+    salt = data[:16]
+    iv = data[16:32]
+    encrypted_content = data[32:]
+
+    key = _derive_key(user_id, salt)
+    cipher = Cipher(algorithms.AES(key), modes.CBC(iv), backend=default_backend())
+    decryptor = cipher.decryptor()
+    decrypted_padded = decryptor.update(encrypted_content) + decryptor.finalize()
+    return json.loads(_unpad_data(decrypted_padded).decode())
 
 
 def _pad_data(data: bytes) -> bytes:


### PR DESCRIPTION
Fixes #2503

## Problem

`application/security/encryption.py` encrypts stored credentials with AES-256-CBC but does not authenticate the ciphertext. This means:

- An attacker who can write to the credential store can flip bits in the ciphertext and the decryptor will silently return garbage or a controlled plaintext (padding oracle / bit-flip).
- There is no way to distinguish corruption from tampering.

## Fix

Implement **encrypt-then-MAC** using HMAC-SHA256:

1. Derive two independent 32-byte keys from the same PBKDF2 call (length 64): `enc_key` for AES and `mac_key` for HMAC.
2. Compute `HMAC-SHA256(mac_key, salt || iv || ciphertext)` after encryption.
3. Store as `\x02 || salt || iv || hmac_tag || ciphertext` — the `\x02` version byte distinguishes new blobs from old ones.
4. On decrypt, verify the HMAC with `hmac.compare_digest` (constant-time) before touching the ciphertext; raise if it fails.

## Backward compatibility

Blobs without the version byte are still decrypted via the original v1 path, so existing stored credentials continue to work. New credentials written after this change will use the authenticated v2 format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated encryption to use versioned, integrity-protected data with separate encryption and authentication keys.
  * Added verification to detect tampering before decryption.
  * Preserved compatibility with existing encrypted data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->