### PR TITLE
fix(db): normalize PostgreSQL URI schemes case-insensitively

### DIFF
--- a/application/core/db_uri.py
+++ b/application/core/db_uri.py
@@ -28,9 +28,9 @@ def _rewrite_uri_prefixes(v, rewrites):
     """Shared URI prefix rewriter used by both normalizers below.
 
     Strips whitespace, returns ``None`` for empty / ``"none"`` values,
-    applies the first matching rewrite, and passes unrecognised input
-    through so downstream consumers (SQLAlchemy, libpq) can produce
-    their own error messages rather than us silently eating a
+    applies the first matching rewrite (case-insensitively on the scheme prefix),
+    and passes unrecognised input through so downstream consumers (SQLAlchemy, libpq)
+    can produce their own error messages rather than us silently eating a
     misconfiguration.
     """
     if v is None:
@@ -40,9 +40,10 @@ def _rewrite_uri_prefixes(v, rewrites):
     v = v.strip()
     if not v or v.lower() == "none":
         return None
+    v_lower = v.lower()
     for prefix, target in rewrites:
-        if v.startswith(prefix):
-            return target + v[len(prefix):]
+        if v_lower.startswith(prefix.lower()):
+            return target + v[len(prefix) :]
     return v
 
 
@@ -51,6 +52,7 @@ def _rewrite_uri_prefixes(v, rewrites):
 # operator-friendly forms TOWARD that dialect.
 _POSTGRES_URI_REWRITES = (
     ("postgresql+psycopg2://", "postgresql+psycopg://"),
+    ("postgresql+psycopg://", "postgresql+psycopg://"),
     ("postgresql://", "postgresql+psycopg://"),
     ("postgres://", "postgresql+psycopg://"),
 )
@@ -64,6 +66,8 @@ _POSTGRES_URI_REWRITES = (
 _PGVECTOR_CONNECTION_STRING_REWRITES = (
     ("postgresql+psycopg2://", "postgresql://"),
     ("postgresql+psycopg://", "postgresql://"),
+    ("postgresql://", "postgresql://"),
+    ("postgres://", "postgres://"),
 )
 
 

--- a/tests/core/test_db_uri.py
+++ b/tests/core/test_db_uri.py
@@ -49,14 +49,47 @@ class TestNormalizePostgresUri:
                 "postgresql+psycopg://u:p@h:5432/d",
                 "postgresql+psycopg://u:p@h:5432/d",
             ),
+            # Case-insensitive scheme rewriting.
+            (
+                "POSTGRESQL://u:p@h:5432/d",
+                "postgresql+psycopg://u:p@h:5432/d",
+            ),
+            (
+                "POSTGRES://u:p@h:5432/d",
+                "postgresql+psycopg://u:p@h:5432/d",
+            ),
+            (
+                "PostgreSQL://u:p@h:5432/d",
+                "postgresql+psycopg://u:p@h:5432/d",
+            ),
+            (
+                "Postgres://u:p@h:5432/d",
+                "postgresql+psycopg://u:p@h:5432/d",
+            ),
+            (
+                "POSTGRESQL+PSYCOPG2://u:p@h:5432/d",
+                "postgresql+psycopg://u:p@h:5432/d",
+            ),
+            (
+                "POSTGRESQL+PSYCOPG://u:p@h:5432/d",
+                "postgresql+psycopg://u:p@h:5432/d",
+            ),
             # Whitespace is trimmed before rewriting.
             (
                 "  postgres://u:p@h/d  ",
                 "postgresql+psycopg://u:p@h/d",
             ),
+            (
+                "  POSTGRESQL://u:p@h/d  ",
+                "postgresql+psycopg://u:p@h/d",
+            ),
             # Query-string params (sslmode, options) are preserved verbatim.
             (
                 "postgresql://u:p@h:5432/d?sslmode=require&application_name=docsgpt",
+                "postgresql+psycopg://u:p@h:5432/d?sslmode=require&application_name=docsgpt",
+            ),
+            (
+                "POSTGRESQL://u:p@h:5432/d?sslmode=require&application_name=docsgpt",
                 "postgresql+psycopg://u:p@h:5432/d?sslmode=require&application_name=docsgpt",
             ),
         ],
@@ -112,14 +145,43 @@ class TestNormalizePgvectorConnectionString:
                 "postgresql+psycopg2://u:p@h:5432/d",
                 "postgresql://u:p@h:5432/d",
             ),
+            # Case-insensitive scheme rewriting.
+            (
+                "POSTGRESQL://u:p@h:5432/d",
+                "postgresql://u:p@h:5432/d",
+            ),
+            (
+                "POSTGRES://u:p@h:5432/d",
+                "postgres://u:p@h:5432/d",
+            ),
+            (
+                "PostgreSQL://u:p@h:5432/d",
+                "postgresql://u:p@h:5432/d",
+            ),
+            (
+                "POSTGRESQL+PSYCOPG://u:p@h:5432/d",
+                "postgresql://u:p@h:5432/d",
+            ),
+            (
+                "POSTGRESQL+PSYCOPG2://u:p@h:5432/d",
+                "postgresql://u:p@h:5432/d",
+            ),
             # Whitespace is trimmed before rewriting.
             (
                 "  postgresql+psycopg://u:p@h/d  ",
                 "postgresql://u:p@h/d",
             ),
+            (
+                "  POSTGRESQL+PSYCOPG://u:p@h/d  ",
+                "postgresql://u:p@h/d",
+            ),
             # Query-string params (sslmode, etc.) are preserved verbatim.
             (
                 "postgresql+psycopg://u:p@h:5432/d?sslmode=require",
+                "postgresql://u:p@h:5432/d?sslmode=require",
+            ),
+            (
+                "POSTGRESQL+PSYCOPG://u:p@h:5432/d?sslmode=require",
                 "postgresql://u:p@h:5432/d?sslmode=require",
             ),
         ],


### PR DESCRIPTION
Fixes #2694

### Summary
- Make Postgres URI scheme matching case-insensitive in `application/core/db_uri.py`.
- Normalize uppercase and mixed-case schemes (such as `POSTGRESQL://`, `POSTGRES://`, `POSTGRESQL+PSYCOPG://`, `POSTGRESQL+PSYCOPG2://`) to lowercase dialects/schemes before passing them downstream.
- Add comprehensive parameterized unit tests covering uppercase and mixed-case URI schemes for both `POSTGRES_URI` and `PGVECTOR_CONNECTION_STRING`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PostgreSQL connection URI prefixes are now recognized consistently regardless of letter casing.
  * Already-normalized SQLAlchemy and libpq connection prefixes are preserved.
  * Existing whitespace trimming and query parameters continue to work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->