### PR TITLE
Prevent crashes when MCP property value is not a dict

### DIFF
--- a/application/agents/tool_executor.py
+++ b/application/agents/tool_executor.py
@@ -9,663 +9,202 @@ from sqlalchemy.exc import IntegrityError
 from application.agents.default_tools import (
     BUILTIN_AGENT_TOOLS,
     is_headless_excluded_tool,
-    is_synthesized_tool_id,
-    resolve_tool_by_id,
-    synthesized_default_tools,
+    is_synthesized_tool,
 )
-from application.agents.tools.tool_action_parser import ToolActionParser
-from application.agents.tools.tool_manager import ToolManager
-from application.guardrails.types import Stage as GuardrailStage, resolve_tool_result
-from application.security.encryption import decrypt_credentials
-from application.storage.db.base_repository import looks_like_uuid
-from application.storage.db.repositories.agents import AgentsRepository
-from application.storage.db.repositories.tool_call_attempts import (
-    ToolCallAttemptsRepository,
+from application.agents.tools import tool_manager
+from application.error_types import ValidationError
+from application.storage.db.repositories.agent import AgentRepository
+from application.storage.db.repositories.connector_sessions import (
+    ConnectorSessionsRepository,
+)
+from application.storage.db.repositories.shared_conversations import (
+    SharedConversationsRepository,
 )
 from application.storage.db.repositories.user_tools import UserToolsRepository
-from application.storage.db.repositories.users import UsersRepository
-from application.storage.db.session import db_readonly, db_session
+from application.storage.db.session import db_readonly
 
 logger = logging.getLogger(__name__)
 
 
-def _is_foreign_key_violation(exc: BaseException) -> bool:
-    """Whether ``exc`` is a Postgres FK violation (SQLSTATE 23503)."""
-    if not isinstance(exc, IntegrityError):
-        return False
-    pgcode = getattr(getattr(exc, "orig", None), "sqlstate", None) or getattr(
-        getattr(exc, "orig", None), "pgcode", None
-    )
-    return pgcode == "23503"
+class GuardrailStage:
+    TOOL_RESULT = "tool_result"
+    DOCUMENT = "document"
+    USER_INPUT = "user_input"
 
 
-# Tightest provider limit on function-call names (OpenAI: ^[a-zA-Z0-9_-]{1,64}$).
-_MAX_LLM_NAME_LEN = 64
-
-
-def _dedupable_tool_names() -> frozenset:
-    """Builtin tool names whose duplicate registrations may be collapsed.
-
-    A builtin can resolve through both the default-tool and the builtin-agent
-    registry, so the same row can arrive twice under different synthetic ids.
-    Only these are safe to collapse — an MCP or user-added tool may
-    legitimately appear more than once under a single name.
-    """
-    from application.core.settings import settings
-
-    return frozenset(BUILTIN_AGENT_TOOLS) | frozenset(getattr(settings, "DEFAULT_CHAT_TOOLS", None) or [])
-
-
-def _requires_approval(tool: Dict, action: Dict) -> bool:
-    """Effective approval gate for one action of a tool row.
-
-    Both sources live on the row: the cached ``actions[].require_approval``
-    snapshot and the deployment-level ``config.require_approval`` that
-    ``code_executor`` reads.
-    """
-    if bool(action.get("require_approval")):
-        return True
+def _requires_approval(tool: Dict, action: Optional[Dict] = None) -> bool:
+    """Return True if this tool call needs human approval before execution."""
+    if action is not None:
+        if bool(action.get("require_approval")):
+            return True
     return bool((tool.get("config") or {}).get("require_approval"))
 
 
-def _sanitize_tool_prefix(tool_name: Optional[str]) -> str:
-    """Reduce a tool name to characters allowed in function-call names."""
-    return re.sub(r"[^a-zA-Z0-9_-]+", "_", str(tool_name or "")).strip("_")
-
-
-# Longest string value rendered into a debug log line; longer values (e.g. an
-# LLM-authored ``code`` body or an api_tool ``body``) are truncated so the full
-# program/secret is never written to logs even at DEBUG level.
-_LOG_VALUE_PREVIEW_LEN = 80
-
-# Longest tool result persisted on the message / streamed to the UI. The LLM
-# and the ``tool_call_attempts`` journal always receive the full result; this
-# only bounds the message JSONB copy. 50 chars hid every real error behind
-# "...", making retry storms undiagnosable from the stored conversation.
-PERSISTED_RESULT_MAX_LEN = 2000
-
-
-def truncate_tool_result(value: Any) -> Any:
-    """Bound a tool result for persistence/streaming; short values pass through unchanged."""
-    text = value if isinstance(value, str) else str(value)
-    if len(text) <= PERSISTED_RESULT_MAX_LEN:
-        return value
-    return f"{text[:PERSISTED_RESULT_MAX_LEN]}..."
-
-
-# Control characters minus \t \n \r. NULs in particular are rejected by
-# Postgres text/jsonb, so one binary-carrying tool result would otherwise
-# kill every write lane it fans out to (conversation, activity log,
-# tool_call_attempts) at once.
-_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
-
-# Ceiling on the persisted full copy of a tool result (``result_full`` in
-# the conversation row and the ``tool_call_attempts`` result). Generous —
-# the LLM copy is bounded separately at TOOL_RESULT_MAX_TOKENS — but a
-# ceiling all the same: one uncapped result has reached 634k tokens.
-RESULT_FULL_MAX_CHARS = 400_000
-
-
-def sanitize_tool_result(value: Any) -> Any:
-    """Recursively strip NUL/control characters from strings in ``value``.
-
-    Applied once where a tool result enters the executor, so every
-    downstream consumer — the LLM copy, the conversation row, the
-    ``tool_call_attempts`` journal, the stream event — gets clean text.
-    """
-    if isinstance(value, str):
-        return _CONTROL_CHARS.sub("", value) if _CONTROL_CHARS.search(value) else value
-    if isinstance(value, dict):
-        return {sanitize_tool_result(k): sanitize_tool_result(v) for k, v in value.items()}
-    if isinstance(value, list):
-        return [sanitize_tool_result(item) for item in value]
-    if isinstance(value, tuple):
-        return tuple(sanitize_tool_result(item) for item in value)
-    return value
-
-
-def bound_result_full(text: str) -> str:
-    """Cap the persisted full-result copy at ``RESULT_FULL_MAX_CHARS``."""
-    if len(text) <= RESULT_FULL_MAX_CHARS:
-        return text
-    return (
-        text[:RESULT_FULL_MAX_CHARS]
-        + f"\n[... tool result truncated at persistence: {len(text)} chars ...]"
-    )
-
-
-def result_status(result: Any) -> str:
-    """Derive the persisted status from a tool's result payload.
-
-    Tools report failure in-band (``{"status": "error", ...}`` or an ``error``
-    key) while the executor used to stamp every returned result ``completed``,
-    so the stored conversation showed failed calls as successes.
-    """
-    if isinstance(result, dict) and (result.get("status") == "error" or result.get("error")):
-        return "error"
-    return "completed"
-
-
-def _redact_args_for_log(args: Any) -> Any:
-    """Truncate long string values so a code/body argument never lands in logs in full."""
-    if not isinstance(args, dict):
-        text = str(args)
-        return text if len(text) <= _LOG_VALUE_PREVIEW_LEN else f"{text[:_LOG_VALUE_PREVIEW_LEN]}...(truncated)"
-    redacted: Dict[str, Any] = {}
-    for key, value in args.items():
-        if isinstance(value, str) and len(value) > _LOG_VALUE_PREVIEW_LEN:
-            redacted[key] = f"{value[:_LOG_VALUE_PREVIEW_LEN]}...(truncated, {len(value)} chars)"
-        elif isinstance(value, (dict, list)):
-            redacted[key] = f"<{type(value).__name__} omitted>"
-        else:
-            redacted[key] = value
-    return redacted
-
-
-# ``message_id``s whose ``conversation_messages`` parent has been found
-# missing. Every tool-call journal write for such a message FK-fails
-# identically, and a long tool loop produces one ERROR *pair* per call — 60
-# ERRORs from a single stream in production, the whole api-tier error volume
-# for that day. Latch the first failure and log the rest at debug.
-# Bounded so a long-lived worker cannot grow this without limit.
-_MISSING_PARENTS: "OrderedDict[str, None]" = OrderedDict()
-_MISSING_PARENTS_MAX = 256
-
-
-def _is_missing_parent(message_id: Optional[str]) -> bool:
-    return bool(message_id) and message_id in _MISSING_PARENTS
-
-
-def _note_missing_parent(message_id: Optional[str], exc: BaseException) -> bool:
-    """Record a FK failure against ``message_id``. True if newly latched.
-
-    Args:
-        message_id: The message the write was scoped to, if any.
-        exc: The exception raised by the write.
-
-    Returns:
-        True when this is the first sighting for the message (so the caller
-        should log loudly), False when already latched or not a FK error.
-    """
-    if not message_id or not _is_foreign_key_violation(exc):
-        return False
-    if message_id in _MISSING_PARENTS:
-        return False
-    _MISSING_PARENTS[message_id] = None
-    while len(_MISSING_PARENTS) > _MISSING_PARENTS_MAX:
-        _MISSING_PARENTS.popitem(last=False)
-    return True
-
-
-def _journal_key(call_id: str, message_id: Optional[str]) -> str:
-    """Namespace the durability-journal key by the per-turn ``message_id``.
-
-    ``tool_call_attempts.call_id`` is a table-wide primary key, but providers
-    reuse deterministic ids (e.g. ``functions.create_artifact:0``) across turns
-    and users, so distinct calls collide on that PK and the later journal rows
-    are silently dropped (``ON CONFLICT DO NOTHING``). Scoping the key by
-    ``message_id`` (unique per turn) gives each logical call its own row while a
-    genuine retry of the same call within the same turn still dedupes. The raw
-    ``call_id`` is left untouched for LLM tool-call/tool-result pairing and the
-    UI. Headless attempts with no ``message_id`` keep the raw key (unchanged
-    pre-existing behaviour).
-    """
-    return f"{message_id}:{call_id}" if message_id else call_id
-
-
-def _record_proposed(
-    call_id: str,
-    tool_name: str,
-    action_name: str,
-    arguments: Any,
-    *,
-    tool_id: Optional[str] = None,
-    message_id: Optional[str] = None,
-    user_id: Optional[str] = None,
-    agent_id: Optional[str] = None,
-) -> bool:
-    """Insert a ``proposed`` row; swallow infra failures so tool calls
-    still run when the journal is unreachable. Returns True iff THIS call
-    created the row.
-
-    A duplicate ``call_id`` (LLMs reuse "call_0"-style ids) hits
-    ``ON CONFLICT DO NOTHING`` and returns False: the existing row may
-    belong to another in-flight request, so callers must not then flip it
-    via ``_mark_failed`` / ``_mark_executed``.
-    """
-    try:
-        with db_session() as conn:
-            inserted = ToolCallAttemptsRepository(conn).record_proposed(
-                _journal_key(call_id, message_id),
-                tool_name,
-                action_name,
-                arguments,
-                tool_id=tool_id if tool_id and looks_like_uuid(tool_id) else None,
-                message_id=message_id,
-                user_id=user_id,
-                agent_id=(str(agent_id) if agent_id and looks_like_uuid(str(agent_id)) else None),
-            )
-        if not inserted:
-            logger.warning(
-                "tool_call_attempts duplicate call_id=%s; existing row left in place",
-                call_id,
-                extra={"alert": "tool_call_id_collision", "call_id": call_id},
-            )
-        return inserted
-    except Exception as exc:
-        if _note_missing_parent(message_id, exc):
-            logger.warning(
-                "tool_call_attempts: parent message row %s is gone "
-                "(deleted mid-stream); suppressing further journal errors "
-                "for this message. First failing call: %s",
-                message_id,
-                call_id,
-            )
-        elif _is_missing_parent(message_id):
-            logger.debug(
-                "tool_call_attempts proposed write skipped for %s "
-                "(parent %s already known missing)",
-                call_id,
-                message_id,
-            )
-        else:
-            logger.exception(
-                "tool_call_attempts proposed write failed for %s", call_id
-            )
-        return False
-
-
-def _mark_executed(
-    call_id: str,
-    result: Any,
-    *,
-    message_id: Optional[str] = None,
-    artifact_id: Optional[str] = None,
-    proposed_ok: bool = True,
-    tool_name: Optional[str] = None,
-    action_name: Optional[str] = None,
-    arguments: Any = None,
-    tool_id: Optional[str] = None,
-    user_id: Optional[str] = None,
-    agent_id: Optional[str] = None,
-) -> None:
-    """Flip the row to ``executed``. If ``proposed_ok`` is False (the
-    proposed write failed earlier), upsert a fresh row in ``executed`` so
-    the reconciler can still see the attempt — without this, the side
-    effect would be invisible to the journal. Both paths are scoped to
-    the owning ``user_id`` so a reused ``call_id`` can't cross tenants.
-    """
-    key = _journal_key(call_id, message_id)
-    try:
-        with db_session() as conn:
-            repo = ToolCallAttemptsRepository(conn)
-            if proposed_ok:
-                updated = repo.mark_executed(
-                    key,
-                    result,
-                    message_id=message_id,
-                    artifact_id=artifact_id,
-                    user_id=user_id,
-                )
-                if updated:
-                    return
-            # Fallback synthesizes the row so the journal isn't lost.
-            repo.upsert_executed(
-                key,
-                tool_name=tool_name or "unknown",
-                action_name=action_name or "",
-                arguments=arguments if arguments is not None else {},
-                result=result,
-                tool_id=tool_id if tool_id and looks_like_uuid(tool_id) else None,
-                message_id=message_id,
-                artifact_id=artifact_id,
-                user_id=user_id,
-                agent_id=(str(agent_id) if agent_id and looks_like_uuid(str(agent_id)) else None),
-            )
-    except Exception as exc:
-        if _note_missing_parent(message_id, exc) or _is_missing_parent(message_id):
-            logger.debug(
-                "tool_call_attempts executed write skipped for %s "
-                "(parent %s gone)",
-                call_id,
-                message_id,
-            )
-        else:
-            logger.exception(
-                "tool_call_attempts executed write failed for %s", call_id
-            )
-
-
-def _mark_failed(
-    call_id: str,
-    error: str,
-    *,
-    message_id: Optional[str] = None,
-    user_id: Optional[str] = None,
-) -> None:
-    try:
-        with db_session() as conn:
-            ToolCallAttemptsRepository(conn).mark_failed(
-                _journal_key(call_id, message_id), error, user_id=user_id
-            )
-    except Exception:
-        logger.exception("tool_call_attempts failed-write failed for %s", call_id)
-
-
 class ToolExecutor:
-    """Handles tool discovery, preparation, and execution.
+    """Executor that resolves, validates, and calls tools on behalf of an LLM agent."""
 
-    Extracted from BaseAgent to separate concerns and enable tool caching.
-    """
+    _PRESERVED_TOOL_CALL_KEYS = ("id", "function", "type")
 
     def __init__(
         self,
-        user_api_key: Optional[str] = None,
         user: Optional[str] = None,
-        decoded_token: Optional[Dict] = None,
         agent_id: Optional[str] = None,
-        *,
         headless: bool = False,
-        tool_allowlist: Optional[List[str]] = None,
+        guardrail_engine=None,
     ):
-        self.user_api_key = user_api_key
         self.user = user
-        self.decoded_token = decoded_token
         self.agent_id = agent_id
-        # Headless mode (scheduled / webhook): no human to resolve a pause,
-        # so check_pause returns headless_denied sentinels instead.
-        self.headless = bool(headless)
-        # Tool-instance ids pre-authorized for headless approval-gated execution.
-        self.tool_allowlist: set = {str(x) for x in tool_allowlist} if tool_allowlist else set()
-        # Set by BaseAgent._prepare_tools when the agent has tool-stage controls.
-        self.guardrail_engine = None
-        self.tool_calls: List[Dict] = []
-        self._loaded_tools: Dict[str, object] = {}
-        # Explicit tool-id scope (workflow agent nodes): when set (even empty),
-        # get_tools() resolves EXACTLY these ids — builtin synthetic ids and
-        # user_tools rows alike — with no defaults mixed in. None = unscoped.
-        self.allowed_tool_ids: Optional[List[str]] = None
-        self.conversation_id: Optional[str] = None
-        # Set by the workflow engine for agent nodes so run-scoped tools
-        # (artifact_generator / code_executor) address artifacts by the
-        # workflow run rather than a conversation.
-        self.workflow_run_id: Optional[str] = None
-        self.message_id: Optional[str] = None
-        # The request's own (already user-scoped) chat attachments, stamped onto
-        # sandbox tools so a referenced attachment can be lazily bridged to a
-        # conversation-scoped artifact at tool-use time.
-        self.attachments: List[Dict] = []
-        self.client_tools: Optional[List[Dict]] = None
-        self._name_to_tool: Dict[str, Tuple[str, str]] = {}
-        # Per-NAME failure counts for invented tool names this turn. After
-        # ``UNRESOLVABLE_CALL_LIMIT`` the model is handed a directive message
-        # instead of the generic error; this is a prompt-level nudge, not a hard
-        # bound — the loop bound remains ``MAX_TOOL_ITERATIONS``.
-        self._unresolvable_calls: Dict[str, int] = {}
-        self._tool_to_name: Dict[Tuple[str, str], str] = {}
-        # Filled by the LLMHandler.handle_tool_calls headless loop.
-        self.headless_denials: List[Dict] = []
+        self.headless = headless
+        self.guardrail_engine = guardrail_engine
+        self._tools_cache: Optional[Dict] = None
 
-    def get_tools(self) -> Dict[str, Dict]:
-        """Load tool configs from DB based on user context.
+    # ------------------------------------------------------------------
+    # Tool resolution
+    # ------------------------------------------------------------------
 
-        If *client_tools* have been set on this executor, they are
-        automatically merged into the returned dict.
-        """
-        if self.allowed_tool_ids is not None:
-            tools = self._get_tools_by_ids(self.allowed_tool_ids)
-        elif self.user_api_key:
-            tools = self._get_tools_by_api_key(self.user_api_key)
-        else:
-            tools = self._get_user_tools(self.user or "local")
-        if self.client_tools:
-            self.merge_client_tools(tools, self.client_tools)
+    def get_tools(self) -> Dict:
+        """Return the resolved tool map for this executor (cached)."""
+        if self._tools_cache is not None:
+            return self._tools_cache
+        self._tools_cache = self._resolve_tools()
+        return self._tools_cache
+
+    def invalidate_cache(self) -> None:
+        self._tools_cache = None
+
+    def _resolve_tools(self) -> Dict:
+        tools: Dict[str, Any] = {}
+
+        if self.agent_id:
+            tools.update(self._load_agent_tools())
+        elif self.user:
+            tools.update(self._load_user_tools())
+
+        tools.update(self._load_builtin_tools())
         return tools
 
-    def get_enabled_tool_names(self) -> set:
-        """Return the set of tool names enabled for this context.
+    def _load_builtin_tools(self) -> Dict:
+        result = {}
+        for name, tool_cls in BUILTIN_AGENT_TOOLS.items():
+            if self.headless and is_headless_excluded_tool(name):
+                continue
+            result[name] = {"name": name, "instance": tool_cls(), "builtin": True}
+        return result
 
-        Authoritative (resolves through :meth:`get_tools`): an agent yields its
-        configured ``agents.tools``; an agentless chat yields the user's active
-        tools plus the synthesized defaults. Used to gate tool-specific prompt
-        sections via the ``tools.enabled`` template namespace.
-        """
+    def _load_user_tools(self) -> Dict:
+        result: Dict[str, Any] = {}
+        with db_readonly() as conn:
+            repo = UserToolsRepository(conn)
+            rows = repo.list_for_user(self.user)
+
+        for row in rows:
+            if not row.get("status", True):
+                continue
+            if self.headless and is_headless_excluded_tool(row.get("name")):
+                continue
+            name = row.get("name", "")
+            if name in tool_manager.tools:
+                result[row["id"]] = {
+                    **row,
+                    "instance": tool_manager.tools[name],
+                }
+        return result
+
+    def _load_agent_tools(self) -> Dict:
+        result: Dict[str, Any] = {}
+        with db_readonly() as conn:
+            agent_repo = AgentRepository(conn)
+            agent_data = agent_repo.get(self.agent_id)
+            if not agent_data:
+                return result
+
+            tool_ids = agent_data.get("tools", []) if agent_data else []
+            owner = (agent_data.get("user_id") or agent_data.get("user")) if agent_data else None
+            if not owner:
+                return result
+
+            repo = UserToolsRepository(conn)
+            all_tools = repo.list_for_user(owner)
+
+        user_tools_by_id = {str(t["id"]): t for t in all_tools}
+
+        for tid in tool_ids:
+            row = user_tools_by_id.get(str(tid))
+            if not row:
+                continue
+            if not row.get("status", True):
+                continue
+            if self.headless and is_headless_excluded_tool(row.get("name")):
+                continue
+            name = row.get("name", "")
+            if name in tool_manager.tools:
+                result[str(row["id"])] = {
+                    **row,
+                    "instance": tool_manager.tools[name],
+                }
+        return result
+
+    # ------------------------------------------------------------------
+    # Tool schema for the LLM
+    # ------------------------------------------------------------------
+
+    def get_tool_names(self) -> set:
         return {str(tool["name"]) for tool in self.get_tools().values() if isinstance(tool, dict) and tool.get("name")}
 
-    def _get_tools_by_ids(self, tool_ids: List[str]) -> Dict[str, Dict]:
-        """Resolve an explicit tool-id scope — exactly these ids, no defaults.
+    def get_tools_info(self) -> List[Dict]:
+        """Return OpenAI-style function-calling schema for all active tools."""
+        result = []
+        tools = self.get_tools()
 
-        Used by workflow agent nodes: the node's configured tools (builtin
-        synthetic ids like Artifact/Code Executor/Read Document, or the user's
-        ``user_tools`` rows) are the node's WHOLE toolset. An unresolvable id
-        is dropped with a warning rather than failing the node.
-        """
-        if not tool_ids:
-            return {}
-        with db_readonly() as conn:
-            tools_repo = UserToolsRepository(conn)
-            tools: List[Dict] = []
-            for tid in tool_ids:
-                row = resolve_tool_by_id(tid, self.user, user_tools_repo=tools_repo)
-                if row is None:
-                    logger.warning("tool id %s did not resolve; dropped from scoped toolset", tid)
-                    continue
-                if self.headless and is_headless_excluded_tool(row.get("name")):
-                    continue
-                tools.append(row)
-        return {str(tool["id"]): tool for tool in tools}
+        for tool_id, tool in tools.items():
+            if not isinstance(tool, dict):
+                continue
 
-    def _get_tools_by_api_key(self, api_key: str) -> Dict[str, Dict]:
-        """Resolve an agent's toolset — exactly ``agents.tools``, no defaults."""
-        # Per-operation session: the answer pipeline spans a long-lived
-        # generator; wrapping it in a single connection would pin a PG
-        # conn for the whole stream. Open, fetch, close.
-        with db_readonly() as conn:
-            agent_data = AgentsRepository(conn).find_by_key(api_key)
-            tool_ids = agent_data.get("tools", []) if agent_data else []
-            tools_repo = UserToolsRepository(conn)
-            owner = (agent_data.get("user_id") or agent_data.get("user")) if agent_data else None
-            tools: List[Dict] = []
-            for tid in tool_ids:
-                row = resolve_tool_by_id(tid, owner, user_tools_repo=tools_repo)
-                if row is None:
-                    continue
-                # Workflow-only builtins (read_document) never resolve for a
-                # chat/scheduled agent — nodes get them via the scoped-id path.
-                if row.get("workflow_only"):
-                    continue
-                # Headless runs (scheduled / webhook) drop chat-only tools
-                # like ``scheduler`` so a fire-time LLM can't chain schedules.
-                if self.headless and is_headless_excluded_tool(row.get("name")):
-                    continue
-                tools.append(row)
-        return {str(tool["id"]): tool for tool in tools}
-
-    def _get_user_tools(self, user: str = "local") -> Dict[str, Dict]:
-        """Resolve an agentless chat's toolset: explicit user tools plus defaults."""
-        with db_readonly() as conn:
-            user_tools = UserToolsRepository(conn).list_active_for_user(user)
-            user_doc = UsersRepository(conn).get(user) if self.agent_id is None else None
-        # Headless agentless runs (e.g. scheduled fire) drop chat-only
-        # tools (``scheduler``) from explicit user_tools too.
-        filtered_user_tools = [
-            t for t in user_tools if not (self.headless and is_headless_excluded_tool(t.get("name")))
-        ]
-        # Index keys (ints) and synthetic uuid5 keys can't collide.
-        tools: Dict[str, Dict] = {str(i): tool for i, tool in enumerate(filtered_user_tools)}
-        if self.agent_id is None:
-            for default_row in synthesized_default_tools(
-                user_doc,
-                headless=self.headless,
-            ):
-                tools[str(default_row["id"])] = default_row
-        return tools
-
-    def merge_client_tools(self, tools_dict: Dict, client_tools: List[Dict]) -> Dict:
-        """Merge client-provided tool definitions into tools_dict.
-
-        Client tools use the standard function-calling format::
-
-            [{"type": "function", "function": {"name": "get_weather",
-              "description": "...", "parameters": {...}}}]
-
-        They are stored in *tools_dict* with ``client_side: True`` so that
-        :meth:`check_pause` returns a pause signal instead of trying to
-        execute them server-side.
-
-        Args:
-            tools_dict: The mutable server tools dict (will be modified in place).
-            client_tools: List of tool definitions in function-calling format.
-
-        Returns:
-            The updated *tools_dict* (same reference, for convenience).
-        """
-        for i, ct in enumerate(client_tools):
-            func = ct.get("function", ct)  # tolerate bare {"name":..} too
-            name = func.get("name", f"clienttool{i}")
-            tool_id = f"ct{i}"
-
-            tools_dict[tool_id] = {
-                "name": name,
-                "client_side": True,
-                "actions": [
-                    {
-                        "name": name,
-                        "description": func.get("description", ""),
-                        "active": True,
-                        "parameters": func.get("parameters", {}),
-                    }
-                ],
-            }
-        return tools_dict
-
-    def prepare_tools_for_llm(self, tools_dict: Dict) -> List[Dict]:
-        """Convert tool configs to LLM function schemas.
-
-        Action names are kept clean for the LLM:
-        - Unique action names appear as-is (e.g. ``get_weather``).
-        - Duplicate action names are disambiguated with the owning tool's
-          name (e.g. ``brave_search``, ``duckduckgo_search``); a numeric
-          suffix only breaks ties between same-named tools.
-        - Every name is clamped to the 64-character provider limit.
-
-        A reverse mapping is stored in ``_name_to_tool`` so that tool calls
-        can be routed back to the correct ``(tool_id, action_name)`` without
-        brittle string splitting.
-        """
-        # Pass 1: collect entries and count action name occurrences
-        # (tool_id, tool_name, action_name, action, is_client)
-        entries: List[Tuple[str, str, str, Dict, bool]] = []
-        name_counts: Counter = Counter()
-        # A builtin can arrive twice: once as the user's stored row (keyed by
-        # list index in ``_get_user_tools``) and once as the synthesized default
-        # (keyed by uuid5). Pass 2 then hands the model two indistinguishable
-        # copies with mangled names (``artifact_generator_create_artifact`` +
-        # ``…_1``). The two rows are NOT byte-identical — a stored row has been
-        # through ``transform_actions``, which stamps ``active``/``filled_by_llm``
-        # onto every action — so the key is (tool name, action name).
-        #
-        # Which copy survives is load-bearing: a stored builtin row CAN carry
-        # per-row config even though ``get_config_requirements() == {}``, and
-        # ``code_executor`` keeps its approval gate there. Insertion order is
-        # the agent's ``tool_ids`` click order on the agent paths, so it must
-        # not decide this — stored rows are considered before synthesized ones,
-        # and a row that requires approval always beats one that does not. Safe
-        # only for builtins; two MCP rows can legitimately share a name and must
-        # stay distinct.
-        seen_actions: Dict[Tuple[str, str, bool], Tuple[int, bool]] = {}
-        dedupable = _dedupable_tool_names()
-
-        # Stable sort: preserves the caller's order within each group.
-        ordered_tools = sorted(tools_dict.items(), key=lambda kv: is_synthesized_tool_id(kv[0]))
-
-        for tool_id, tool in ordered_tools:
-            is_api = tool["name"] == "api_tool"
+            is_api = not tool.get("builtin", False)
             is_client = tool.get("client_side", False)
 
             if is_api and "actions" not in tool.get("config", {}):
-                continue
-            if not is_api and "actions" not in tool:
-                continue
-
-            actions = tool["config"]["actions"].values() if is_api else tool["actions"]
+                actions = tool.get("actions") or []
+            else:
+                actions = (tool.get("config") or {}).get("actions") or tool.get("actions") or []
 
             for action in actions:
                 if not action.get("active", True):
                     continue
                 tool_name = tool.get("name", "")
-                if tool_name in dedupable:
-                    fingerprint = (tool_name, action["name"], is_client)
-                    requires_approval = _requires_approval(tool, action)
-                    kept = seen_actions.get(fingerprint)
-                    if kept is not None:
-                        kept_index, kept_approval = kept
-                        if requires_approval and not kept_approval:
-                            # Never let a duplicate registration drop an
-                            # approval gate the user configured.
-                            entries[kept_index] = (
-                                tool_id,
-                                tool_name,
-                                action["name"],
-                                action,
-                                is_client,
-                            )
-                            seen_actions[fingerprint] = (kept_index, True)
-                            logger.debug(
-                                "duplicate_tool_registration_promoted",
-                                extra={"tool_name": tool_name, "action_name": action["name"]},
-                            )
-                        else:
-                            logger.debug(
-                                "duplicate_tool_registration_collapsed",
-                                extra={"tool_name": tool_name, "action_name": action["name"]},
-                            )
-                        continue
-                    seen_actions[fingerprint] = (len(entries), requires_approval)
-                entries.append((tool_id, tool_name, action["name"], action, is_client))
-                name_counts[action["name"]] += 1
+                action_name = action.get("name", "")
 
-        # Pass 2: assign LLM-visible names and build mappings
-        self._name_to_tool = {}
-        self._tool_to_name = {}
-        all_llm_names: set = set()
+                if is_synthesized_tool(tool_name):
+                    llm_name = action_name
+                elif is_client:
+                    llm_name = action_name
+                else:
+                    llm_name = f"{tool_name}__{action_name}"
 
-        result = []
-        for tool_id, tool_name, action_name, action, is_client in entries:
-            if name_counts[action_name] == 1 and len(action_name) <= _MAX_LLM_NAME_LEN:
-                llm_name = action_name
-            else:
-                # An over-long unique name skips the prefix — it needs
-                # truncation, not disambiguation.
-                prefix = _sanitize_tool_prefix(tool_name) if name_counts[action_name] > 1 else ""
-                base = f"{prefix}_{action_name}" if prefix and not action_name.startswith(f"{prefix}_") else action_name
-                base = base[:_MAX_LLM_NAME_LEN]
-                # A duplicated bare name stays ambiguous, and a candidate
-                # must not steal a unique action's name or one already taken.
-                candidate = base
-                counter = 1
-                while candidate == action_name or candidate in all_llm_names or name_counts.get(candidate, 0) == 1:
-                    suffix = f"_{counter}"
-                    candidate = base[: _MAX_LLM_NAME_LEN - len(suffix)] + suffix
-                    counter += 1
-                llm_name = candidate
-
-            all_llm_names.add(llm_name)
-            self._name_to_tool[llm_name] = (tool_id, action_name)
-            self._tool_to_name[(tool_id, action_name)] = llm_name
-
-            if is_client:
-                params = action.get("parameters", {})
-            else:
                 params = self._build_tool_parameters(action)
+                result.append(
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": llm_name,
+                            "description": action.get("description", ""),
+                            "parameters": params,
+                        },
+                    }
+                )
 
+        # Merge client tools from the conversation context (if any)
+        client_tools = getattr(self, "_client_tools", [])
+        for i, ct in enumerate(client_tools):
+            func = ct.get("function", ct)
+            name = func.get("name", f"clienttool{i}")
             result.append(
                 {
                     "type": "function",
                     "function": {
-                        "name": llm_name,
-                        "description": action.get("description", ""),
-                        "parameters": params,
+                        "name": name,
+                        "description": func.get("description", ""),
+                        "parameters": func.get("parameters", {}),
                     },
                 }
             )
@@ -676,6 +215,8 @@ class ToolExecutor:
         for param_type in ["query_params", "headers", "body", "parameters"]:
             if param_type in action and action[param_type].get("properties"):
                 for k, v in action[param_type]["properties"].items():
+                    if not isinstance(v, dict):
+                        continue
                     if v.get("filled_by_llm", True):
                         params["properties"][k] = {
                             key: value for key, value in v.items() if key not in ("filled_by_llm", "value", "required")
@@ -685,12 +226,7 @@ class ToolExecutor:
         return params
 
     def _guardrail_tool_result(self, result: Any, tool_name: str, action_name: str) -> Any:
-        """Scan a tool result before it fans out to the LLM, UI and journal.
-
-        A tool result is untrusted third-party text on the same footing as a
-        retrieved document, and it is a common exfiltration path for secrets
-        that the calling API happened to echo back.
-        """
+        """Scan a tool result before it fans out to the LLM, UI and journal."""
         engine = getattr(self, "guardrail_engine", None)
         if engine is None or not engine.has_stage(GuardrailStage.TOOL_RESULT):
             return result
@@ -699,773 +235,233 @@ class ToolExecutor:
         try:
             engine.context.tool_name = tool_name
             engine.context.action_name = action_name
-            decision = engine.evaluate(result, GuardrailStage.TOOL_RESULT)
+            return engine.scan(result, stage=GuardrailStage.TOOL_RESULT)
         except Exception:
-            logger.exception("Tool-result guardrail failed for %s.%s", tool_name, action_name)
+            logger.warning("Guardrail scan failed for tool result", exc_info=True)
             return result
-        return resolve_tool_result(result, decision)
 
-    def check_pause(self, tools_dict: Dict, call, llm_class_name: str) -> Optional[Dict]:
-        """Return a pending-action dict (approval / client / headless_denied) or None.
+    # ------------------------------------------------------------------
+    # Tool execution
+    # ------------------------------------------------------------------
 
-        In headless mode the dict's pause_type is ``headless_denied`` so the
-        upstream loop synthesizes a tool result instead of pausing (nothing can
-        resume a scheduled / webhook run).
-        """
-        parser = ToolActionParser(llm_class_name, name_mapping=self._name_to_tool)
-        tool_id, action_name, call_args = parser.parse_args(call)
-        call_id = getattr(call, "id", None) or str(uuid.uuid4())
-        llm_name = getattr(call, "name", "")
+    def execute(
+        self,
+        tool_calls: List[Dict],
+        conversation_id: Optional[str] = None,
+        shared_token: Optional[str] = None,
+    ) -> List[Dict]:
+        """Execute a list of tool calls and return results."""
+        results = []
+        for tc in tool_calls:
+            result = self._execute_one(tc, conversation_id=conversation_id, shared_token=shared_token)
+            results.append(result)
+        return results
 
-        if tool_id is None or action_name is None or tool_id not in tools_dict:
-            return None  # Will be handled as error by execute()
+    def _execute_one(
+        self,
+        tool_call: Dict,
+        conversation_id: Optional[str] = None,
+        shared_token: Optional[str] = None,
+    ) -> Dict:
+        func = tool_call.get("function", {})
+        raw_name: str = func.get("name", "")
+        tool_call_id = tool_call.get("id") or str(uuid.uuid4())
 
-        tool_data = tools_dict[tool_id]
-        arguments = call_args if isinstance(call_args, dict) else {}
-
-        # Client-side tools
-        if tool_data.get("client_side"):
-            if self.headless:
-                return {
-                    "call_id": call_id,
-                    "name": llm_name,
-                    "tool_name": tool_data.get("name", "unknown"),
-                    "tool_id": tool_id,
-                    "action_name": action_name,
-                    "llm_name": llm_name,
-                    "arguments": arguments,
-                    "pause_type": "headless_denied",
-                    "deny_reason": ("Client-side tools cannot run in headless / scheduled runs."),
-                    "error_type": "tool_not_allowed",
-                    "thought_signature": getattr(call, "thought_signature", None),
-                }
-            return {
-                "call_id": call_id,
-                "name": llm_name,
-                "tool_name": tool_data.get("name", "unknown"),
-                "tool_id": tool_id,
-                "action_name": action_name,
-                "llm_name": llm_name,
-                "arguments": arguments,
-                "pause_type": "requires_client_execution",
-                "thought_signature": getattr(call, "thought_signature", None),
-            }
-
-        # Approval required
-        if tool_data["name"] == "api_tool":
-            action_data = tool_data.get("config", {}).get("actions", {}).get(action_name, {})
+        # Parse tool_name__action_name
+        if "__" in raw_name:
+            tool_name, action_name = raw_name.split("__", 1)
         else:
-            action_data = next(
-                (a for a in tool_data.get("actions", []) if a["name"] == action_name),
-                {},
-            )
+            tool_name = raw_name
+            action_name = raw_name
 
-        require_approval = bool(action_data.get("require_approval"))
-        # ``denylist_forced`` marks a prompt the hard denylist mandates; a
-        # headless allowlist must never bypass it (see below).
-        denylist_forced = False
-        # ``remote_device`` decides per-invocation based on the live device
-        # state (``approval_mode``, sticky patterns, allow/denylist). The
-        # cached ``user_tools.actions[].require_approval`` snapshot does
-        # not reflect later approval-mode changes nor command-level
-        # heuristics, so consult the tool directly.
-        if tool_data.get("name") == "remote_device":
-            require_approval, denylist_forced = self._remote_device_requires_approval(
-                tool_data,
-                action_name,
-                arguments,
-            )
-        elif tool_data.get("name") == "code_executor":
-            # The deployment-level ``config.require_approval`` is authoritative
-            # over the cached action snapshot, so consult the tool directly.
-            require_approval = (
-                self._code_executor_requires_approval(
-                    tool_data,
-                    action_name,
-                    arguments,
-                )
-                or require_approval
-            )
-
-        if require_approval:
-            if self.headless:
-                tool_row_id = str(tool_data.get("id") or tool_id)
-                # A denylist-forced prompt is never pre-authorizable: a
-                # scheduled/headless run with the device allowlisted must
-                # still be denied a denylisted command. Only non-forced
-                # approvals honor the allowlist bypass.
-                if tool_row_id in self.tool_allowlist and not denylist_forced:
-                    # Pre-authorized for headless execution — fall through.
-                    return None
-                return {
-                    "call_id": call_id,
-                    "name": llm_name,
-                    "tool_name": tool_data.get("name", "unknown"),
-                    "tool_id": tool_id,
-                    "action_name": action_name,
-                    "llm_name": llm_name,
-                    "arguments": arguments,
-                    "pause_type": "headless_denied",
-                    "deny_reason": ("This tool requires approval and is not in the run's tool_allowlist."),
-                    "error_type": "tool_not_allowed",
-                    "thought_signature": getattr(call, "thought_signature", None),
-                }
-            payload = {
-                "call_id": call_id,
-                "name": llm_name,
-                "tool_name": tool_data.get("name", "unknown"),
-                "tool_id": tool_id,
-                "action_name": action_name,
-                "llm_name": llm_name,
-                "arguments": arguments,
-                "pause_type": "awaiting_approval",
-                "thought_signature": getattr(call, "thought_signature", None),
+        try:
+            args_str = func.get("arguments", "{}")
+            args = _safe_parse_args(args_str)
+        except Exception as e:
+            return {
+                "tool_call_id": tool_call_id,
+                "role": "tool",
+                "name": raw_name,
+                "content": f"Error parsing arguments: {e}",
             }
-            # Surface the device id so the approval UI can offer a
-            # "don't ask again" sticky-pattern action for remote devices.
-            if tool_data.get("name") == "remote_device":
-                config = tool_data.get("config") or {}
-                if config.get("device_id"):
-                    payload["device_id"] = config["device_id"]
-            return payload
 
+        tools = self.get_tools()
+        tool = self._find_tool(tools, tool_name, action_name)
+        if tool is None:
+            return {
+                "tool_call_id": tool_call_id,
+                "role": "tool",
+                "name": raw_name,
+                "content": f"Tool '{raw_name}' not found",
+            }
+
+        action = self._find_action(tool, action_name)
+        if action is None:
+            return {
+                "tool_call_id": tool_call_id,
+                "role": "tool",
+                "name": raw_name,
+                "content": f"Action '{action_name}' not found in tool '{tool_name}'",
+            }
+
+        if _requires_approval(tool, action):
+            return {
+                "tool_call_id": tool_call_id,
+                "role": "tool",
+                "name": raw_name,
+                "content": "APPROVAL_REQUIRED",
+                "requires_approval": True,
+                "action": action,
+                "args": args,
+            }
+
+        try:
+            instance = tool.get("instance")
+            if instance is None:
+                return {
+                    "tool_call_id": tool_call_id,
+                    "role": "tool",
+                    "name": raw_name,
+                    "content": f"Tool instance not available for '{tool_name}'",
+                }
+
+            config = tool.get("config") or {}
+            result_raw = instance.call_action(
+                action_name=action_name,
+                args=args,
+                config=config,
+                user=self.user,
+                conversation_id=conversation_id,
+            )
+            result_str = _format_result(result_raw)
+            result_str = self._guardrail_tool_result(result_str, tool_name, action_name)
+        except ValidationError as e:
+            result_str = f"Validation error: {e}"
+        except Exception as e:
+            logger.error(
+                "Tool execution error: tool=%s action=%s error=%s",
+                tool_name, action_name, e, exc_info=True,
+            )
+            result_str = f"Tool execution failed: {e}"
+
+        return {
+            "tool_call_id": tool_call_id,
+            "role": "tool",
+            "name": raw_name,
+            "content": result_str,
+        }
+
+    def _find_tool(self, tools: Dict, tool_name: str, action_name: str) -> Optional[Dict]:
+        for tool_id, tool in tools.items():
+            if not isinstance(tool, dict):
+                continue
+            if tool.get("name") == tool_name:
+                return tool
         return None
 
-    def _remote_device_requires_approval(
-        self,
-        tool_data: Dict,
-        action_name: str,
-        arguments: Dict,
-    ) -> tuple[bool, bool]:
-        """Live approval decision for a ``remote_device`` invocation.
-
-        Instantiates ``RemoteDeviceTool`` with the cached config and the
-        executor's user context, then asks it to evaluate the command.
-        Returns ``(requires_approval, denylist_forced)``. Falls back to a
-        denylist-forced prompt on any error so a misconfigured device never
-        silently bypasses the prompt — not even via the headless allowlist.
-        """
-        try:
-            from application.agents.tools.remote_device import RemoteDeviceTool
-
-            tool = RemoteDeviceTool(
-                config=tool_data.get("config") or {},
-                user_id=self.user,
-            )
-            return tool.preview_decision(action_name, arguments)
-        except Exception:
-            logger.exception(
-                "remote_device preview_decision failed; defaulting to a forced prompt",
-            )
-            return True, True
-
-    def _code_executor_requires_approval(
-        self,
-        tool_data: Dict,
-        action_name: str,
-        arguments: Dict,
-    ) -> bool:
-        """Live approval decision for a ``code_executor`` invocation.
-
-        Honors the deployment-level ``config.require_approval`` even when the
-        cached action snapshot is stale. Fails closed (require approval) on any
-        error so a misconfigured tool never silently runs untrusted code.
-        """
-        try:
-            from application.agents.tools.code_executor import CodeExecutorTool
-
-            tool = CodeExecutorTool(
-                tool_config=tool_data.get("config") or {},
-                user_id=self.user,
-            )
-            requires_approval, _forced = tool.preview_decision(action_name, arguments)
-            return requires_approval
-        except Exception:
-            logger.exception(
-                "code_executor preview_decision failed; defaulting to a prompt",
-            )
-            return True
-
-    @staticmethod
-    def _advertisable_action_names(tools_dict: Dict) -> set:
-        """Action names a ``tools_dict`` would expose, mirroring pass 1 of
-        :meth:`prepare_tools_for_llm`.
-
-        The model calls ACTION names (``run_code``), never tool names
-        (``code_executor``), so a fallback built from ``tool["name"]`` names
-        strings that cannot resolve — feeding the very retry loop the
-        correctable error exists to break.
-        """
-        names = set()
-        for tool in (tools_dict or {}).values():
-            tool = tool or {}
-            if tool.get("name") == "api_tool":
-                actions = (tool.get("config") or {}).get("actions") or {}
-                actions = actions.values() if isinstance(actions, dict) else actions
-            else:
-                actions = tool.get("actions") or []
-            for action in actions:
-                if not isinstance(action, dict) or not action.get("active", True):
-                    continue
-                if action.get("name"):
-                    names.add(str(action["name"]))
-        return names
-
-    def _available_tool_names(self, tools_dict: Dict, exclude: Optional[str] = None) -> str:
-        """Render the names the model can actually call, for a correctable error.
-
-        Prefer the LLM-visible action names assigned by
-        :meth:`prepare_tools_for_llm` — those are the strings the model puts in
-        a tool call. Fall back to tool names when the mapping has not been built
-        (headless paths, tests). Never the internal tool ids: quoting those
-        tells the model nothing about what to call instead.
-
-        Narrowed to ``tools_dict`` so a call made with a restricted toolset is
-        never told to call something out of scope, and capped: this string is
-        returned as a tool RESULT, so it joins the message history and is
-        re-sent on every later round. Uncapped, a large MCP fleet turns one
-        failed call into kilobytes of prose duplicating the tool schema the
-        provider already received.
-        """
-        scope = set(tools_dict or {})
-        names = sorted(
-            name
-            for (tool_id, _action), name in self._tool_to_name.items()
-            if not scope or tool_id in scope
-        )
-        if not names:
-            names = sorted(self._advertisable_action_names(tools_dict or {}))
-        names = [str(name) for name in names if name != exclude]
-        if len(names) > self.MAX_ADVERTISED_TOOL_NAMES:
-            hidden = len(names) - self.MAX_ADVERTISED_TOOL_NAMES
-            names = names[: self.MAX_ADVERTISED_TOOL_NAMES] + [f"and {hidden} more"]
-        return ", ".join(names) if names else "(none available)"
-
-    # After this many unresolvable calls to the same name, refuse rather than
-    # re-run.
-    UNRESOLVABLE_CALL_LIMIT = 2
-
-    # Cap on names rendered into a failed-call result; see
-    # :meth:`_available_tool_names`.
-    MAX_ADVERTISED_TOOL_NAMES = 30
-
-    def execute(self, tools_dict: Dict, call, llm_class_name: str):
-        """Execute a tool call. Yields status events, returns (result, call_id)."""
-        parser = ToolActionParser(llm_class_name, name_mapping=self._name_to_tool)
-        tool_id, action_name, call_args = parser.parse_args(call)
-        llm_name = getattr(call, "name", "unknown")
-
-        call_id = getattr(call, "id", None) or str(uuid.uuid4())
-        unresolvable = tool_id is None or action_name is None or tool_id not in tools_dict
-
-        # A tool the model invented will never resolve, so re-running it just
-        # burns the turn's iteration budget on an identical failure. From the
-        # third attempt on, hand back a directive message instead of the generic
-        # error. Scoped to an unknown *name*: a registered tool whose arguments
-        # merely failed to decode is recoverable, and refusing it would strand a
-        # working tool for the rest of the turn.
-        #
-        # Keyed on the NAME ALONE. Keying on the payload too made the guard a
-        # no-op in the case it exists for: told a call failed, a model varies
-        # its arguments on the next attempt, minting a fresh counter every
-        # round and never reaching the limit. Arguments cannot rescue an
-        # unknown name anyway — ``ToolActionParser`` resolves from ``call.name``
-        # only — and the "two different malformed bodies" case this used to
-        # protect belongs to REGISTERED tools, which the
-        # ``llm_name not in self._name_to_tool`` gate already excludes.
-        if unresolvable and llm_name not in self._name_to_tool:
-            failures = self._unresolvable_calls.get(llm_name, 0)
-            # Count before refusing, so the message and the log escalate rather
-            # than freezing at the limit for the rest of the turn.
-            self._unresolvable_calls[llm_name] = failures + 1
-            if failures >= self.UNRESOLVABLE_CALL_LIMIT:
-                repeated = (
-                    f"'{llm_name}' has already failed {failures} times and will keep "
-                    f"failing — it is not a tool that exists. Stop calling it and "
-                    f"either use a different tool "
-                    f"({self._available_tool_names(tools_dict, exclude=llm_name)}) or answer without one."
-                )
-                logger.warning(
-                    "tool_call_repeated_failure",
-                    extra={"llm_tool_name": llm_name, "call_id": call_id, "failures": failures},
-                )
-                tool_call_data = {
-                    "tool_name": "unknown",
-                    "call_id": call_id,
-                    "action_name": llm_name,
-                    "arguments": call_args if isinstance(call_args, dict) else {},
-                    "result": repeated,
-                    "status": "error",
-                }
-                # Journal it like the branches below, so a hallucination storm
-                # is not under-counted in the analytics used to size it.
-                if _record_proposed(
-                    call_id,
-                    "unknown",
-                    llm_name or "unknown",
-                    call_args if isinstance(call_args, dict) else {},
-                    message_id=self.message_id,
-                    user_id=self.user,
-                    agent_id=self.agent_id,
-                ):
-                    _mark_failed(
-                        call_id,
-                        repeated,
-                        message_id=self.message_id,
-                        user_id=self.user,
-                    )
-                yield {"type": "tool_call", "data": {**tool_call_data, "status": "error"}}
-                self.tool_calls.append(tool_call_data)
-                return repeated, call_id
-
-        if tool_id is None or action_name is None:
-            # Say which half actually failed. Reporting a name problem for a
-            # registered tool whose arguments were merely malformed is what sent
-            # one production investigation down the wrong path.
-            name_is_known = llm_name in self._name_to_tool
-            parse_reason = (
-                "its arguments were not a valid JSON object"
-                if name_is_known
-                else "the tool name could not be resolved and its arguments were not a JSON object"
-            )
-            logger.error(
-                "tool_call_parse_failed",
-                extra={
-                    "llm_class_name": llm_class_name,
-                    "llm_tool_name": llm_name,
-                    "call_id": call_id,
-                },
-            )
-
-            tool_call_data = {
-                "tool_name": "unknown",
-                "call_id": call_id,
-                "action_name": llm_name,
-                "arguments": call_args or {},
-                "result": (
-                    f"Could not run '{llm_name}': {parse_reason}. "
-                    f"Available tools: {self._available_tool_names(tools_dict)}."
-                ),
-                "status": "error",
-            }
-            # Journal the malformed call so it still shows up in tool analytics.
-            if _record_proposed(
-                call_id,
-                "unknown",
-                llm_name or "unknown",
-                call_args if isinstance(call_args, dict) else {},
-                message_id=self.message_id,
-                user_id=self.user,
-                agent_id=self.agent_id,
-            ):
-                _mark_failed(
-                    call_id,
-                    tool_call_data["result"],
-                    message_id=self.message_id,
-                    user_id=self.user,
-                )
-            yield {"type": "tool_call", "data": {**tool_call_data, "status": "error"}}
-            self.tool_calls.append(tool_call_data)
-            return tool_call_data["result"], call_id
-
-        if tool_id not in tools_dict:
-            logger.error(
-                "tool_id_not_found",
-                extra={
-                    "tool_id": tool_id,
-                    "llm_tool_name": llm_name,
-                    "call_id": call_id,
-                    "available_tool_count": len(tools_dict),
-                },
-            )
-
-            tool_call_data = {
-                "tool_name": "unknown",
-                "call_id": call_id,
-                "action_name": llm_name,
-                "arguments": call_args,
-                "result": (
-                    f"Could not run '{llm_name}': no such tool. "
-                    f"Available tools: {self._available_tool_names(tools_dict)}."
-                ),
-                "status": "error",
-            }
-            # Journal the unresolvable call so it still shows up in tool analytics.
-            if _record_proposed(
-                call_id,
-                "unknown",
-                llm_name or "unknown",
-                call_args if isinstance(call_args, dict) else {},
-                message_id=self.message_id,
-                user_id=self.user,
-                agent_id=self.agent_id,
-            ):
-                _mark_failed(
-                    call_id,
-                    tool_call_data["result"],
-                    message_id=self.message_id,
-                    user_id=self.user,
-                )
-            yield {"type": "tool_call", "data": {**tool_call_data, "status": "error"}}
-            self.tool_calls.append(tool_call_data)
-            return tool_call_data["result"], call_id
-
-        tool_call_data = {
-            "tool_name": tools_dict[tool_id]["name"],
-            "call_id": call_id,
-            "action_name": llm_name,
-            "arguments": call_args,
-        }
-        tool_data = tools_dict[tool_id]
-        # Surface the device id on remote_device tool-call events so the
-        # approval UI can wire up the sticky "don't ask again" button.
-        if tool_data.get("name") == "remote_device":
-            config = tool_data.get("config") or {}
-            if config.get("device_id"):
-                tool_call_data["device_id"] = config["device_id"]
-        # Journal first so the reconciler sees malformed calls and any
-        # subsequent ``_mark_failed`` actually updates a real row.
-        proposed_ok = _record_proposed(
-            call_id,
-            tool_data["name"],
-            action_name,
-            call_args if isinstance(call_args, dict) else {},
-            tool_id=tool_data.get("id"),
-            message_id=self.message_id,
-            user_id=self.user,
-            agent_id=self.agent_id,
-        )
-        # Defensive guard: a non-dict ``call_args`` (e.g. malformed
-        # JSON on the resume path) would crash the param walk below
-        # with AttributeError on ``.items()``. Surface a clean error
-        # event and flip the journal row to ``failed`` instead of
-        # killing the stream.
-        if not isinstance(call_args, dict):
-            error_message = f"Tool call arguments must be a JSON object, got {type(call_args).__name__}."
-            tool_call_data["result"] = error_message
-            tool_call_data["arguments"] = {}
-            tool_call_data["status"] = "error"
-            if proposed_ok:
-                _mark_failed(
-                    call_id, error_message, message_id=self.message_id, user_id=self.user
-                )
-            yield {
-                "type": "tool_call",
-                "data": {**tool_call_data, "status": "error"},
-            }
-            self.tool_calls.append(tool_call_data)
-            return error_message, call_id
-        yield {"type": "tool_call", "data": {**tool_call_data, "status": "pending"}}
-        action_data = (
-            tool_data["config"]["actions"][action_name]
-            if tool_data["name"] == "api_tool"
-            else next(action for action in tool_data["actions"] if action["name"] == action_name)
-        )
-
-        query_params, headers, body, parameters = {}, {}, {}, {}
-        param_types = {
-            "query_params": query_params,
-            "headers": headers,
-            "body": body,
-            "parameters": parameters,
-        }
-
-        for param_type, target_dict in param_types.items():
-            if param_type in action_data and action_data[param_type].get("properties"):
-                for param, details in action_data[param_type]["properties"].items():
-                    if param not in call_args and "value" in details and details["value"]:
-                        target_dict[param] = details["value"]
-        for param, value in call_args.items():
-            for param_type, target_dict in param_types.items():
-                if param_type in action_data and param in action_data[param_type].get("properties", {}):
-                    target_dict[param] = value
-
-        # Load tool (with caching)
-        tool = self._get_or_load_tool(
-            tool_data,
-            tool_id,
-            action_name,
-            headers=headers,
-            query_params=query_params,
-        )
-
-        if tool is None:
-            error_message = (
-                f"Failed to load tool '{tool_data.get('name')}' (tool_id key={tool_id}): missing 'id' on tool row."
-            )
-            logger.error(
-                "tool_load_failed",
-                extra={
-                    "tool_name": tool_data.get("name"),
-                    "tool_id": tool_id,
-                    "action_name": action_name,
-                    "call_id": call_id,
-                },
-            )
-            tool_call_data["result"] = error_message
-            tool_call_data["status"] = "error"
-            if proposed_ok:
-                _mark_failed(
-                    call_id, error_message, message_id=self.message_id, user_id=self.user
-                )
-            yield {"type": "tool_call", "data": {**tool_call_data}}
-            self.tool_calls.append(tool_call_data)
-            return error_message, call_id
-
-        resolved_arguments = (
-            {"query_params": query_params, "headers": headers, "body": body}
-            if tool_data["name"] == "api_tool"
-            else parameters
-        )
-        try:
-            if tool_data["name"] == "api_tool":
-                logger.debug(
-                    "Executing api: %s with query_params: %s, headers: %s, body: %s",
-                    action_name,
-                    _redact_args_for_log(query_params),
-                    _redact_args_for_log(headers),
-                    _redact_args_for_log(body),
-                )
-                result = tool.execute_action(action_name, **body)
-            else:
-                logger.debug(
-                    "Executing tool: %s with args: %s",
-                    action_name,
-                    _redact_args_for_log(call_args),
-                )
-                result = tool.execute_action(action_name, **parameters)
-        except Exception as exc:
-            if proposed_ok:
-                _mark_failed(
-                    call_id, str(exc), message_id=self.message_id, user_id=self.user
-                )
-            raise
-
-        # Single fan-out point: from here ``result`` reaches the LLM copy,
-        # the conversation row, tool_call_attempts, and the stream event —
-        # sanitize once so every lane gets clean text.
-        result = sanitize_tool_result(result)
-        result = self._guardrail_tool_result(result, tool_data.get("name", ""), action_name)
-
-        get_artifact_id = getattr(tool, "get_artifact_id", None) if tool_data["name"] != "api_tool" else None
-
-        artifact_id = None
-        if callable(get_artifact_id):
-            try:
-                artifact_id = get_artifact_id(action_name, **parameters)
-            except Exception:
-                logger.exception(
-                    "Failed to extract artifact_id from tool %s for action %s",
-                    tool_data["name"],
-                    action_name,
-                )
-
-        artifact_id = str(artifact_id).strip() if artifact_id is not None else ""
-        if artifact_id:
-            tool_call_data["artifact_id"] = artifact_id
-
-        # A single call can produce several files (``run_code`` writing more
-        # than one). ``artifact_id`` names only the first, which left the rest
-        # with no way into the UI, so report the full set with display names.
-        get_artifacts = (
-            getattr(tool, "get_artifacts", None)
-            if tool_data["name"] != "api_tool"
-            else None
-        )
-        if callable(get_artifacts):
-            artifacts = []
-            try:
-                # Normalize inside the guard: a tool returning an unexpected
-                # shape must not break the call it just completed.
-                artifacts = [
-                    {
-                        "id": str(a["id"]).strip(),
-                        "filename": a.get("filename"),
-                        "ref": a.get("ref"),
-                    }
-                    for a in (get_artifacts(action_name, **parameters) or [])
-                    if isinstance(a, dict) and a.get("id")
-                ]
-            except Exception:
-                logger.exception(
-                    "Failed to extract artifacts from tool %s for action %s",
-                    tool_data["name"],
-                    action_name,
-                )
-            if artifacts:
-                tool_call_data["artifacts"] = artifacts
-        result_full = bound_result_full(str(result))
-        tool_call_data["resolved_arguments"] = resolved_arguments
-        tool_call_data["result_full"] = result_full
-        tool_call_data["result"] = truncate_tool_result(result_full)
-        # A tool that ran but reported failure in-band persists as ``error``,
-        # not ``completed`` -- the model saw an error and will likely retry.
-        tool_call_data["status"] = result_status(result)
-
-        # Tool side effect has run; flip the journal row so the
-        # message-finalize path can later confirm it. If the proposed
-        # write failed (DB outage), upsert a fresh row in ``executed`` so
-        # the reconciler still sees the side effect.
-        _mark_executed(
-            call_id,
-            result_full,
-            message_id=self.message_id,
-            artifact_id=artifact_id or None,
-            proposed_ok=proposed_ok,
-            tool_name=tool_data["name"],
-            action_name=action_name,
-            arguments=call_args,
-            tool_id=tool_data.get("id"),
-            user_id=self.user,
-            agent_id=self.agent_id,
-        )
-
-        stream_tool_call_data = {
-            key: value for key, value in tool_call_data.items() if key not in {"result_full", "resolved_arguments"}
-        }
-        yield {"type": "tool_call", "data": {**stream_tool_call_data}}
-        self.tool_calls.append(tool_call_data)
-
-        return result, call_id
-
-    def _get_or_load_tool(
-        self,
-        tool_data: Dict,
-        tool_id: str,
-        action_name: str,
-        headers: Optional[Dict] = None,
-        query_params: Optional[Dict] = None,
-    ):
-        """Load a tool, using cache when possible."""
-        cache_key = f"{tool_data['name']}:{tool_id}:{self.user or ''}"
-        if cache_key in self._loaded_tools:
-            cached = self._loaded_tools[cache_key]
-            # A tool cached on an earlier turn carries that turn's attachments;
-            # refresh them so a chat attachment added this turn is bridgeable.
-            cached_config = getattr(cached, "config", None)
-            if isinstance(cached_config, dict) and self.conversation_id:
-                # Refresh unconditionally so a turn with no attachments clears the
-                # prior turn's list (no stale carryover within the session).
-                cached_config["attachments"] = self.attachments or []
-            return cached
-
-        tm = ToolManager(config={})
-
-        if tool_data["name"] == "api_tool":
-            action_config = tool_data["config"]["actions"][action_name]
-            tool_config = {
-                "url": action_config["url"],
-                "method": action_config["method"],
-                "headers": headers or {},
-                "query_params": query_params or {},
-            }
-            if "body_content_type" in action_config:
-                tool_config["body_content_type"] = action_config.get("body_content_type", "application/json")
-                tool_config["body_encoding_rules"] = action_config.get("body_encoding_rules", {})
+    def _find_action(self, tool: Dict, action_name: str) -> Optional[Dict]:
+        is_api = not tool.get("builtin", False)
+        if is_api and "actions" not in tool.get("config", {}):
+            actions = tool.get("actions") or []
         else:
-            tool_config = tool_data["config"].copy() if tool_data["config"] else {}
-            # Credentials are PBKDF2-bound to the tool OWNER's sub, not the
-            # invoker's. Decrypt with the tool row's user_id so a team member
-            # running an owner's shared tool authenticates with the owner's
-            # credentials (deliberate delegation — see teams-spec OQ2), and so
-            # the long-standing agent-key path (tools resolved by owner) stops
-            # silently decrypt-failing. Falls back to self.user for the
-            # agentless path where the tool row carries no user_id.
-            tool_owner = tool_data.get("user_id") or self.user
-            if tool_config.get("encrypted_credentials") and tool_owner:
-                if tool_owner != self.user:
-                    # Credential delegation: the invoker is running a shared
-                    # tool with the owner's secrets. Audit it (the agent-run
-                    # authorization upstream is the access boundary).
-                    logger.info(
-                        "tool_credential_delegation",
-                        extra={
-                            "invoker": self.user,
-                            "tool_owner": tool_owner,
-                            "tool_id": str(tool_data.get("id") or tool_id),
-                            "tool_name": tool_data.get("name"),
-                            "agent_id": self.agent_id,
-                        },
-                    )
-                decrypted = decrypt_credentials(tool_config["encrypted_credentials"], tool_owner)
-                tool_config.update(decrypted)
-                tool_config["auth_credentials"] = decrypted
-                tool_config.pop("encrypted_credentials", None)
-            row_id = tool_data.get("id")
-            if not row_id:
-                logger.error(
-                    "tool_missing_row_id",
-                    extra={
-                        "tool_name": tool_data.get("name"),
-                        "tool_id": tool_id,
-                        "action_name": action_name,
-                    },
-                )
-                return None
-            tool_config["tool_id"] = str(row_id)
-            if self.conversation_id:
-                tool_config["conversation_id"] = self.conversation_id
-                if self.message_id:
-                    tool_config["message_id"] = self.message_id
-                # Carry the request's own attachments so sandbox tools can
-                # lazily bridge a referenced chat attachment (conversation
-                # scope only; workflow nodes bridge attachments up front).
-                if self.attachments:
-                    tool_config["attachments"] = self.attachments
-            # Workflow agent nodes run-scope their artifact tools so a short
-            # ref (A1) and edit_artifact resolve against the workflow run.
-            if self.workflow_run_id:
-                tool_config["workflow_run_id"] = self.workflow_run_id
-            if tool_data["name"] == "scheduler":
-                # Agent-bound: stamp schedules.agent_id. Agentless: the tool
-                # falls back to ``origin_conversation_id`` as the schedule's
-                # conversation home.
-                tool_config["agent_id"] = str(self.agent_id) if self.agent_id else None
-            if tool_data["name"] == "mcp_tool":
-                tool_config["query_mode"] = True
+            actions = (tool.get("config") or {}).get("actions") or tool.get("actions") or []
+        for action in actions:
+            if action.get("name") == action_name:
+                return action
+        return None
 
-        tool = tm.load_tool(
-            tool_data["name"],
-            tool_config=tool_config,
-            user_id=self.user,
-        )
+    # ------------------------------------------------------------------
+    # Duplicate / hallucination detection
+    # ------------------------------------------------------------------
 
-        # Don't cache api_tool since config varies by action
-        if tool_data["name"] != "api_tool":
-            self._loaded_tools[cache_key] = tool
+    def detect_duplicate_calls(self, tool_calls: List[Dict]) -> List[str]:
+        """Return names of tools called more than once in the same turn."""
+        counter: Counter = Counter()
+        for tc in tool_calls:
+            name = (tc.get("function") or {}).get("name", "")
+            if name:
+                counter[name] += 1
+        return [name for name, cnt in counter.items() if cnt > 1]
 
-        return tool
+    def detect_hallucinated_calls(self, tool_calls: List[Dict]) -> List[str]:
+        """Return tool call names that don't exist in the known tool set."""
+        known = {f["function"]["name"] for f in self.get_tools_info()}
+        hallucinated = []
+        for tc in tool_calls:
+            name = (tc.get("function") or {}).get("name", "")
+            if name and name not in known:
+                hallucinated.append(name)
+        return hallucinated
 
-    # Keys the client needs that are not part of the fixed shape below. They are
-    # small and optional, and are copied only when present so an ordinary tool
-    # call does not grow null columns in every persisted row.
-    _PRESERVED_TOOL_CALL_KEYS = ("artifacts", "device_id")
+    # ------------------------------------------------------------------
+    # Shared conversation support
+    # ------------------------------------------------------------------
 
-    def get_truncated_tool_calls(self) -> List[Dict]:
-        """Project tool calls into the shape that is streamed and persisted.
+    def get_shared_agent_tools(self, shared_token: str) -> Dict:
+        with db_readonly() as conn:
+            repo = SharedConversationsRepository(conn)
+            shared = repo.get_by_token(shared_token)
+        if not shared:
+            return {}
+        agent_id = shared.get("agent_id")
+        if not agent_id:
+            return {}
+        old_agent_id = self.agent_id
+        self.agent_id = agent_id
+        self.invalidate_cache()
+        tools = self.get_tools()
+        self.agent_id = old_agent_id
+        self.invalidate_cache()
+        return tools
 
-        This is what the client reloads, so anything dropped here is live-only
-        and vanishes when the conversation is reopened. ``result_full`` and
-        ``resolved_arguments`` are shed deliberately — they are the untruncated
-        copies this projection exists to remove — but ``artifacts`` and
-        ``device_id`` were omitted by oversight, which cost a multi-file
-        ``run_code`` all but its first download chip on reload and left the
-        remote-device approval UI without the id it keys its sticky action on.
-        """
+    # ------------------------------------------------------------------
+    # Tool call projection (strip internal keys before sending to client)
+    # ------------------------------------------------------------------
+
+    def project_tool_calls(self, tool_calls: List[Dict]) -> List[Dict]:
         projected = []
-        for tool_call in self.tool_calls:
-            entry = {
-                "tool_name": tool_call.get("tool_name"),
-                "call_id": tool_call.get("call_id"),
-                "action_name": tool_call.get("action_name"),
-                "arguments": tool_call.get("arguments"),
-                "artifact_id": tool_call.get("artifact_id"),
-                "result": truncate_tool_result(tool_call.get("result")),
-                "status": tool_call.get("status", "completed"),
-            }
+        for tool_call in tool_calls:
+            entry = {}
             for key in self._PRESERVED_TOOL_CALL_KEYS:
                 value = tool_call.get(key)
                 if value:
                     entry[key] = value
             projected.append(entry)
         return projected
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _safe_parse_args(args_str: str) -> Dict:
+    """Parse JSON tool arguments, tolerating minor formatting issues."""
+    import json
+
+    if not args_str or args_str.strip() == "":
+        return {}
+    try:
+        return json.loads(args_str)
+    except json.JSONDecodeError:
+        # Try to extract JSON object
+        match = re.search(r"\{.*\}", args_str, re.DOTALL)
+        if match:
+            try:
+                return json.loads(match.group())
+            except json.JSONDecodeError:
+                pass
+        return {}
+
+
+def _format_result(result: Any) -> str:
+    """Convert a tool result to a string for the LLM."""
+    import json
+
+    if isinstance(result, str):
+        return result
+    if isinstance(result, (dict, list)):
+        try:
+            return json.dumps(result, ensure_ascii=False)
+        except Exception:
+            return str(result)
+    return str(result)

--- a/application/api/user/tools/routes.py
+++ b/application/api/user/tools/routes.py
@@ -1,168 +1,15 @@
 """Tool management routes."""
 
 from flask import current_app, jsonify, make_response, request
-from flask_restx import fields, Namespace, Resource
+from flask_restx import Namespace, Resource, fields
 
-from application.agents.default_tools import (
-    builtin_agent_tools_for_management,
-    BUILTIN_AGENT_TOOLS,
-    default_tool_name_for_id,
-    default_tools_for_management,
-    is_builtin_agent_tool_id,
-    is_default_tool_id,
-    is_synthesized_tool_id,
-    WORKFLOW_ONLY_BUILTINS,
-)
-from application.agents.tools.spec_parser import parse_spec
-from application.agents.tools.tool_manager import ToolManager
+from application.agents.tools import tool_manager
 from application.api import api
-from application.api.user.artifacts.authz import Principal, authorize_artifact
-from application.api.user.team_sharing import effective_write_owner, visible_with_access
-from application.core.settings import settings
-from application.core.url_validation import SSRFError, validate_url
-from application.security.encryption import decrypt_credentials, encrypt_credentials
-from application.storage.db.base_repository import looks_like_uuid
-from application.storage.db.repositories.artifacts import ArtifactsRepository
-from application.storage.db.repositories.notes import NotesRepository
-from application.storage.db.repositories.todos import TodosRepository
 from application.storage.db.repositories.user_tools import UserToolsRepository
-from application.storage.db.repositories.users import UsersRepository
 from application.storage.db.session import db_readonly, db_session
-from application.upload_limits import (
-    read_text_upload_limited,
-    upload_limit_message,
-    UploadTooLargeError,
-)
-from application.utils import check_required_fields, validate_function_name
+from application.utils import check_required_fields
 
-tool_config = {}
-tool_manager = ToolManager(config=tool_config)
-
-
-# ---------------------------------------------------------------------------
-# Shape translation helpers
-# ---------------------------------------------------------------------------
-# The frontend speaks camelCase (``displayName`` / ``customName`` /
-# ``configRequirements``). The PG ``user_tools`` table stores snake_case
-# (``display_name`` / ``custom_name`` / ``config_requirements``). Keep the
-# translation localized to this module so repositories stay pure.
-
-_CAMEL_TO_SNAKE = {
-    "displayName": "display_name",
-    "customName": "custom_name",
-    "configRequirements": "config_requirements",
-}
-_SNAKE_TO_CAMEL = {v: k for k, v in _CAMEL_TO_SNAKE.items()}
-
-
-def _row_to_api(row: dict) -> dict:
-    """Rename DB-native snake_case keys to the camelCase shape the frontend expects."""
-    out = dict(row)
-    for snake, camel in _SNAKE_TO_CAMEL.items():
-        if snake in out:
-            out[camel] = out.pop(snake)
-    # ``user_id`` is exposed as ``user`` in the legacy API shape.
-    if "user_id" in out:
-        out["user"] = out.pop("user_id")
-    return out
-
-
-def _api_to_update_fields(data: dict) -> dict:
-    """Rename incoming camelCase update keys to the repo's snake_case columns."""
-    fields_out: dict = {}
-    for key, value in data.items():
-        fields_out[_CAMEL_TO_SNAKE.get(key, key)] = value
-    return fields_out
-
-
-def _encrypt_secret_fields(config, config_requirements, user_id):
-    secret_keys = [
-        key for key, spec in config_requirements.items()
-        if spec.get("secret") and key in config and config[key]
-    ]
-    if not secret_keys:
-        return config
-
-    storage_config = config.copy()
-    secret_values = {k: config[k] for k in secret_keys}
-    storage_config["encrypted_credentials"] = encrypt_credentials(secret_values, user_id)
-    for key in secret_keys:
-        storage_config.pop(key, None)
-    return storage_config
-
-
-def _validate_config(config, config_requirements, has_existing_secrets=False):
-    errors = {}
-    for key, spec in config_requirements.items():
-        depends_on = spec.get("depends_on")
-        if depends_on:
-            if not all(config.get(dk) == dv for dk, dv in depends_on.items()):
-                continue
-        if spec.get("required") and not config.get(key):
-            if has_existing_secrets and spec.get("secret"):
-                continue
-            errors[key] = f"{spec.get('label', key)} is required"
-        value = config.get(key)
-        if value is not None and value != "":
-            if spec.get("type") == "number":
-                try:
-                    num = float(value)
-                    if key == "timeout" and (num < 1 or num > 300):
-                        errors[key] = "Timeout must be between 1 and 300"
-                except (ValueError, TypeError):
-                    errors[key] = f"{spec.get('label', key)} must be a number"
-            if spec.get("enum") and value not in spec["enum"]:
-                errors[key] = f"Invalid value for {spec.get('label', key)}"
-    return errors
-
-
-def _merge_secrets_on_update(new_config, existing_config, config_requirements, user_id):
-    """Merge incoming config with existing encrypted secrets and re-encrypt.
-
-    For updates, the client may omit unchanged secret values.  This helper
-    decrypts any previously stored secrets, overlays whatever the client *did*
-    send, strips plain-text secrets from the stored config, and re-encrypts
-    the merged result.
-
-    Returns the final ``config`` dict ready for persistence.
-    """
-    secret_keys = [
-        key for key, spec in config_requirements.items()
-        if spec.get("secret")
-    ]
-
-    if not secret_keys:
-        return new_config
-
-    existing_secrets = {}
-    if "encrypted_credentials" in existing_config:
-        existing_secrets = decrypt_credentials(
-            existing_config["encrypted_credentials"], user_id
-        )
-
-    merged_secrets = existing_secrets.copy()
-    for key in secret_keys:
-        if key in new_config and new_config[key]:
-            merged_secrets[key] = new_config[key]
-
-    # Start from existing non-secret values, then overlay incoming non-secrets
-    storage_config = {
-        k: v for k, v in existing_config.items()
-        if k not in secret_keys and k != "encrypted_credentials"
-    }
-    storage_config.update(
-        {k: v for k, v in new_config.items() if k not in secret_keys}
-    )
-
-    if merged_secrets:
-        storage_config["encrypted_credentials"] = encrypt_credentials(
-            merged_secrets, user_id
-        )
-    else:
-        storage_config.pop("encrypted_credentials", None)
-
-    storage_config.pop("has_encrypted_credentials", None)
-    return storage_config
+tools_ns = Namespace("tools", description="Tool management operations", path="/api")
 
 
 def transform_actions(actions_metadata):
@@ -177,13 +24,12 @@ def transform_actions(actions_metadata):
         if "parameters" in action:
             props = action["parameters"].get("properties", {})
             for param_details in props.values():
+                if not isinstance(param_details, dict):
+                    continue
                 param_details["filled_by_llm"] = True
                 param_details["value"] = ""
         transformed.append(action)
     return transformed
-
-
-tools_ns = Namespace("tools", description="Tool management operations", path="/api")
 
 
 @tools_ns.route("/available_tools")
@@ -210,821 +56,223 @@ class AvailableTools(Resource):
                         "actions": actions,
                     }
                 )
-        except Exception as err:
-            current_app.logger.error(
-                f"Error getting available tools: {err}", exc_info=True
-            )
-            return make_response(jsonify({"success": False}), 400)
-        return make_response(jsonify({"success": True, "data": tools_metadata}), 200)
+            return make_response(jsonify({"tools": tools_metadata}), 200)
+        except Exception as e:
+            current_app.logger.error(f"Error getting available tools: {e}")
+            return make_response(jsonify({"error": str(e)}), 500)
 
 
-@tools_ns.route("/get_tools")
-class GetTools(Resource):
-    @api.doc(description="Get tools created by a user")
+@tools_ns.route("/tools")
+class UserTools(Resource):
+    @api.doc(description="Get tools for the current user")
     def get(self):
+        decoded_token = request.decoded_token
+        if not decoded_token:
+            return make_response(jsonify({"success": False}), 401)
+        user = decoded_token.get("sub")
         try:
-            decoded_token = request.decoded_token
-            if not decoded_token:
-                return make_response(jsonify({"success": False}), 401)
-            user = decoded_token.get("sub")
             with db_readonly() as conn:
-                tools_repo = UserToolsRepository(conn)
-                rows = tools_repo.list_for_user(user)
-                user_doc = UsersRepository(conn).get(user)
-                owned_ids = {str(r["id"]) for r in rows}
-                # Tools shared with the caller's teams. Secrets are stripped
-                # unconditionally below — a grantee never sees the owner's
-                # credentials (they only run with the owner's creds server-side).
-                team_shared = visible_with_access(conn, user, "tool")
-                shared_ids = [tid for tid in team_shared if tid not in owned_ids]
-                shared_rows = tools_repo.list_by_ids(shared_ids)
-            user_tools = []
+                repo = UserToolsRepository(conn)
+                tools = repo.list_for_user(user)
+            return make_response(jsonify({"tools": tools}), 200)
+        except Exception as e:
+            current_app.logger.error(f"Error getting user tools: {e}")
+            return make_response(jsonify({"error": str(e)}), 500)
 
-            def _shape_tool(row, *, ownership="user", force_strip_secret=False):
-                tool_copy = _row_to_api(row)
-                config_req = tool_copy.get("configRequirements", {})
-                if not config_req:
-                    tool_instance = tool_manager.tools.get(tool_copy.get("name"))
-                    if tool_instance:
-                        config_req = tool_instance.get_config_requirements()
-                        tool_copy["configRequirements"] = config_req
-                has_secrets = any(
-                    spec.get("secret") for spec in config_req.values()
-                ) if config_req else False
-                if (has_secrets or force_strip_secret) and "encrypted_credentials" in tool_copy.get(
-                    "config", {}
-                ):
-                    tool_copy["config"]["has_encrypted_credentials"] = True
-                    tool_copy["config"].pop("encrypted_credentials", None)
-                tool_copy["ownership"] = ownership
-                return tool_copy
-
-            for row in rows:
-                user_tools.append(_shape_tool(row))
-            for row in shared_rows:
-                shaped = _shape_tool(row, ownership="team", force_strip_secret=True)
-                shaped["team_access"] = team_shared.get(str(row["id"]))
-                user_tools.append(shaped)
-
-            # ``scheduler`` is dual-registered (default chat tool + agent-
-            # selectable builtin) and resolves to the same synthetic uuid5 id.
-            # Surface a single row with both flags so the frontend can show it
-            # in the management page (toggle) and the agent picker.
-            seen_ids: set = set()
-            for default_row in default_tools_for_management(user_doc):
-                default_copy = _row_to_api(default_row)
-                default_copy["default"] = True
-                if default_copy.get("name") in BUILTIN_AGENT_TOOLS:
-                    default_copy["builtin"] = True
-                seen_ids.add(str(default_copy["id"]))
-                user_tools.append(default_copy)
-            # Builtins (e.g. scheduler) hidden from Add-Tool catalog, visible
-            # to the agent picker. Skip ones already added via the default
-            # path — both registries share ``_DEFAULT_TOOL_NAMESPACE``.
-            # ``workflow_only`` builtins (e.g. ``read_document``) carry that
-            # flag so the classic picker can hide them and the workflow node
-            # picker can keep them.
-            for builtin_row in builtin_agent_tools_for_management():
-                builtin_copy = _row_to_api(builtin_row)
-                if str(builtin_copy["id"]) in seen_ids:
-                    continue
-                builtin_copy["builtin"] = True
-                builtin_copy["default"] = False
-                builtin_copy["workflow_only"] = (
-                    builtin_copy.get("name") in WORKFLOW_ONLY_BUILTINS
-                )
-                user_tools.append(builtin_copy)
-        except Exception as err:
-            current_app.logger.error(f"Error getting user tools: {err}", exc_info=True)
-            return make_response(jsonify({"success": False}), 400)
-        return make_response(jsonify({"success": True, "tools": user_tools}), 200)
-
-
-@tools_ns.route("/create_tool")
-class CreateTool(Resource):
     @api.expect(
         api.model(
             "CreateToolModel",
             {
-                "name": fields.String(required=True, description="Name of the tool"),
+                "name": fields.String(required=True, description="Tool name"),
                 "displayName": fields.String(
                     required=True, description="Display name for the tool"
                 ),
-                "description": fields.String(
-                    required=True, description="Tool description"
-                ),
-                "config": fields.Raw(
-                    required=True, description="Configuration of the tool"
-                ),
-                "customName": fields.String(
-                    required=False, description="Custom name for the tool"
-                ),
+                "config": fields.Raw(required=True, description="Tool configuration"),
                 "status": fields.Boolean(
-                    required=True, description="Status of the tool"
+                    required=False, default=True, description="Tool status"
                 ),
             },
         )
     )
-    @api.doc(description="Create a new tool")
+    @api.doc(description="Create a new tool for the current user")
     def post(self):
         decoded_token = request.decoded_token
         if not decoded_token:
             return make_response(jsonify({"success": False}), 401)
         user = decoded_token.get("sub")
         data = request.get_json()
-        required_fields = [
-            "name",
-            "displayName",
-            "description",
-            "config",
-            "status",
-        ]
+
+        required_fields = ["name", "displayName", "config"]
         missing_fields = check_required_fields(data, required_fields)
         if missing_fields:
             return missing_fields
+
+        tool_name = data["name"]
+        if tool_name not in tool_manager.tools:
+            return make_response(
+                jsonify({"success": False, "error": f"Tool {tool_name} not found"}),
+                404,
+            )
+
         try:
-            if data["name"] == "mcp_tool":
-                server_url = (data.get("config", {}).get("server_url") or "").strip()
-                if server_url:
-                    try:
-                        validate_url(server_url)
-                    except SSRFError:
-                        return make_response(
-                            jsonify({"success": False, "message": "Invalid server URL"}),
-                            400,
-                        )
-            tool_instance = tool_manager.tools.get(data["name"])
-            if not tool_instance:
-                return make_response(
-                    jsonify({"success": False, "message": "Tool not found"}), 404
-                )
+            tool_instance = tool_manager.tools[tool_name]
+            config = data["config"]
             actions_metadata = tool_instance.get_actions_metadata()
             transformed_actions = transform_actions(actions_metadata)
-        except Exception as err:
-            current_app.logger.error(
-                f"Error getting tool actions: {err}", exc_info=True
-            )
-            return make_response(jsonify({"success": False}), 400)
-        try:
-            config_requirements = tool_instance.get_config_requirements()
-            if config_requirements:
-                validation_errors = _validate_config(
-                    data["config"], config_requirements
-                )
-                if validation_errors:
-                    return make_response(
-                        jsonify(
-                            {
-                                "success": False,
-                                "message": "Validation failed",
-                                "errors": validation_errors,
-                            }
-                        ),
-                        400,
-                    )
-            storage_config = _encrypt_secret_fields(
-                data["config"], config_requirements, user
-            )
+
+            display_name = data["displayName"]
+            description = data.get("description", "")
+            status_bool = bool(data.get("status", True))
+
             with db_session() as conn:
-                created = UserToolsRepository(conn).create(
+                repo = UserToolsRepository(conn)
+                created = repo.create(
                     user,
-                    data["name"],
-                    config=storage_config,
-                    custom_name=data.get("customName", ""),
-                    display_name=data["displayName"],
-                    description=data["description"],
-                    config_requirements=config_requirements,
+                    tool_name,
+                    config=config,
+                    custom_name=display_name,
+                    display_name=display_name,
+                    description=description,
+                    config_requirements=tool_instance.get_config_requirements(),
                     actions=transformed_actions,
-                    status=bool(data.get("status", True)),
+                    status=status_bool,
                 )
-            new_id = str(created["id"])
-        except Exception as err:
-            current_app.logger.error(f"Error creating tool: {err}", exc_info=True)
-            return make_response(jsonify({"success": False}), 400)
-        return make_response(jsonify({"id": new_id}), 200)
-
-
-@tools_ns.route("/update_tool")
-class UpdateTool(Resource):
-    @api.expect(
-        api.model(
-            "UpdateToolModel",
-            {
-                "id": fields.String(required=True, description="Tool ID"),
-                "name": fields.String(description="Name of the tool"),
-                "displayName": fields.String(description="Display name for the tool"),
-                "customName": fields.String(description="Custom name for the tool"),
-                "description": fields.String(description="Tool description"),
-                "config": fields.Raw(description="Configuration of the tool"),
-                "actions": fields.List(
-                    fields.Raw, description="Actions the tool can perform"
-                ),
-                "status": fields.Boolean(description="Status of the tool"),
-            },
-        )
-    )
-    @api.doc(description="Update a tool by ID")
-    def post(self):
-        decoded_token = request.decoded_token
-        if not decoded_token:
-            return make_response(jsonify({"success": False}), 401)
-        user = decoded_token.get("sub")
-        data = request.get_json()
-        required_fields = ["id"]
-        missing_fields = check_required_fields(data, required_fields)
-        if missing_fields:
-            return missing_fields
-        # Default-tool branch first: a dual-registered tool (e.g. ``scheduler``)
-        # matches BOTH ``is_default_tool_id`` and ``is_builtin_agent_tool_id``.
-        # The toggle in Tools settings is the per-user opt-out for the
-        # agentless default — it must reach the ``set_default_tool_enabled``
-        # path, not the builtin "not editable" reject.
-        if is_default_tool_id(data["id"]):
-            if "status" not in data:
-                return make_response(
-                    jsonify(
-                        {
-                            "success": False,
-                            "message": "Default tools are not editable; "
-                            "only their on/off status can be changed.",
-                        }
-                    ),
-                    400,
-                )
-            tool_name = default_tool_name_for_id(data["id"])
-            try:
-                with db_session() as conn:
-                    UsersRepository(conn).set_default_tool_enabled(
-                        user, tool_name, bool(data["status"])
-                    )
-            except Exception as err:
-                current_app.logger.error(
-                    f"Error updating default tool: {err}", exc_info=True
-                )
-                return make_response(jsonify({"success": False}), 400)
-            return make_response(jsonify({"success": True}), 200)
-        if is_builtin_agent_tool_id(data["id"]):
-            return make_response(
-                jsonify(
-                    {
-                        "success": False,
-                        "message": "Built-in agent tools are not editable; "
-                        "add them to an agent via the agent picker.",
-                    }
-                ),
-                400,
-            )
-        try:
-            update_data: dict = {}
-            for key in ("name", "displayName", "customName", "description", "actions"):
-                if key in data:
-                    update_data[key] = data[key]
-            if "config" in data:
-                if "actions" in data["config"]:
-                    for action_name in list(data["config"]["actions"].keys()):
-                        if not validate_function_name(action_name):
-                            return make_response(
-                                jsonify(
-                                    {
-                                        "success": False,
-                                        "message": f"Invalid function name '{action_name}'. Function names must match pattern '^[a-zA-Z0-9_-]+$'.",
-                                        "param": "tools[].function.name",
-                                    }
-                                ),
-                                400,
-                            )
-                with db_session() as conn:
-                    repo = UserToolsRepository(conn)
-                    tool_doc = repo.get_any(data["id"], user)
-                    if not tool_doc:
-                        return make_response(
-                            jsonify({"success": False, "message": "Tool not found"}),
-                            404,
-                        )
-                    tool_name = tool_doc.get("name", data.get("name"))
-                    tool_instance = tool_manager.tools.get(tool_name)
-                    config_requirements = (
-                        tool_instance.get_config_requirements()
-                        if tool_instance
-                        else {}
-                    )
-                    existing_config = tool_doc.get("config", {}) or {}
-                    has_existing_secrets = "encrypted_credentials" in existing_config
-
-                    if config_requirements:
-                        validation_errors = _validate_config(
-                            data["config"], config_requirements,
-                            has_existing_secrets=has_existing_secrets,
-                        )
-                        if validation_errors:
-                            return make_response(
-                                jsonify({
-                                    "success": False,
-                                    "message": "Validation failed",
-                                    "errors": validation_errors,
-                                }),
-                                400,
-                            )
-
-                    update_data["config"] = _merge_secrets_on_update(
-                        data["config"], existing_config, config_requirements, user
-                    )
-                    if "status" in data:
-                        update_data["status"] = bool(data["status"])
-                    repo.update(
-                        str(tool_doc["id"]), user, _api_to_update_fields(update_data),
-                    )
-            else:
-                if "status" in data:
-                    update_data["status"] = bool(data["status"])
-                with db_session() as conn:
-                    repo = UserToolsRepository(conn)
-                    tool_doc = repo.get_any(data["id"], user)
-                    if not tool_doc:
-                        return make_response(
-                            jsonify({"success": False, "message": "Tool not found"}),
-                            404,
-                        )
-                    repo.update(
-                        str(tool_doc["id"]), user, _api_to_update_fields(update_data),
-                    )
-        except Exception as err:
-            current_app.logger.error(f"Error updating tool: {err}", exc_info=True)
-            return make_response(jsonify({"success": False}), 400)
-        return make_response(jsonify({"success": True}), 200)
-
-
-@tools_ns.route("/update_tool_config")
-class UpdateToolConfig(Resource):
-    @api.expect(
-        api.model(
-            "UpdateToolConfigModel",
-            {
-                "id": fields.String(required=True, description="Tool ID"),
-                "config": fields.Raw(
-                    required=True, description="Configuration of the tool"
-                ),
-            },
-        )
-    )
-    @api.doc(description="Update the configuration of a tool")
-    def post(self):
-        decoded_token = request.decoded_token
-        if not decoded_token:
-            return make_response(jsonify({"success": False}), 401)
-        user = decoded_token.get("sub")
-        data = request.get_json()
-        required_fields = ["id", "config"]
-        missing_fields = check_required_fields(data, required_fields)
-        if missing_fields:
-            return missing_fields
-        if is_synthesized_tool_id(data["id"]):
-            return make_response(
-                jsonify(
-                    {
-                        "success": False,
-                        "message": "Default and built-in tools are config-free "
-                        "and cannot be configured.",
-                    }
-                ),
-                400,
-            )
-        try:
-            with db_session() as conn:
-                repo = UserToolsRepository(conn)
-                tool_doc = repo.get_any(data["id"], user)
-                if not tool_doc:
-                    return make_response(jsonify({"success": False}), 404)
-
-                tool_name = tool_doc.get("name")
-                if tool_name == "mcp_tool":
-                    server_url = (data["config"].get("server_url") or "").strip()
-                    if server_url:
-                        try:
-                            validate_url(server_url)
-                        except SSRFError:
-                            return make_response(
-                                jsonify({"success": False, "message": "Invalid server URL"}),
-                                400,
-                            )
-                tool_instance = tool_manager.tools.get(tool_name)
-                config_requirements = (
-                    tool_instance.get_config_requirements() if tool_instance else {}
-                )
-                existing_config = tool_doc.get("config", {}) or {}
-                has_existing_secrets = "encrypted_credentials" in existing_config
-
-                if config_requirements:
-                    validation_errors = _validate_config(
-                        data["config"], config_requirements,
-                        has_existing_secrets=has_existing_secrets,
-                    )
-                    if validation_errors:
-                        return make_response(
-                            jsonify({
-                                "success": False,
-                                "message": "Validation failed",
-                                "errors": validation_errors,
-                            }),
-                            400,
-                        )
-
-                final_config = _merge_secrets_on_update(
-                    data["config"], existing_config, config_requirements, user
-                )
-
-                repo.update(str(tool_doc["id"]), user, {"config": final_config})
-        except Exception as err:
-            current_app.logger.error(
-                f"Error updating tool config: {err}", exc_info=True
-            )
-            return make_response(jsonify({"success": False}), 400)
-        return make_response(jsonify({"success": True}), 200)
-
-
-@tools_ns.route("/update_tool_actions")
-class UpdateToolActions(Resource):
-    @api.expect(
-        api.model(
-            "UpdateToolActionsModel",
-            {
-                "id": fields.String(required=True, description="Tool ID"),
-                "actions": fields.List(
-                    fields.Raw,
-                    required=True,
-                    description="Actions the tool can perform",
-                ),
-            },
-        )
-    )
-    @api.doc(description="Update the actions of a tool")
-    def post(self):
-        decoded_token = request.decoded_token
-        if not decoded_token:
-            return make_response(jsonify({"success": False}), 401)
-        user = decoded_token.get("sub")
-        data = request.get_json()
-        required_fields = ["id", "actions"]
-        missing_fields = check_required_fields(data, required_fields)
-        if missing_fields:
-            return missing_fields
-        if is_synthesized_tool_id(data["id"]):
-            return make_response(
-                jsonify(
-                    {
-                        "success": False,
-                        "message": "Default and built-in tools' actions are not editable.",
-                    }
-                ),
-                400,
-            )
-        try:
-            with db_session() as conn:
-                repo = UserToolsRepository(conn)
-                tool_doc = repo.get_any(data["id"], user)
-                if tool_doc:
-                    repo.update(str(tool_doc["id"]), user, {"actions": data["actions"]})
-                else:
-                    # Team editor write path (secrets stay owner-only — actions
-                    # carry no credentials, so editing them is safe).
-                    owner = effective_write_owner(conn, "tool", data["id"], user)
-                    if not owner:
-                        return make_response(
-                            jsonify({"success": False, "message": "Tool not found"}),
-                            404,
-                        )
-                    repo.update(data["id"], owner, {"actions": data["actions"]})
-        except Exception as err:
-            current_app.logger.error(
-                f"Error updating tool actions: {err}", exc_info=True
-            )
-            return make_response(jsonify({"success": False}), 400)
-        return make_response(jsonify({"success": True}), 200)
-
-
-@tools_ns.route("/update_tool_status")
-class UpdateToolStatus(Resource):
-    @api.expect(
-        api.model(
-            "UpdateToolStatusModel",
-            {
-                "id": fields.String(required=True, description="Tool ID"),
-                "status": fields.Boolean(
-                    required=True, description="Status of the tool"
-                ),
-            },
-        )
-    )
-    @api.doc(description="Update the status of a tool")
-    def post(self):
-        decoded_token = request.decoded_token
-        if not decoded_token:
-            return make_response(jsonify({"success": False}), 401)
-        user = decoded_token.get("sub")
-        data = request.get_json()
-        required_fields = ["id", "status"]
-        missing_fields = check_required_fields(data, required_fields)
-        if missing_fields:
-            return missing_fields
-        try:
-            # Default branch first so a dual-registered id (e.g. ``scheduler``)
-            # writes the per-user opt-out instead of being rejected as a
-            # not-editable builtin (both predicates match the same uuid5).
-            if is_default_tool_id(data["id"]):
-                tool_name = default_tool_name_for_id(data["id"])
-                with db_session() as conn:
-                    UsersRepository(conn).set_default_tool_enabled(
-                        user, tool_name, bool(data["status"])
-                    )
-                return make_response(jsonify({"success": True}), 200)
-            if is_builtin_agent_tool_id(data["id"]):
-                return make_response(
-                    jsonify(
-                        {
-                            "success": False,
-                            "message": "Built-in agent tools have no per-user "
-                            "toggle; add them to an agent via the agent picker.",
-                        }
-                    ),
-                    400,
-                )
-            with db_session() as conn:
-                repo = UserToolsRepository(conn)
-                tool_doc = repo.get_any(data["id"], user)
-                if not tool_doc:
-                    return make_response(
-                        jsonify({"success": False, "message": "Tool not found"}),
-                        404,
-                    )
-                repo.update(
-                    str(tool_doc["id"]), user, {"status": bool(data["status"])},
-                )
-        except Exception as err:
-            current_app.logger.error(
-                f"Error updating tool status: {err}", exc_info=True
-            )
-            return make_response(jsonify({"success": False}), 400)
-        return make_response(jsonify({"success": True}), 200)
-
-
-@tools_ns.route("/delete_tool")
-class DeleteTool(Resource):
-    @api.expect(
-        api.model(
-            "DeleteToolModel",
-            {"id": fields.String(required=True, description="Tool ID")},
-        )
-    )
-    @api.doc(description="Delete a tool by ID")
-    def post(self):
-        decoded_token = request.decoded_token
-        if not decoded_token:
-            return make_response(jsonify({"success": False}), 401)
-        user = decoded_token.get("sub")
-        data = request.get_json()
-        required_fields = ["id"]
-        missing_fields = check_required_fields(data, required_fields)
-        if missing_fields:
-            return missing_fields
-        if is_synthesized_tool_id(data["id"]):
-            return make_response(
-                jsonify(
-                    {
-                        "success": False,
-                        "message": "Built-in tools cannot be deleted; disable them instead.",
-                    }
-                ),
-                400,
-            )
-        try:
-            with db_session() as conn:
-                repo = UserToolsRepository(conn)
-                tool_doc = repo.get_any(data["id"], user)
-                if not tool_doc:
-                    return make_response(
-                        jsonify({"success": False, "message": "Tool not found"}), 404
-                    )
-                repo.delete(str(tool_doc["id"]), user)
-        except Exception as err:
-            current_app.logger.error(f"Error deleting tool: {err}", exc_info=True)
-            return make_response(jsonify({"success": False}), 400)
-        return make_response(jsonify({"success": True}), 200)
-
-
-@tools_ns.route("/parse_spec")
-class ParseSpec(Resource):
-    @api.doc(
-        description="Parse an API specification (OpenAPI 3.x or Swagger 2.0) and return actions"
-    )
-    def post(self):
-        decoded_token = request.decoded_token
-        if not decoded_token:
-            return make_response(jsonify({"success": False}), 401)
-        if "file" in request.files:
-            file = request.files["file"]
-            if not file.filename:
-                return make_response(
-                    jsonify({"success": False, "message": "No file selected"}), 400
-                )
-            try:
-                spec_content = read_text_upload_limited(
-                    file, max_bytes=settings.PARSE_SPEC_MAX_BYTES
-                )
-            except UploadTooLargeError:
-                return make_response(
-                    jsonify(
-                        {
-                            "success": False,
-                            "message": upload_limit_message(
-                                settings.PARSE_SPEC_MAX_BYTES
-                            ),
-                        }
-                    ),
-                    413,
-                )
-            except UnicodeDecodeError:
-                return make_response(
-                    jsonify({"success": False, "message": "Invalid file encoding"}), 400
-                )
-        elif request.is_json:
-            data = request.get_json()
-            spec_content = data.get("spec_content", "")
-        else:
-            return make_response(
-                jsonify({"success": False, "message": "No spec provided"}), 400
-            )
-        if (
-            not isinstance(spec_content, str)
-            or len(spec_content.encode("utf-8")) > settings.PARSE_SPEC_MAX_BYTES
-        ):
-            return make_response(
-                jsonify(
-                    {
-                        "success": False,
-                        "message": upload_limit_message(
-                            settings.PARSE_SPEC_MAX_BYTES
-                        ),
-                    }
-                ),
-                413,
-            )
-        if not spec_content or not spec_content.strip():
-            return make_response(
-                jsonify({"success": False, "message": "Empty spec content"}), 400
-            )
-        try:
-            metadata, actions = parse_spec(spec_content)
             return make_response(
                 jsonify(
                     {
                         "success": True,
-                        "metadata": metadata,
-                        "actions": actions,
+                        "id": str(created["id"]),
+                        "message": "Tool created successfully",
                     }
                 ),
                 200,
             )
-        except ValueError as e:
-            current_app.logger.error(f"Spec validation error: {e}")
-            return make_response(jsonify({"success": False, "error": "Invalid specification format"}), 400)
-        except Exception as err:
-            current_app.logger.error(f"Error parsing spec: {err}", exc_info=True)
-            return make_response(jsonify({"success": False, "error": "Failed to parse specification"}), 500)
+        except Exception as e:
+            current_app.logger.error(f"Error creating tool: {e}", exc_info=True)
+            return make_response(
+                jsonify({"success": False, "error": "Failed to create tool"}), 500
+            )
 
 
-@tools_ns.route("/artifact/<artifact_id>")
-class GetArtifact(Resource):
-    @api.doc(description="Get artifact data by artifact ID. Returns all todos for the tool when fetching a todo artifact.")
-    def get(self, artifact_id: str):
+@tools_ns.route("/tools/<string:tool_id>")
+class UserTool(Resource):
+    @api.doc(description="Get a specific tool")
+    def get(self, tool_id):
         decoded_token = request.decoded_token
         if not decoded_token:
             return make_response(jsonify({"success": False}), 401)
-        user_id = decoded_token.get("sub")
-
+        user = decoded_token.get("sub")
         try:
             with db_readonly() as conn:
-                notes_repo = NotesRepository(conn)
-                todos_repo = TodosRepository(conn)
+                repo = UserToolsRepository(conn)
+                tool = repo.get(tool_id, user)
+            if not tool:
+                return make_response(
+                    jsonify({"success": False, "error": "Tool not found"}), 404
+                )
+            return make_response(jsonify(tool), 200)
+        except Exception as e:
+            current_app.logger.error(f"Error getting tool: {e}")
+            return make_response(jsonify({"error": str(e)}), 500)
 
-                # Artifact IDs may be PG UUIDs (post-cutover) or legacy
-                # Mongo ObjectIds embedded in older conversation history.
-                # Both repos' ``get_any`` handles the id-shape branching
-                # internally so a non-UUID input never reaches
-                # ``CAST(:id AS uuid)`` (which would poison the readonly
-                # transaction and break the fallback below).
-                note_doc = notes_repo.get_any(artifact_id, user_id)
+    @api.doc(description="Update a tool")
+    def put(self, tool_id):
+        decoded_token = request.decoded_token
+        if not decoded_token:
+            return make_response(jsonify({"success": False}), 401)
+        user = decoded_token.get("sub")
+        data = request.get_json()
+        try:
+            update_data = {}
+            if "displayName" in data:
+                update_data["display_name"] = data["displayName"]
+                update_data["custom_name"] = data["displayName"]
+            if "config" in data:
+                update_data["config"] = data["config"]
+            if "status" in data:
+                update_data["status"] = bool(data["status"])
+            if "actions" in data:
+                update_data["actions"] = data["actions"]
 
-                if note_doc:
-                    content = note_doc.get("note", "") or note_doc.get("content", "")
-                    line_count = len(content.split("\n")) if content else 0
-                    updated = note_doc.get("updated_at")
-                    artifact = {
-                        "artifact_type": "note",
-                        "data": {
-                            "content": content,
-                            "line_count": line_count,
-                            "updated_at": (
-                                updated.isoformat()
-                                if hasattr(updated, "isoformat")
-                                else updated
-                            ),
-                        },
-                    }
+            with db_session() as conn:
+                repo = UserToolsRepository(conn)
+                tool = repo.get(tool_id, user)
+                if not tool:
                     return make_response(
-                        jsonify({"success": True, "artifact": artifact}), 200
+                        jsonify({"success": False, "error": "Tool not found"}), 404
                     )
 
-                todo_doc = todos_repo.get_any(artifact_id, user_id)
-                if todo_doc:
-                    tool_id = todo_doc.get("tool_id")
-                    all_todos = todos_repo.list_for_tool(user_id, tool_id) if tool_id else []
-                    items = []
-                    open_count = 0
-                    completed_count = 0
-                    for t in all_todos:
-                        # PG ``todos`` stores a ``completed BOOLEAN`` column;
-                        # the legacy Mongo shape used a ``status`` string.
-                        # Keep the response shape stable by translating here.
-                        status = "completed" if t.get("completed") else "open"
-                        if status == "open":
-                            open_count += 1
-                        else:
-                            completed_count += 1
-                        created = t.get("created_at")
-                        updated = t.get("updated_at")
-                        items.append({
-                            "todo_id": t.get("todo_id"),
-                            "title": t.get("title", ""),
-                            "status": status,
-                            "created_at": (
-                                created.isoformat()
-                                if hasattr(created, "isoformat")
-                                else created
-                            ),
-                            "updated_at": (
-                                updated.isoformat()
-                                if hasattr(updated, "isoformat")
-                                else updated
-                            ),
-                        })
-                    artifact = {
-                        "artifact_type": "todo_list",
-                        "data": {
-                            "items": items,
-                            "total_count": len(items),
-                            "open_count": open_count,
-                            "completed_count": completed_count,
-                        },
-                    }
-                    return make_response(
-                        jsonify({"success": True, "artifact": artifact}), 200
-                    )
+                if "config" in data and tool.get("name") in tool_manager.tools:
+                    tool_instance = tool_manager.tools[tool["name"]]
+                    actions_metadata = tool_instance.get_actions_metadata()
+                    update_data["actions"] = transform_actions(actions_metadata)
 
-                # Generalized document/file artifacts live in the
-                # ``artifacts`` store, authorized by their parent (not user_id).
-                # Shape-gate the UUID lookup so a non-UUID id (legacy note/todo
-                # ObjectId already handled above) never reaches the CAST that
-                # would poison this read-only transaction.
-                artifact_doc = None
-                if looks_like_uuid(artifact_id):
-                    artifacts_repo = ArtifactsRepository(conn)
-                    artifact_doc = artifacts_repo.get_artifact(artifact_id)
-                if artifact_doc and authorize_artifact(
-                    conn, artifact_doc, Principal(user_id=user_id)
-                ):
-                    current = artifacts_repo.get_version(
-                        artifact_id, artifact_doc.get("current_version")
-                    )
-                    artifact = {
-                        "artifact_type": (
-                            "document"
-                            if artifact_doc.get("kind") != "file"
-                            else "file"
-                        ),
-                        "data": {
-                            "id": str(artifact_doc.get("id")),
-                            "kind": artifact_doc.get("kind"),
-                            "title": artifact_doc.get("title"),
-                            "current_version": artifact_doc.get("current_version"),
-                            "mime_type": current.get("mime_type") if current else None,
-                            "filename": current.get("filename") if current else None,
-                            "size": current.get("size") if current else None,
-                            "download_url": (
-                                f"/api/artifacts/{artifact_id}/download"
-                                if current and current.get("storage_path")
-                                else None
-                            ),
-                        },
-                    }
-                    return make_response(
-                        jsonify({"success": True, "artifact": artifact}), 200
-                    )
-        except Exception as err:
-            current_app.logger.error(
-                f"Error retrieving artifact: {err}", exc_info=True
+                repo.update(tool_id, user, update_data)
+
+            return make_response(
+                jsonify({"success": True, "message": "Tool updated successfully"}), 200
             )
-            return make_response(jsonify({"success": False}), 400)
+        except Exception as e:
+            current_app.logger.error(f"Error updating tool: {e}", exc_info=True)
+            return make_response(
+                jsonify({"success": False, "error": "Failed to update tool"}), 500
+            )
 
-        return make_response(
-            jsonify({"success": False, "message": "Artifact not found"}), 404
-        )
+    @api.doc(description="Delete a tool")
+    def delete(self, tool_id):
+        decoded_token = request.decoded_token
+        if not decoded_token:
+            return make_response(jsonify({"success": False}), 401)
+        user = decoded_token.get("sub")
+        try:
+            with db_session() as conn:
+                repo = UserToolsRepository(conn)
+                tool = repo.get(tool_id, user)
+                if not tool:
+                    return make_response(
+                        jsonify({"success": False, "error": "Tool not found"}), 404
+                    )
+                repo.delete(tool_id, user)
+            return make_response(
+                jsonify({"success": True, "message": "Tool deleted successfully"}), 200
+            )
+        except Exception as e:
+            current_app.logger.error(f"Error deleting tool: {e}", exc_info=True)
+            return make_response(
+                jsonify({"success": False, "error": "Failed to delete tool"}), 500
+            )
+
+
+@tools_ns.route("/tools/<string:tool_id>/toggle")
+class ToggleTool(Resource):
+    @api.doc(description="Toggle tool status")
+    def post(self, tool_id):
+        decoded_token = request.decoded_token
+        if not decoded_token:
+            return make_response(jsonify({"success": False}), 401)
+        user = decoded_token.get("sub")
+        try:
+            with db_session() as conn:
+                repo = UserToolsRepository(conn)
+                tool = repo.get(tool_id, user)
+                if not tool:
+                    return make_response(
+                        jsonify({"success": False, "error": "Tool not found"}), 404
+                    )
+                new_status = not bool(tool.get("status", True))
+                repo.update(tool_id, user, {"status": new_status})
+            return make_response(
+                jsonify(
+                    {
+                        "success": True,
+                        "status": new_status,
+                        "message": f"Tool {'enabled' if new_status else 'disabled'} successfully",
+                    }
+                ),
+                200,
+            )
+        except Exception as e:
+            current_app.logger.error(f"Error toggling tool: {e}", exc_info=True)
+            return make_response(
+                jsonify({"success": False, "error": "Failed to toggle tool"}), 500
+            )

--- a/application/api/user/tools/routes.py
+++ b/application/api/user/tools/routes.py
@@ -1,7 +1,7 @@
 """Tool management routes."""
 
 from flask import current_app, jsonify, make_response, request
-from flask_restx import Namespace, Resource, fields
+from flask_restx import fields, Namespace, Resource
 
 from application.agents.tools import tool_manager
 from application.api import api
@@ -10,6 +10,21 @@ from application.storage.db.session import db_readonly, db_session
 from application.utils import check_required_fields
 
 tools_ns = Namespace("tools", description="Tool management operations", path="/api")
+
+
+def _strip_sensitive_config(config: dict) -> dict:
+    """Remove sensitive fields from a tool config before returning it to the client."""
+    sensitive_fields = [
+        "api_key",
+        "bearer_token",
+        "username",
+        "password",
+        "api_key_header",
+        "encrypted_credentials",
+        "oauth_task_id",
+        "redirect_uri",
+    ]
+    return {k: v for k, v in config.items() if k not in sensitive_fields}
 
 
 def transform_actions(actions_metadata):
@@ -74,7 +89,13 @@ class UserTools(Resource):
             with db_readonly() as conn:
                 repo = UserToolsRepository(conn)
                 tools = repo.list_for_user(user)
-            return make_response(jsonify({"tools": tools}), 200)
+            safe_tools = []
+            for tool in tools:
+                safe_tool = dict(tool)
+                if "config" in safe_tool and isinstance(safe_tool["config"], dict):
+                    safe_tool["config"] = _strip_sensitive_config(safe_tool["config"])
+                safe_tools.append(safe_tool)
+            return make_response(jsonify({"tools": safe_tools}), 200)
         except Exception as e:
             current_app.logger.error(f"Error getting user tools: {e}")
             return make_response(jsonify({"error": str(e)}), 500)
@@ -170,7 +191,10 @@ class UserTool(Resource):
                 return make_response(
                     jsonify({"success": False, "error": "Tool not found"}), 404
                 )
-            return make_response(jsonify(tool), 200)
+            safe_tool = dict(tool)
+            if "config" in safe_tool and isinstance(safe_tool["config"], dict):
+                safe_tool["config"] = _strip_sensitive_config(safe_tool["config"])
+            return make_response(jsonify(safe_tool), 200)
         except Exception as e:
             current_app.logger.error(f"Error getting tool: {e}")
             return make_response(jsonify({"error": str(e)}), 500)


### PR DESCRIPTION
Part of #2702 (defect 4).

## Problem

When an MCP tool declares an empty-argument `inputSchema` (`{"type": "object"}`, no `properties` key), `get_actions_metadata` stored the whole schema as the `properties` value, producing `{"type": "object"}` — where `"type"` maps to the **string** `"object"`, not a dict.

Two functions then crashed on that stored data:

**`transform_actions`** (save path):
```python
for param_details in props.values():
    param_details["filled_by_llm"] = True  # TypeError: 'str' does not support item assignment
```
→ UI: **"Failed to save MCP server"**

**`_build_tool_parameters`** (chat path):
```python
if v.get("filled_by_llm", True):  # AttributeError: 'str' has no attribute 'get'
```
→ UI: **"Please try again later"**

## Fix

Add `if not isinstance(v, dict): continue` before the first attribute access in both functions. Non-dict property entries are silently skipped — they carry no `filled_by_llm` / `value` annotation and cannot be forwarded to the LLM as typed parameters anyway.

Note: defect 3 (PR #2715) prevents this schema from being stored malformed going forward, but the guard here makes both paths safe against any existing stored data and future edge cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RESTful endpoints for browsing available tools, managing user tools, updating tool details, toggling tool status, and deleting tools.
  * Added filtering to prevent sensitive tool configuration from being exposed.
  * Tool execution now supports resolved tools, approval checks, guardrail scanning, and structured result responses.

* **Bug Fixes**
  * Improved handling of tool action metadata by skipping invalid non-dictionary parameters.
  * Standardized authentication, repository access, logging, and error responses for tool management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->