### PR TITLE
feat: add image attachment previews

### DIFF
--- a/application/api/user/attachments/routes.py
+++ b/application/api/user/attachments/routes.py
@@ -339,6 +339,10 @@ class AttachmentPreview(Resource):
                     upload_path,
                     expires_in=_ATTACHMENT_PREVIEW_PRESIGNED_TTL_SECONDS,
                     content_type=content_type,
+                    # The S3 object response needs its own directive: the
+                    # Flask 302's no-store does not cover the redirected
+                    # bytes, which would otherwise stay cacheable.
+                    cache_control="no-store",
                 )
                 response = redirect(image_url, code=302)
                 # no-store: preview URLs are identity-authorized, so neither

--- a/application/api/user/attachments/routes.py
+++ b/application/api/user/attachments/routes.py
@@ -1,5 +1,6 @@
 """File attachments and media routes."""
 
+import mimetypes
 import os
 import tempfile
 from pathlib import Path
@@ -15,6 +16,11 @@ from application.cache import get_redis_instance
 from application.core.settings import settings
 from application.storage.db.base_repository import looks_like_uuid
 from application.storage.db.repositories.agents import AgentsRepository
+from application.storage.db.repositories.attachments import AttachmentsRepository
+from application.storage.db.repositories.conversations import ConversationsRepository
+from application.storage.db.repositories.shared_conversations import (
+    SharedConversationsRepository,
+)
 from application.storage.db.session import db_readonly
 from application.stt.constants import (
     SUPPORTED_AUDIO_EXTENSIONS,
@@ -62,6 +68,10 @@ attachments_ns = Namespace(
 _AGENT_IMAGE_CHUNK_BYTES = 64 * 1024
 _AGENT_IMAGE_PRESIGNED_TTL_SECONDS = 300
 _AGENT_IMAGE_REDIRECT_CACHE_SECONDS = _AGENT_IMAGE_PRESIGNED_TTL_SECONDS - 60
+_ATTACHMENT_PREVIEW_PRESIGNED_TTL_SECONDS = 300
+_ATTACHMENT_PREVIEW_REDIRECT_CACHE_SECONDS = (
+    _ATTACHMENT_PREVIEW_PRESIGNED_TTL_SECONDS - 60
+)
 
 
 def _stream_file(file_obj, size_bytes: int):
@@ -167,6 +177,151 @@ def _parse_bool_form_value(value: str | None) -> bool:
     if value is None:
         return False
     return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _attachment_preview_content_type(att: dict) -> str | None:
+    """Image-only Content-Type for an attachment row.
+
+    Prefers the server-derived stored ``mime_type``; falls back to the
+    filename suffix for legacy rows that predate it. Returns None for
+    non-images so the preview endpoint refuses them.
+    """
+    stored = (att.get("mime_type") or "").split(";")[0].strip().lower()
+    if stored.startswith("image/"):
+        return stored
+    guessed, _ = mimetypes.guess_type(att.get("filename") or "")
+    if (guessed or "").lower().startswith("image/"):
+        return guessed.lower()
+    return None
+
+
+def _resolve_share_attachment_scope(conn, share_id: str, attachment_id: str):
+    """Resolve ``(owner_user_id, allowed)`` for share-scoped preview access.
+
+    Mirrors GetPubliclySharedConversations: the share identifier is the
+    capability, and only attachments of the share's visible messages
+    (``first_n_queries``) are in scope — never the owner's other files.
+    Returns ``(None, False)`` unless every check passes.
+    """
+    if not looks_like_uuid(share_id):
+        return None, False
+    shared = SharedConversationsRepository(conn).find_by_uuid(share_id)
+    if not shared or not shared.get("conversation_id"):
+        return None, False
+    owner_user = shared.get("user_id")
+    if not owner_user:
+        return None, False
+    conv_pg_id = str(shared["conversation_id"])
+    conversation = ConversationsRepository(conn).get_owned(conv_pg_id, owner_user)
+    if conversation is None:
+        return None, False
+    messages = ConversationsRepository(conn).get_messages(conv_pg_id)
+    first_n = shared.get("first_n_queries") or 0
+    for msg in messages[:first_n]:
+        for candidate in msg.get("attachments") or []:
+            if str(candidate) == str(attachment_id):
+                return owner_user, True
+    return owner_user, False
+
+
+@attachments_ns.route("/attachment/<string:attachment_id>/preview")
+class AttachmentPreview(Resource):
+    @api.doc(
+        description="Serve a stored image attachment's bytes for chat thumbnail "
+        "previews. Owner JWT/API-key auth, or a share identifier for attachments "
+        "visible in that shared conversation."
+    )
+    def get(self, attachment_id):
+        try:
+            share_id = request.args.get("share")
+            with db_readonly() as conn:
+                attachments_repo = AttachmentsRepository(conn)
+                if share_id:
+                    owner_user, allowed = _resolve_share_attachment_scope(
+                        conn, share_id, attachment_id
+                    )
+                    if not allowed:
+                        return make_response(
+                            jsonify({"success": False, "message": "Image not found"}),
+                            404,
+                        )
+                    # get_any: the id the client holds is the route-minted
+                    # UUID (legacy_mongo_id), not necessarily the row PK.
+                    att = attachments_repo.get_any(attachment_id, owner_user)
+                else:
+                    auth_user = _resolve_authenticated_user()
+                    if hasattr(auth_user, "status_code"):
+                        return auth_user
+                    if not auth_user:
+                        return make_response(
+                            jsonify(
+                                {
+                                    "success": False,
+                                    "message": "Authentication required",
+                                }
+                            ),
+                            401,
+                        )
+                    att = attachments_repo.get_any(attachment_id, auth_user)
+                if not att:
+                    return make_response(
+                        jsonify({"success": False, "message": "Image not found"}),
+                        404,
+                    )
+                content_type = _attachment_preview_content_type(att)
+                # The path comes from the user-scoped DB row, never from the
+                # request — no filesystem path is exposable here.
+                upload_path = att.get("upload_path") or att.get("path")
+                if not content_type or not upload_path:
+                    return make_response(
+                        jsonify({"success": False, "message": "Image not found"}),
+                        404,
+                    )
+
+            from application.api.user.base import storage
+
+            size_bytes = storage.get_file_size(upload_path)
+            if size_bytes < 0 or size_bytes > settings.UPLOAD_MAX_FILE_BYTES:
+                current_app.logger.warning(
+                    "Rejected oversized attachment preview for %s", attachment_id
+                )
+                return make_response(
+                    jsonify({"success": False, "message": "Image not found"}),
+                    404,
+                )
+
+            if settings.STORAGE_TYPE == "s3":
+                image_url = storage.generate_presigned_url(
+                    upload_path,
+                    expires_in=_ATTACHMENT_PREVIEW_PRESIGNED_TTL_SECONDS,
+                    content_type=content_type,
+                )
+                response = redirect(image_url, code=302)
+                response.headers.set(
+                    "Cache-Control",
+                    f"private, max-age={_ATTACHMENT_PREVIEW_REDIRECT_CACHE_SECONDS}",
+                )
+                response.headers.set("X-Content-Type-Options", "nosniff")
+                return response
+
+            file_obj = storage.get_file(upload_path)
+            response = Response(
+                _stream_file(file_obj, size_bytes),
+                content_type=content_type,
+                direct_passthrough=True,
+            )
+            response.headers.set(
+                "Cache-Control", "private, max-age=86400, immutable"
+            )
+            response.headers.set("X-Content-Type-Options", "nosniff")
+            return response
+        except Exception as err:
+            current_app.logger.error(
+                f"Error serving attachment preview: {err}", exc_info=True
+            )
+            return make_response(
+                jsonify({"success": False, "message": "Image not found"}), 404
+            )
 
 
 @attachments_ns.route("/store_attachment")

--- a/application/api/user/attachments/routes.py
+++ b/application/api/user/attachments/routes.py
@@ -1,6 +1,5 @@
 """File attachments and media routes."""
 
-import mimetypes
 import os
 import tempfile
 from pathlib import Path
@@ -69,9 +68,37 @@ _AGENT_IMAGE_CHUNK_BYTES = 64 * 1024
 _AGENT_IMAGE_PRESIGNED_TTL_SECONDS = 300
 _AGENT_IMAGE_REDIRECT_CACHE_SECONDS = _AGENT_IMAGE_PRESIGNED_TTL_SECONDS - 60
 _ATTACHMENT_PREVIEW_PRESIGNED_TTL_SECONDS = 300
-_ATTACHMENT_PREVIEW_REDIRECT_CACHE_SECONDS = (
-    _ATTACHMENT_PREVIEW_PRESIGNED_TTL_SECONDS - 60
+
+# Raster image MIME types the preview endpoint may serve. SVG (and any
+# other non-raster image type) is deliberately absent: the share-scoped
+# preview URL needs no auth headers, so a navigated-to SVG would execute
+# script in the application origin (stored XSS). Raster formats are inert
+# both in <img> and as documents.
+_ATTACHMENT_PREVIEW_RASTER_MIME_TYPES = frozenset(
+    {
+        "image/png",
+        "image/jpeg",
+        "image/gif",
+        "image/webp",
+        "image/tiff",
+        "image/bmp",
+    }
 )
+
+# Suffix -> MIME for the same set. A controlled map rather than
+# mimetypes.guess_type: the stdlib table is version-dependent (e.g. .webp
+# is absent on some supported Pythons, which would otherwise refuse
+# legitimate uploads), and only pipeline-storable suffixes are listed.
+_ATTACHMENT_PREVIEW_SUFFIX_MIME_TYPES = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".tiff": "image/tiff",
+    ".tif": "image/tiff",
+    ".bmp": "image/bmp",
+    ".webp": "image/webp",
+    ".gif": "image/gif",
+}
 
 
 def _stream_file(file_obj, size_bytes: int):
@@ -183,16 +210,22 @@ def _attachment_preview_content_type(att: dict) -> str | None:
     """Image-only Content-Type for an attachment row.
 
     Prefers the server-derived stored ``mime_type``; falls back to the
-    filename suffix for legacy rows that predate it. Returns None for
-    non-images so the preview endpoint refuses them.
+    controlled suffix map for legacy rows that predate it (or whose
+    stored type the stdlib cannot name, e.g. ``.webp``). Returns None for
+    anything outside the raster allowlist — notably SVG, which must never
+    be served here (see ``_ATTACHMENT_PREVIEW_RASTER_MIME_TYPES``).
+
+    Args:
+        att: Attachment row dict with ``mime_type``/``filename`` keys.
+
+    Returns:
+        The ``image/*`` Content-Type to serve, or None to refuse.
     """
     stored = (att.get("mime_type") or "").split(";")[0].strip().lower()
-    if stored.startswith("image/"):
+    if stored in _ATTACHMENT_PREVIEW_RASTER_MIME_TYPES:
         return stored
-    guessed, _ = mimetypes.guess_type(att.get("filename") or "")
-    if (guessed or "").lower().startswith("image/"):
-        return guessed.lower()
-    return None
+    suffix = os.path.splitext(att.get("filename") or "")[1].lower()
+    return _ATTACHMENT_PREVIEW_SUFFIX_MIME_TYPES.get(suffix)
 
 
 def _resolve_share_attachment_scope(conn, share_id: str, attachment_id: str):
@@ -232,6 +265,17 @@ class AttachmentPreview(Resource):
         "visible in that shared conversation."
     )
     def get(self, attachment_id):
+        """Serve one stored image attachment's bytes for preview rendering.
+
+        Args:
+            attachment_id: Route-minted attachment UUID (``legacy_mongo_id``).
+
+        Returns:
+            The image bytes (local storage) or a short-lived presigned
+            redirect (S3) with ``no-store`` caching; 404 for missing,
+            foreign, non-image, or oversized attachments, 401 when owner
+            authentication is absent or invalid.
+        """
         try:
             share_id = request.args.get("share")
             with db_readonly() as conn:
@@ -297,10 +341,9 @@ class AttachmentPreview(Resource):
                     content_type=content_type,
                 )
                 response = redirect(image_url, code=302)
-                response.headers.set(
-                    "Cache-Control",
-                    f"private, max-age={_ATTACHMENT_PREVIEW_REDIRECT_CACHE_SECONDS}",
-                )
+                # no-store: preview URLs are identity-authorized, so neither
+                # the bytes nor the redirect may sit in a shared cache.
+                response.headers.set("Cache-Control", "no-store")
                 response.headers.set("X-Content-Type-Options", "nosniff")
                 return response
 
@@ -310,9 +353,7 @@ class AttachmentPreview(Resource):
                 content_type=content_type,
                 direct_passthrough=True,
             )
-            response.headers.set(
-                "Cache-Control", "private, max-age=86400, immutable"
-            )
+            response.headers.set("Cache-Control", "no-store")
             response.headers.set("X-Content-Type-Options", "nosniff")
             return response
         except Exception as err:

--- a/application/api/user/conversations/routes.py
+++ b/application/api/user/conversations/routes.py
@@ -267,6 +267,7 @@ class GetSingleConversation(Resource):
                                             "fileName": att.get(
                                                 "filename", "Unknown file"
                                             ),
+                                            "mime_type": att.get("mime_type"),
                                         }
                                     )
                             except Exception as e:

--- a/application/api/user/sharing/routes.py
+++ b/application/api/user/sharing/routes.py
@@ -361,6 +361,7 @@ class GetPubliclySharedConversations(Resource):
                                             "fileName": attachment.get(
                                                 "filename", "Unknown file"
                                             ),
+                                            "mime_type": attachment.get("mime_type"),
                                         }
                                     )
                             except Exception as e:

--- a/application/storage/base.py
+++ b/application/storage/base.py
@@ -65,6 +65,7 @@ class BaseStorage(ABC):
         path: str,
         expires_in: int = 300,
         content_type: Optional[str] = None,
+        cache_control: Optional[str] = None,
     ) -> str:
         """Return a short-lived presigned download URL; not all backends support it.
 
@@ -72,6 +73,7 @@ class BaseStorage(ABC):
             path: Path to the file
             expires_in: TTL of the signed URL in seconds
             content_type: Optional response Content-Type override
+            cache_control: Optional response Cache-Control override
 
         Returns:
             str: A presigned URL granting time-limited read access

--- a/application/storage/s3.py
+++ b/application/storage/s3.py
@@ -140,6 +140,7 @@ class S3Storage(BaseStorage):
         path: str,
         expires_in: int = 300,
         content_type: Optional[str] = None,
+        cache_control: Optional[str] = None,
     ) -> str:
         """Return a short-lived presigned GET URL for a private object (TTL <= 1h)."""
         path = self._validate_path(path)
@@ -147,6 +148,8 @@ class S3Storage(BaseStorage):
         params = {"Bucket": self.bucket_name, "Key": path}
         if content_type:
             params["ResponseContentType"] = content_type
+        if cache_control:
+            params["ResponseCacheControl"] = cache_control
         return self.s3.generate_presigned_url(
             "get_object",
             Params=params,

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -103,6 +103,12 @@ const endpoints = {
       `/api/delete_chunk?id=${docId}&chunk_id=${chunkId}`,
     UPDATE_CHUNK: '/api/update_chunk',
     STORE_ATTACHMENT: '/api/store_attachment',
+    ATTACHMENT_PREVIEW: (id: string, shareId?: string | null) => {
+      const params = new URLSearchParams();
+      if (shareId) params.set('share', shareId);
+      const qs = params.toString();
+      return `/api/attachment/${encodeURIComponent(id)}/preview${qs ? `?${qs}` : ''}`;
+    },
     STT: '/api/stt',
     TTS: '/api/tts',
     LIVE_STT_START: '/api/stt/live/start',

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -103,6 +103,7 @@ const endpoints = {
       `/api/delete_chunk?id=${docId}&chunk_id=${chunkId}`,
     UPDATE_CHUNK: '/api/update_chunk',
     STORE_ATTACHMENT: '/api/store_attachment',
+    /** Chat image-preview bytes for an attachment ID (share-scoped via ?share=). */
     ATTACHMENT_PREVIEW: (id: string, shareId?: string | null) => {
       const params = new URLSearchParams();
       if (shareId) params.set('share', shareId);

--- a/frontend/src/api/services/userService.ts
+++ b/frontend/src/api/services/userService.ts
@@ -378,6 +378,7 @@ const userService = {
       // Accept header is the same opt-in via content negotiation.
       disposition === 'url' ? { Accept: 'application/json' } : {},
     ),
+  /** Fetch stored image bytes for a chat attachment preview. */
   getAttachmentPreview: (
     attachmentId: string,
     token: string | null,

--- a/frontend/src/api/services/userService.ts
+++ b/frontend/src/api/services/userService.ts
@@ -378,6 +378,15 @@ const userService = {
       // Accept header is the same opt-in via content negotiation.
       disposition === 'url' ? { Accept: 'application/json' } : {},
     ),
+  getAttachmentPreview: (
+    attachmentId: string,
+    token: string | null,
+    shareId?: string | null,
+  ): Promise<Response> =>
+    apiClient.get(
+      endpoints.USER.ATTACHMENT_PREVIEW(attachmentId, shareId),
+      token,
+    ),
   restoreArtifactVersion: (
     artifactId: string,
     version: number,

--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -315,6 +315,10 @@ type MessageInputProps = {
   onQueuedQuestionConsumed?: () => void;
 };
 
+/**
+ * Chat composer: message input with file attachments (image thumbnails),
+ * voice input, send gating, and tool/source triggers.
+ */
 export default function MessageInput({
   onSubmit,
   loading,

--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -48,6 +48,7 @@ import { useArmedSend } from './message-input/armedSend';
 import { handleAbort } from '../conversation/conversationSlice';
 import {
   AUDIO_FILE_ACCEPT_ATTR,
+  createImagePreviewUrl,
   getFileExtension,
   parseUploadErrorMessage,
   parseUploadErrorsByIndex,
@@ -543,6 +544,9 @@ export default function MessageInput({
               progress: 0,
               status: 'uploading' as const,
               taskId: '',
+              mimeType: file.type || undefined,
+              // Images only — documents keep no preview URL.
+              previewUrl: createImagePreviewUrl(file),
             }),
           );
         });
@@ -833,6 +837,9 @@ export default function MessageInput({
           progress: 0,
           status: 'uploading' as const,
           taskId: '',
+          mimeType: file.type || undefined,
+          // Images only — documents keep no preview URL.
+          previewUrl: createImagePreviewUrl(file),
         };
 
         dispatch(addAttachment(newAttachment));

--- a/frontend/src/components/message-input/AttachmentChipList.test.tsx
+++ b/frontend/src/components/message-input/AttachmentChipList.test.tsx
@@ -1,0 +1,150 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Attachment } from '../../upload/uploadSlice';
+import AttachmentChipList, { isImageAttachment } from './AttachmentChipList';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const att = (over: Partial<Attachment> = {}): Attachment => ({
+  id: 'a1',
+  fileName: 'report.pdf',
+  progress: 100,
+  status: 'completed',
+  taskId: 't1',
+  ...over,
+});
+
+describe('isImageAttachment', () => {
+  it('treats a stored preview URL as an image', () => {
+    expect(isImageAttachment({ previewUrl: 'blob:local/1' })).toBe(true);
+  });
+
+  it('classifies by mime type', () => {
+    expect(isImageAttachment({ mimeType: 'image/png' })).toBe(true);
+    expect(isImageAttachment({ mimeType: 'IMAGE/JPEG' })).toBe(true);
+    expect(isImageAttachment({ mimeType: 'application/pdf' })).toBe(false);
+  });
+
+  it('falls back to the file-name suffix', () => {
+    expect(isImageAttachment({ fileName: 'photo.jpg' })).toBe(true);
+    expect(isImageAttachment({ fileName: 'scan.webp' })).toBe(true);
+    expect(isImageAttachment({ fileName: 'doc.pdf' })).toBe(false);
+  });
+
+  it('rejects empty attachments', () => {
+    expect(isImageAttachment({})).toBe(false);
+  });
+});
+
+describe('AttachmentChipList', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  const render = async (
+    attachments: Attachment[],
+    onRemove: (id: string) => void = () => {},
+  ) => {
+    await act(async () => {
+      root.render(
+        <AttachmentChipList
+          attachments={attachments}
+          draggingId={null}
+          onRemove={onRemove}
+          onDragStart={() => {}}
+          onDragOver={() => {}}
+          onDropOn={() => {}}
+        />,
+      );
+    });
+  };
+
+  it('renders the document icon for a completed PDF', async () => {
+    await render([att()]);
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('alt')).toBe('Attachment');
+    expect(container.textContent).toContain('report.pdf');
+  });
+
+  it('renders a thumbnail for a completed image', async () => {
+    await render([
+      att({
+        id: 'img1',
+        fileName: 'photo.png',
+        mimeType: 'image/png',
+        previewUrl: 'blob:test-photo',
+      }),
+    ]);
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toBe('blob:test-photo');
+    expect(img?.getAttribute('alt')).toBe('photo.png');
+  });
+
+  it('renders a thumbnail with a progress overlay while uploading', async () => {
+    await render([
+      att({
+        id: 'img1',
+        fileName: 'photo.png',
+        status: 'uploading',
+        progress: 40,
+        mimeType: 'image/png',
+        previewUrl: 'blob:test-photo',
+      }),
+    ]);
+    const img = container.querySelector('img');
+    expect(img?.getAttribute('src')).toBe('blob:test-photo');
+    // The ring overlay, not the plain icon branch.
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('keeps the error icon for a failed attachment', async () => {
+    await render([att({ status: 'failed', fileName: 'broken.pdf' })]);
+    expect(container.querySelector('img')?.getAttribute('alt')).toBe('Failed');
+  });
+
+  it('falls back to the icon for an image without a preview URL', async () => {
+    await render([att({ fileName: 'photo.png', mimeType: 'image/png' })]);
+    const img = container.querySelector('img');
+    expect(img?.getAttribute('alt')).toBe('Attachment');
+    expect(img?.getAttribute('src')).not.toBe('blob:test-photo');
+  });
+
+  it('calls onRemove with the attachment id', async () => {
+    const onRemove = vi.fn();
+    await render(
+      [
+        att({
+          id: 'img1',
+          fileName: 'photo.png',
+          mimeType: 'image/png',
+          previewUrl: 'blob:test-photo',
+        }),
+      ],
+      onRemove,
+    );
+    const button = container.querySelector('button');
+    expect(button).not.toBeNull();
+    await act(async () => {
+      button?.click();
+    });
+    expect(onRemove).toHaveBeenCalledWith('img1');
+  });
+});

--- a/frontend/src/components/message-input/AttachmentChipList.test.tsx
+++ b/frontend/src/components/message-input/AttachmentChipList.test.tsx
@@ -11,6 +11,7 @@ vi.mock('react-i18next', () => ({
 
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 
+/** Completed-PDF attachment fixture, overridable per test. */
 const att = (over: Partial<Attachment> = {}): Attachment => ({
   id: 'a1',
   fileName: 'report.pdf',
@@ -57,6 +58,7 @@ describe('AttachmentChipList', () => {
     container.remove();
   });
 
+  /** Render the chip list with inert drag/drop callbacks. */
   const render = async (
     attachments: Attachment[],
     onRemove: (id: string) => void = () => {},

--- a/frontend/src/components/message-input/AttachmentChipList.tsx
+++ b/frontend/src/components/message-input/AttachmentChipList.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import AlertIcon from '../../assets/alert.svg';
 import DocumentationDark from '../../assets/documentation-dark.svg';
+import { isImageFileName } from '../../constants/fileUpload';
 import type { Attachment } from '../../upload/uploadSlice';
 import { Button } from '../ui/button';
 
@@ -14,6 +15,30 @@ type AttachmentChipListProps = {
   onDragOver: (e: React.DragEvent) => void;
   onDropOn: (e: React.DragEvent, targetId: string) => void;
 };
+
+/**
+ * Whether an attachment should render as an image thumbnail. A stored
+ * ``previewUrl`` is decisive — it is only ever created for images — while
+ * ``mimeType`` and the file-name suffix cover rows whose URL is gone
+ * (or was never creatable).
+ */
+export function isImageAttachment(attachment: {
+  mimeType?: string;
+  fileName?: string;
+  previewUrl?: string;
+}): boolean {
+  if (attachment.previewUrl) return true;
+  if (
+    attachment.mimeType &&
+    attachment.mimeType.toLowerCase().startsWith('image/')
+  ) {
+    return true;
+  }
+  if (attachment.fileName) {
+    return isImageFileName(attachment.fileName);
+  }
+  return false;
+}
 
 export default function AttachmentChipList({
   attachments,
@@ -36,6 +61,15 @@ export default function AttachmentChipList({
     <>
       <div className="flex flex-wrap gap-1.5 px-2 py-2 sm:gap-2 sm:px-3">
         {attachments.map((attachment) => {
+          // A thumbnail needs a live URL; without one an image renders
+          // with the generic icon, exactly like a document.
+          const previewUrl =
+            isImageAttachment(attachment) && attachment.previewUrl
+              ? attachment.previewUrl
+              : undefined;
+          const showProgress =
+            attachment.status === 'uploading' ||
+            attachment.status === 'processing';
           return (
             <div
               key={attachment.id}
@@ -56,26 +90,22 @@ export default function AttachmentChipList({
                   : attachment.fileName
               }
             >
-              <div className="bg-primary mr-2 flex h-8 w-8 items-center justify-center rounded-md p-1">
-                {attachment.status === 'completed' && (
+              {previewUrl && attachment.status === 'completed' ? (
+                <div className="bg-muted mr-2 flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-md">
                   <img
-                    src={DocumentationDark}
-                    alt="Attachment"
-                    className="h-[15px] w-[15px] object-fill"
+                    src={previewUrl}
+                    alt={attachment.fileName}
+                    className="h-full w-full object-cover"
                   />
-                )}
-
-                {attachment.status === 'failed' && (
+                </div>
+              ) : previewUrl && showProgress ? (
+                <div className="bg-muted relative mr-2 flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-md">
                   <img
-                    src={AlertIcon}
-                    alt="Failed"
-                    className="h-[15px] w-[15px] object-fill"
+                    src={previewUrl}
+                    alt={attachment.fileName}
+                    className="h-full w-full object-cover opacity-50"
                   />
-                )}
-
-                {(attachment.status === 'uploading' ||
-                  attachment.status === 'processing') && (
-                  <div className="flex h-[15px] w-[15px] items-center justify-center">
+                  <div className="absolute inset-0 flex items-center justify-center">
                     <svg className="h-[15px] w-[15px]" viewBox="0 0 24 24">
                       <circle
                         className="opacity-0"
@@ -102,8 +132,56 @@ export default function AttachmentChipList({
                       />
                     </svg>
                   </div>
-                )}
-              </div>
+                </div>
+              ) : (
+                <div className="bg-primary mr-2 flex h-8 w-8 items-center justify-center rounded-md p-1">
+                  {attachment.status === 'completed' && (
+                    <img
+                      src={DocumentationDark}
+                      alt="Attachment"
+                      className="h-[15px] w-[15px] object-fill"
+                    />
+                  )}
+
+                  {attachment.status === 'failed' && (
+                    <img
+                      src={AlertIcon}
+                      alt="Failed"
+                      className="h-[15px] w-[15px] object-fill"
+                    />
+                  )}
+
+                  {showProgress && (
+                    <div className="flex h-[15px] w-[15px] items-center justify-center">
+                      <svg className="h-[15px] w-[15px]" viewBox="0 0 24 24">
+                        <circle
+                          className="opacity-0"
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke="transparent"
+                          strokeWidth="4"
+                          fill="none"
+                        />
+                        <circle
+                          className="text-[#ECECF1]"
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke="currentColor"
+                          strokeWidth="4"
+                          fill="none"
+                          strokeDasharray="62.83"
+                          strokeDashoffset={
+                            62.83 * (1 - attachment.progress / 100)
+                          }
+                          transform="rotate(-90 12 12)"
+                        />
+                      </svg>
+                    </div>
+                  )}
+                </div>
+              )}
 
               <span className="max-w-[120px] truncate font-medium sm:max-w-[150px]">
                 {attachment.fileName}

--- a/frontend/src/components/message-input/AttachmentChipList.tsx
+++ b/frontend/src/components/message-input/AttachmentChipList.tsx
@@ -40,6 +40,11 @@ export function isImageAttachment(attachment: {
   return false;
 }
 
+/**
+ * Composer attachment chips: image thumbnails (or the generic icon for
+ * documents), upload progress overlays, inline failure reasons, and the
+ * remove control. Drag-to-reorder is wired through the parent callbacks.
+ */
 export default function AttachmentChipList({
   attachments,
   draggingId,

--- a/frontend/src/constants/fileUpload.test.ts
+++ b/frontend/src/constants/fileUpload.test.ts
@@ -1,14 +1,19 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   ATTACHMENT_FILE_ACCEPT_ATTR,
+  ATTACHMENT_IMAGE_EXTENSIONS,
   ATTACHMENT_PARSER_EXTENSIONS,
+  createImagePreviewUrl,
   getFileExtension,
   hasAttachmentParser,
+  isImageFile,
+  isImageFileName,
   looksLikeText,
   parseUploadErrorMessage,
   parseUploadErrorsByIndex,
   partitionAttachmentFiles,
+  revokeImagePreviewUrl,
 } from './fileUpload';
 
 const file = (name: string, body: BlobPart = 'x', type = '') =>
@@ -236,5 +241,112 @@ describe('parseUploadErrorsByIndex', () => {
     expect(
       parseUploadErrorsByIndex('{"errors":[{"error":"no index"}]}').size,
     ).toBe(0);
+  });
+});
+
+describe('isImageFileName', () => {
+  it('accepts parser-supported image suffixes', () => {
+    for (const name of [
+      'photo.png',
+      'photo.jpg',
+      'photo.jpeg',
+      'scan.tiff',
+      'scan.tif',
+      'diagram.bmp',
+      'shot.webp',
+    ]) {
+      expect(isImageFileName(name)).toBe(true);
+    }
+  });
+
+  it('is case-insensitive', () => {
+    expect(isImageFileName('PHOTO.PNG')).toBe(true);
+    expect(isImageFileName('Photo.JpG')).toBe(true);
+  });
+
+  it('rejects documents, audio, and suffix-less names', () => {
+    for (const name of [
+      'report.pdf',
+      'notes.txt',
+      'song.mp3',
+      'clip.webm',
+      'archive.zip',
+      'noextension',
+      '.png',
+    ]) {
+      expect(isImageFileName(name)).toBe(false);
+    }
+  });
+
+  it('only lists suffixes the attachment pipeline can parse', () => {
+    for (const ext of ATTACHMENT_IMAGE_EXTENSIONS) {
+      expect(ext.startsWith('.')).toBe(true);
+      expect(ATTACHMENT_PARSER_EXTENSIONS).toContain(ext);
+    }
+    expect(ATTACHMENT_IMAGE_EXTENSIONS).not.toContain('.pdf');
+    expect(ATTACHMENT_IMAGE_EXTENSIONS).not.toContain('.mp3');
+  });
+});
+
+describe('isImageFile', () => {
+  it('trusts an image mime type even with an odd name', () => {
+    expect(isImageFile({ type: 'image/png', name: 'blob' })).toBe(true);
+    expect(isImageFile({ type: 'IMAGE/JPEG', name: 'blob' })).toBe(true);
+  });
+
+  it('falls back to the suffix when the picker reports no type', () => {
+    expect(isImageFile({ type: '', name: 'photo.png' })).toBe(true);
+    expect(isImageFile({ name: 'photo.png' })).toBe(true);
+  });
+
+  it('rejects documents even when the mime type is present', () => {
+    expect(isImageFile({ type: 'application/pdf', name: 'doc.pdf' })).toBe(
+      false,
+    );
+    expect(isImageFile({ type: '', name: 'notes.txt' })).toBe(false);
+  });
+});
+
+describe('createImagePreviewUrl / revokeImagePreviewUrl', () => {
+  const realCreate = URL.createObjectURL;
+  const realRevoke = URL.revokeObjectURL;
+  const created: unknown[] = [];
+  const revoked: string[] = [];
+
+  beforeEach(() => {
+    created.length = 0;
+    revoked.length = 0;
+    URL.createObjectURL = ((obj: unknown) => {
+      created.push(obj);
+      return 'blob:mock-url';
+    }) as typeof URL.createObjectURL;
+    URL.revokeObjectURL = ((url: string) => {
+      revoked.push(url);
+    }) as typeof URL.revokeObjectURL;
+  });
+
+  afterEach(() => {
+    URL.createObjectURL = realCreate;
+    URL.revokeObjectURL = realRevoke;
+  });
+
+  it('creates a preview URL for images only', () => {
+    const image = new File(['bytes'], 'photo.png', { type: 'image/png' });
+    expect(createImagePreviewUrl(image)).toBe('blob:mock-url');
+    expect(created).toEqual([image]);
+  });
+
+  it('creates no preview URL for PDFs/documents', () => {
+    const pdf = new File(['bytes'], 'doc.pdf', { type: 'application/pdf' });
+    expect(createImagePreviewUrl(pdf)).toBeUndefined();
+    expect(created).toEqual([]);
+  });
+
+  it('revokes blob URLs and ignores anything else', () => {
+    revokeImagePreviewUrl('blob:mock-url');
+    expect(revoked).toEqual(['blob:mock-url']);
+    revokeImagePreviewUrl(undefined);
+    revokeImagePreviewUrl('https://example.com/photo.png');
+    expect(revoked).toEqual(['blob:mock-url']);
   });
 });

--- a/frontend/src/constants/fileUpload.ts
+++ b/frontend/src/constants/fileUpload.ts
@@ -144,6 +144,83 @@ export function getFileExtension(name: string): string {
 }
 
 /**
+ * Image suffixes the attachment pipeline can parse. This is the image
+ * subset of ``ATTACHMENT_PARSER_EXTENSIONS`` — it mirrors the backend's
+ * image support (application/parser/file/constants.py), so update both
+ * together. Used as the fallback image check when the picker reports no
+ * (or an untrustworthy) mime type.
+ */
+export const ATTACHMENT_IMAGE_EXTENSIONS: readonly string[] = [
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.tiff',
+  '.tif',
+  '.bmp',
+  '.webp',
+];
+
+/** Whether a file name has an image suffix the backend can parse. */
+export function isImageFileName(name: string): boolean {
+  return ATTACHMENT_IMAGE_EXTENSIONS.includes(getFileExtension(name));
+}
+
+/**
+ * Whether an upload should get an image preview. The picker's mime type
+ * decides first; the suffix is the fallback for pickers that report none
+ * (mobile) or lie about it — never the other way round.
+ */
+export function isImageFile(file: { type?: string; name: string }): boolean {
+  if (
+    typeof file.type === 'string' &&
+    file.type.toLowerCase().startsWith('image/')
+  ) {
+    return true;
+  }
+  return isImageFileName(file.name);
+}
+
+/**
+ * A short-lived ``blob:`` URL for an image preview, or ``undefined`` for
+ * non-images. The caller owns the URL: hand it to ``revokeImagePreviewUrl``
+ * once no chip or conversation bubble shows it anymore. Never throws —
+ * hosts without ``URL.createObjectURL`` simply get no preview.
+ */
+export function createImagePreviewUrl(file: File): string | undefined {
+  if (!isImageFile(file)) return undefined;
+  try {
+    if (
+      typeof URL !== 'undefined' &&
+      typeof URL.createObjectURL === 'function'
+    ) {
+      return URL.createObjectURL(file);
+    }
+  } catch {
+    // No blob-URL support here — the attachment still uploads, it just
+    // renders with the generic document icon.
+  }
+  return undefined;
+}
+
+/**
+ * Release a URL from ``createImagePreviewUrl``. Safe to call with
+ * ``undefined``, non-blob URLs, or an already-revoked URL.
+ */
+export function revokeImagePreviewUrl(previewUrl: string | undefined): void {
+  if (!previewUrl || !previewUrl.startsWith('blob:')) return;
+  try {
+    if (
+      typeof URL !== 'undefined' &&
+      typeof URL.revokeObjectURL === 'function'
+    ) {
+      URL.revokeObjectURL(previewUrl);
+    }
+  } catch {
+    // Already revoked — nothing to do.
+  }
+}
+
+/**
  * Whether the backend has a parser for this suffix. False is not a refusal:
  * the file then has to read as text. Never decided by the mime type the
  * picker reports — mobile pickers ignore `accept` and lie about types.

--- a/frontend/src/conversation/Conversation.tsx
+++ b/frontend/src/conversation/Conversation.tsx
@@ -190,6 +190,8 @@ export default function Conversation() {
   );
 
   const handleQuestion = useCallback(
+    /** Send a question: snapshot completed attachments, add the query row,
+     * fetch the answer, and clear the composer. Retries reuse the row's ids. */
     ({
       question,
       isRetry = false,

--- a/frontend/src/conversation/Conversation.tsx
+++ b/frontend/src/conversation/Conversation.tsx
@@ -229,7 +229,12 @@ export default function Conversation() {
       } else {
         const filesAttached = completedAttachments
           .filter((a) => a.id)
-          .map((a) => ({ id: a.id as string, fileName: a.fileName }));
+          .map((a) => ({
+            id: a.id as string,
+            fileName: a.fileName,
+            mimeType: a.mimeType,
+            previewUrl: a.previewUrl,
+          }));
 
         if (!isRetry)
           dispatch(

--- a/frontend/src/conversation/ConversationBubble.test.tsx
+++ b/frontend/src/conversation/ConversationBubble.test.tsx
@@ -1,0 +1,51 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { AttachmentPreviewImage } from './ConversationBubble';
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+describe('AttachmentPreviewImage', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  const render = async (previewUrl: string, fileName: string) => {
+    await act(async () => {
+      root.render(
+        <AttachmentPreviewImage previewUrl={previewUrl} fileName={fileName} />,
+      );
+    });
+  };
+
+  it('renders the thumbnail with accessible alt text', async () => {
+    await render('blob:test-photo', 'photo.png');
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toBe('blob:test-photo');
+    expect(img?.getAttribute('alt')).toBe('photo.png');
+  });
+
+  it('falls back to the document icon when the image cannot load', async () => {
+    await render('blob:dead-url', 'photo.png');
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    await act(async () => {
+      img?.dispatchEvent(new Event('error'));
+    });
+    const fallback = container.querySelector('img');
+    expect(fallback?.getAttribute('alt')).toBe('Attachment');
+    expect(fallback?.getAttribute('src')).not.toBe('blob:dead-url');
+  });
+});

--- a/frontend/src/conversation/ConversationBubble.test.tsx
+++ b/frontend/src/conversation/ConversationBubble.test.tsx
@@ -21,6 +21,7 @@ describe('AttachmentPreviewImage', () => {
     container.remove();
   });
 
+  /** Render the preview image in isolation (no store needed). */
   const render = async (previewUrl: string, fileName: string) => {
     await act(async () => {
       root.render(

--- a/frontend/src/conversation/ConversationBubble.tsx
+++ b/frontend/src/conversation/ConversationBubble.tsx
@@ -126,6 +126,7 @@ function BubbleAttachmentChip({
   );
 }
 
+/** Chat message bubble: question, answer, sources, and response metadata. */
 const ConversationBubble = forwardRef<
   HTMLDivElement,
   {

--- a/frontend/src/conversation/ConversationBubble.tsx
+++ b/frontend/src/conversation/ConversationBubble.tsx
@@ -31,13 +31,100 @@ import { isToolCallRunning } from '../utils/streamingStatusUtils';
 import AnswerFlow from './AnswerFlow';
 import { AnswerSegment } from './answerSegments';
 import { deriveArtifactChips } from './artifactChips';
-import { FEEDBACK, MESSAGE_TYPE, ResearchState } from './conversationModels';
+import {
+  FEEDBACK,
+  MESSAGE_TYPE,
+  QueryAttachment,
+  ResearchState,
+} from './conversationModels';
 import MarkdownAnswer from './MarkdownAnswer';
 import ResearchProgress from './ResearchProgress';
 import { ToolCallsType } from './types';
 import { wikiWriteActionKey, wikiWritePath } from './wikiToolCall';
+import { useAttachmentPreviewUrl } from './useAttachmentPreview';
 
 const DisableSourceFE = import.meta.env.VITE_DISABLE_SOURCE_FE || false;
+
+/**
+ * Thumbnail for a sent image attachment. A ``blob:`` snapshot URL can be
+ * dead (reloaded history, shared link opened in another session) — then
+ * the image errors and we fall back to the document icon, exactly as if
+ * there had never been a preview.
+ */
+export function AttachmentPreviewImage({
+  previewUrl,
+  fileName,
+}: {
+  previewUrl: string;
+  fileName: string;
+}) {
+  const [failed, setFailed] = useState(false);
+
+  if (failed) {
+    return (
+      <div className="bg-primary mr-2 items-center justify-center rounded-lg p-[5.5px]">
+        <img
+          src={DocumentationDark}
+          alt="Attachment"
+          className="h-3.75 w-3.75 object-fill"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-muted mr-2 flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-lg">
+      <img
+        src={previewUrl}
+        alt={fileName}
+        title={fileName}
+        className="h-full w-full object-cover"
+        onError={() => setFailed(true)}
+      />
+    </div>
+  );
+}
+
+/**
+ * One sent-attachment chip. A separate component so the preview hook
+ * (one fetch per attachment) runs unconditionally per chip instead of
+ * inside the parent's variable-length ``.map()``.
+ */
+function BubbleAttachmentChip({
+  file,
+  token,
+  shareId,
+}: {
+  file: QueryAttachment;
+  token: string | null;
+  shareId?: string | null;
+}) {
+  // Priority: live snapshot URL -> fetched bytes by ID -> generic icon.
+  const previewUrl = useAttachmentPreviewUrl(file, token, shareId);
+
+  return (
+    <div
+      title={file.fileName}
+      className="dark:text-foreground dark:bg-accent text-muted-foreground bg-muted flex items-center rounded-xl p-2 text-sm"
+    >
+      {previewUrl ? (
+        <AttachmentPreviewImage
+          previewUrl={previewUrl}
+          fileName={file.fileName}
+        />
+      ) : (
+        <div className="bg-primary mr-2 items-center justify-center rounded-lg p-[5.5px]">
+          <img
+            src={DocumentationDark}
+            alt="Attachment"
+            className="h-3.75 w-3.75 object-fill"
+          />
+        </div>
+      )}
+      <span className="max-w-37.5 truncate font-normal">{file.fileName}</span>
+    </div>
+  );
+}
 
 const ConversationBubble = forwardRef<
   HTMLDivElement,
@@ -64,7 +151,12 @@ const ConversationBubble = forwardRef<
       updated?: boolean,
       index?: number,
     ) => void;
-    filesAttached?: { id: string; fileName: string }[];
+    filesAttached?: QueryAttachment[];
+    /**
+     * Share identifier when rendering inside a shared conversation view.
+     * Image fetches for history rows then use share-scoped authorization.
+     */
+    shareId?: string | null;
     /**
      * Every artifact in the conversation, for resolving inline links. Refs
      * are conversation-scoped, so a link may point at an earlier turn's file.
@@ -98,6 +190,7 @@ const ConversationBubble = forwardRef<
     isStreaming,
     handleUpdatedQuestionSubmission,
     filesAttached,
+    shareId,
     conversationArtifacts,
     onOpenArtifact,
     onToolAction,
@@ -109,6 +202,7 @@ const ConversationBubble = forwardRef<
   // const bubbleRef = useRef<HTMLDivElement | null>(null);
   const chunks = useSelector(selectChunks);
   const selectedDocs = useSelector(selectSelectedDocs);
+  const token = useSelector(selectToken);
   const [isEditClicked, setIsEditClicked] = useState(false);
   const [editInputBox, setEditInputBox] = useState<string>('');
   const messageRef = useRef<HTMLDivElement>(null);
@@ -144,22 +238,12 @@ const ConversationBubble = forwardRef<
           {filesAttached && filesAttached.length > 0 && (
             <div className="mr-5 mb-4 flex flex-wrap justify-end gap-2">
               {filesAttached.map((file, index) => (
-                <div
+                <BubbleAttachmentChip
                   key={index}
-                  title={file.fileName}
-                  className="dark:text-foreground dark:bg-accent text-muted-foreground bg-muted flex items-center rounded-xl p-2 text-sm"
-                >
-                  <div className="bg-primary mr-2 items-center justify-center rounded-lg p-[5.5px]">
-                    <img
-                      src={DocumentationDark}
-                      alt="Attachment"
-                      className="h-3.75 w-3.75 object-fill"
-                    />
-                  </div>
-                  <span className="max-w-37.5 truncate font-normal">
-                    {file.fileName}
-                  </span>
-                </div>
+                  file={file}
+                  token={token}
+                  shareId={shareId}
+                />
               ))}
             </div>
           )}

--- a/frontend/src/conversation/ConversationMessages.tsx
+++ b/frontend/src/conversation/ConversationMessages.tsx
@@ -50,6 +50,11 @@ type ConversationMessagesProps = {
   isSplitView?: boolean;
   /** Active agent id; threaded into SchedulerToolCallCard. */
   agentId?: string;
+  /**
+   * Share identifier when rendering a shared conversation view, so image
+   * attachment fetches use share-scoped authorization.
+   */
+  shareId?: string | null;
 };
 
 const MS_VIEWPORT_SELECTOR = '[data-slot="message-scroller-viewport"]';
@@ -72,6 +77,7 @@ export default function ConversationMessages({
   onToolAction,
   isSplitView = false,
   agentId,
+  shareId,
 }: ConversationMessagesProps) {
   const { t } = useTranslation();
 
@@ -291,6 +297,7 @@ export default function ConversationMessages({
                       questionNumber={index}
                       sources={query.sources}
                       filesAttached={query.attachments}
+                      shareId={shareId}
                     />
                   </MessageScrollerItem>
                   {responseView && (

--- a/frontend/src/conversation/SharedConversation.tsx
+++ b/frontend/src/conversation/SharedConversation.tsx
@@ -112,7 +112,12 @@ export const SharedConversation = () => {
 
     const filesAttached = completedAttachments
       .filter((a) => a.id)
-      .map((a) => ({ id: a.id as string, fileName: a.fileName }));
+      .map((a) => ({
+        id: a.id as string,
+        fileName: a.fileName,
+        mimeType: a.mimeType,
+        previewUrl: a.previewUrl,
+      }));
 
     !isRetry &&
       dispatch(
@@ -159,6 +164,7 @@ export const SharedConversation = () => {
           handleQuestionSubmission={handleQuestionSubmission}
           queries={queries}
           status={status}
+          shareId={identifier}
         />
         <div className="flex w-full max-w-290 flex-col items-center gap-4 pb-2 md:w-10/12 lg:w-9/12 xl:w-8/12 2xl:w-7/12">
           {apiKey ? (

--- a/frontend/src/conversation/SharedConversation.tsx
+++ b/frontend/src/conversation/SharedConversation.tsx
@@ -100,6 +100,7 @@ export const SharedConversation = () => {
     }
   };
 
+  /** Send a question in a shared conversation (snapshot attachments first). */
   const handleQuestion = ({
     question,
     isRetry = false,

--- a/frontend/src/conversation/conversationModels.ts
+++ b/frontend/src/conversation/conversationModels.ts
@@ -35,6 +35,20 @@ export interface ResearchState {
   tokens_used?: number;
 }
 
+/**
+ * The display snapshot of a sent attachment, copied from the composer
+ * state into the query row at send time. ``previewUrl`` is a session-local
+ * ``blob:`` URL (images only): present while this session owns the upload,
+ * absent for documents and for rows reloaded from the server — renderers
+ * must fall back to the document icon without it.
+ */
+export interface QueryAttachment {
+  id: string;
+  fileName: string;
+  mimeType?: string;
+  previewUrl?: string;
+}
+
 export interface ConversationState {
   queries: Query[];
   status: Status;
@@ -74,7 +88,7 @@ export interface Query {
   // Non-fatal notice (e.g. some workflow input documents were dropped). Shown
   // alongside the answer; unlike ``error`` it does not fail the turn or end the stream.
   notice?: string;
-  attachments?: { id: string; fileName: string }[];
+  attachments?: QueryAttachment[];
   structured?: boolean;
   schema?: object;
   research?: ResearchState;

--- a/frontend/src/conversation/conversationSlice.ts
+++ b/frontend/src/conversation/conversationSlice.ts
@@ -6,6 +6,7 @@ import {
 } from '@reduxjs/toolkit';
 
 import conversationService from '../api/services/conversationService';
+import { revokeImagePreviewUrl } from '../constants/fileUpload';
 import {
   sseEventReceived,
   type SSEEvent,
@@ -49,6 +50,25 @@ export function mapServerQueryToClient(raw: any): Query {
   // renderer from rendering a blank bubble for in-flight rows and
   // matches the shape live-stream queries start with.
   const toolCalls = Array.isArray(raw?.tool_calls) ? raw.tool_calls : undefined;
+  // The server projects attachments as {id, fileName, mime_type}; the
+  // client snapshot shape is {id, fileName, mimeType, previewUrl}.
+  // Normalise here so reloads and live rows render through one type.
+  const attachments = Array.isArray(raw?.attachments)
+    ? raw.attachments
+        .filter(
+          (a: unknown): a is Record<string, unknown> =>
+            !!a &&
+            typeof (a as Record<string, unknown>).id === 'string' &&
+            typeof (a as Record<string, unknown>).fileName === 'string',
+        )
+        .map((a: Record<string, unknown>) => ({
+          id: a.id as string,
+          fileName: a.fileName as string,
+          mimeType: (a.mime_type ?? a.mimeType ?? undefined) as
+            string | undefined,
+          previewUrl: (a.previewUrl ?? undefined) as string | undefined,
+        }))
+    : undefined;
   const sources = Array.isArray(raw?.sources) ? raw.sources : undefined;
   const query: Query = {
     prompt: raw?.prompt ?? '',
@@ -57,7 +77,7 @@ export function mapServerQueryToClient(raw: any): Query {
     sources: sources && sources.length > 0 ? sources : undefined,
     tool_calls: toolCalls && toolCalls.length > 0 ? toolCalls : undefined,
     workflow_run_id: raw?.workflow_run_id ?? undefined,
-    attachments: raw?.attachments ?? undefined,
+    attachments,
     messageId: raw?.message_id ?? undefined,
     messageStatus: status,
     requestId: raw?.request_id ?? undefined,
@@ -1236,5 +1256,48 @@ conversationListenerMiddleware.startListening({
         error,
       );
     }
+  },
+});
+
+// Listener (not a reducer): releasing an object URL is a browser side
+// effect, and reducers must stay replay-safe. Outgoing query snapshots
+// unmount with their bubbles, so no live <img> references these URLs
+// afterwards — revoking here cannot blank a rendered preview.
+function revokeSnapshotPreviewUrls(queries: Query[]): void {
+  for (const query of queries) {
+    for (const attachment of query.attachments ?? []) {
+      revokeImagePreviewUrl(attachment.previewUrl);
+    }
+  }
+}
+
+conversationListenerMiddleware.startListening({
+  actionCreator: setConversation,
+  effect: (_action, listenerApi) => {
+    revokeSnapshotPreviewUrls(
+      (listenerApi.getOriginalState() as RootState).conversation.queries,
+    );
+  },
+});
+
+conversationListenerMiddleware.startListening({
+  actionCreator: resetConversation,
+  effect: (_action, listenerApi) => {
+    revokeSnapshotPreviewUrls(
+      (listenerApi.getOriginalState() as RootState).conversation.queries,
+    );
+  },
+});
+
+conversationListenerMiddleware.startListening({
+  actionCreator: resendQuery,
+  effect: (action, listenerApi) => {
+    // Only the trimmed tail unmounts; the kept row stays rendered, so
+    // its snapshot is left alone.
+    const { index } = action.payload;
+    const queries = (listenerApi.getOriginalState() as RootState).conversation
+      .queries;
+    if (index < 0 || index >= queries.length) return;
+    revokeSnapshotPreviewUrls(queries.slice(index + 1));
   },
 });

--- a/frontend/src/conversation/conversationSlice.ts
+++ b/frontend/src/conversation/conversationSlice.ts
@@ -36,10 +36,14 @@ import {
 } from './conversationModels';
 import { ToolCallsType } from './types';
 
-// Maps a server message dict into the client ``Query`` shape. Only
-// terminal ``complete`` rows expose ``response``; non-terminal rows
-// would carry the WAL placeholder text, which must never render.
-// ``failed`` rows surface as ``error`` so they pick up Retry.
+/**
+ * Maps a server message dict into the client ``Query`` shape. Only
+ * terminal ``complete`` rows expose ``response``; non-terminal rows
+ * would carry the WAL placeholder text, which must never render.
+ * ``failed`` rows surface as ``error`` so they pick up Retry.
+ * Attachments are normalised to the client snapshot shape (notably
+ * ``mime_type`` -> ``mimeType``) so reloads render like live rows.
+ */
 export function mapServerQueryToClient(raw: any): Query {
   const status = raw?.status as MessageStatus | undefined;
   const isTerminalComplete = status === 'complete';

--- a/frontend/src/conversation/sharedConversationSlice.ts
+++ b/frontend/src/conversation/sharedConversationSlice.ts
@@ -264,19 +264,25 @@ export const sharedConversationSlice = createSlice({
       state.queries[index].thought = '';
     },
     saveToLocalStorage(state) {
+      // Persist without session-local blob preview URLs: they die with
+      // the document, and a reloaded row must resolve its image through
+      // the preview endpoint (by ID + share identifier) instead.
+      const last = state.queries[state.queries.length - 1];
+      const storable = {
+        ...last,
+        attachments: last?.attachments?.map((a) => ({
+          id: a.id,
+          fileName: a.fileName,
+          mimeType: a.mimeType,
+        })),
+      };
       const previousQueriesStr = localStorage.getItem(state.identifier);
       previousQueriesStr
         ? localStorage.setItem(
             state.identifier,
-            JSON.stringify([
-              ...JSON.parse(previousQueriesStr),
-              state.queries[state.queries.length - 1],
-            ]),
+            JSON.stringify([...JSON.parse(previousQueriesStr), storable]),
           )
-        : localStorage.setItem(
-            state.identifier,
-            JSON.stringify([state.queries[state.queries.length - 1]]),
-          );
+        : localStorage.setItem(state.identifier, JSON.stringify([storable]));
     },
   },
   extraReducers(builder) {

--- a/frontend/src/conversation/sharedConversationSlice.ts
+++ b/frontend/src/conversation/sharedConversationSlice.ts
@@ -28,6 +28,7 @@ const initialState: SharedConversationsType = {
   status: 'idle',
 };
 
+/** Fetch an answer in a shared conversation, consuming completed attachments. */
 export const fetchSharedAnswer = createAsyncThunk<Answer, { question: string }>(
   'shared/fetchAnswer',
   async ({ question }, { dispatch, getState, signal }) => {
@@ -263,10 +264,13 @@ export const sharedConversationSlice = createSlice({
       state.queries[index].response = '';
       state.queries[index].thought = '';
     },
+    /**
+     * Persist the latest query for share-link reloads, without
+     * session-local blob preview URLs: they die with the document, and a
+     * reloaded row must resolve its image through the preview endpoint
+     * (by ID + share identifier) instead.
+     */
     saveToLocalStorage(state) {
-      // Persist without session-local blob preview URLs: they die with
-      // the document, and a reloaded row must resolve its image through
-      // the preview endpoint (by ID + share identifier) instead.
       const last = state.queries[state.queries.length - 1];
       const storable = {
         ...last,

--- a/frontend/src/conversation/useAttachmentPreview.test.tsx
+++ b/frontend/src/conversation/useAttachmentPreview.test.tsx
@@ -12,6 +12,7 @@ vi.mock('../api/services/userService', () => ({
 
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 
+/** Host rendering the hook result as text for assertions. */
 function Host({
   attachment,
   token,
@@ -49,6 +50,7 @@ describe('useAttachmentPreviewUrl', () => {
     URL.createObjectURL = realCreateObjectURL;
   });
 
+  /** Render the hook with a token defaulting to a dummy value. */
   const render = async (
     attachment: AttachmentPreviewSource,
     token: string | null = 'tok',
@@ -61,6 +63,7 @@ describe('useAttachmentPreviewUrl', () => {
     });
   };
 
+  /** Successful image fetch resolving to in-memory bytes. */
   const okImage = () =>
     mockGetPreview.mockResolvedValue(
       new Response(new Blob(['imgbytes'], { type: 'image/png' })),

--- a/frontend/src/conversation/useAttachmentPreview.test.tsx
+++ b/frontend/src/conversation/useAttachmentPreview.test.tsx
@@ -1,0 +1,133 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useAttachmentPreviewUrl } from './useAttachmentPreview';
+import type { AttachmentPreviewSource } from './useAttachmentPreview';
+
+const { mockGetPreview } = vi.hoisted(() => ({ mockGetPreview: vi.fn() }));
+vi.mock('../api/services/userService', () => ({
+  default: { getAttachmentPreview: mockGetPreview },
+}));
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+function Host({
+  attachment,
+  token,
+  shareId,
+}: {
+  attachment: {
+    id?: string;
+    fileName?: string;
+    mimeType?: string;
+    previewUrl?: string;
+  };
+  token: string | null;
+  shareId?: string | null;
+}) {
+  const url = useAttachmentPreviewUrl(attachment, token, shareId);
+  return <span>{url ?? 'none'}</span>;
+}
+
+describe('useAttachmentPreviewUrl', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const realCreateObjectURL = URL.createObjectURL;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mockGetPreview.mockReset();
+    URL.createObjectURL = (() => 'blob:fetched') as typeof URL.createObjectURL;
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    URL.createObjectURL = realCreateObjectURL;
+  });
+
+  const render = async (
+    attachment: AttachmentPreviewSource,
+    token: string | null = 'tok',
+    shareId?: string | null,
+  ) => {
+    await act(async () => {
+      root.render(
+        <Host attachment={attachment} token={token} shareId={shareId} />,
+      );
+    });
+  };
+
+  const okImage = () =>
+    mockGetPreview.mockResolvedValue(
+      new Response(new Blob(['imgbytes'], { type: 'image/png' })),
+    );
+
+  it('reuses a live snapshot previewUrl without fetching', async () => {
+    await render({
+      id: 'a1',
+      fileName: 'photo.png',
+      mimeType: 'image/png',
+      previewUrl: 'blob:snap',
+    });
+    expect(container.textContent).toBe('blob:snap');
+    expect(mockGetPreview).not.toHaveBeenCalled();
+  });
+
+  it('fetches image bytes by ID when no snapshot URL exists', async () => {
+    okImage();
+    await render({ id: 'att-1', fileName: 'photo.png', mimeType: 'image/png' });
+    expect(container.textContent).toBe('blob:fetched');
+    expect(mockGetPreview).toHaveBeenCalledWith('att-1', 'tok', undefined);
+  });
+
+  it('fetches for image suffixes when the mime type is absent', async () => {
+    okImage();
+    await render({ id: 'att-2', fileName: 'scan.webp' });
+    expect(container.textContent).toBe('blob:fetched');
+  });
+
+  it('never fetches for non-image attachments', async () => {
+    await render({
+      id: 'att-3',
+      fileName: 'doc.pdf',
+      mimeType: 'application/pdf',
+    });
+    expect(container.textContent).toBe('none');
+    expect(mockGetPreview).not.toHaveBeenCalled();
+  });
+
+  it('falls back to null when the fetch fails', async () => {
+    mockGetPreview.mockResolvedValue(new Response(null, { status: 404 }));
+    await render({ id: 'att-4', fileName: 'photo.png', mimeType: 'image/png' });
+    expect(container.textContent).toBe('none');
+  });
+
+  it('passes the share identifier through for share-scoped fetches', async () => {
+    okImage();
+    await render(
+      { id: 'att-5', fileName: 'photo.png', mimeType: 'image/png' },
+      null,
+      'share-9',
+    );
+    expect(mockGetPreview).toHaveBeenCalledWith('att-5', null, 'share-9');
+    expect(container.textContent).toBe('blob:fetched');
+  });
+
+  it('caches by attachment ID and does not refetch on remount', async () => {
+    okImage();
+    await render({ id: 'att-6', fileName: 'photo.png', mimeType: 'image/png' });
+    expect(container.textContent).toBe('blob:fetched');
+    await act(async () => root.unmount());
+    container.remove();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await render({ id: 'att-6', fileName: 'photo.png', mimeType: 'image/png' });
+    expect(container.textContent).toBe('blob:fetched');
+    expect(mockGetPreview).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/conversation/useAttachmentPreview.ts
+++ b/frontend/src/conversation/useAttachmentPreview.ts
@@ -17,6 +17,7 @@ function cacheKey(attachmentId: string, shareId?: string | null): string {
   return `${shareId ?? ''}:${attachmentId}`;
 }
 
+/** Insert, refreshing recency and evicting (revoking) past the cap. */
 function cacheSet(key: string, url: string): void {
   previewCache.delete(key);
   previewCache.set(key, url);
@@ -35,6 +36,7 @@ function cacheSet(key: string, url: string): void {
   }
 }
 
+/** Whether the row carries enough image signal to attempt a fetch. */
 function isPreviewableImage(attachment: {
   mimeType?: string;
   fileName?: string;
@@ -51,6 +53,7 @@ function isPreviewableImage(attachment: {
   return false;
 }
 
+/** Fetch-once bytes for an attachment ID, cached as a blob URL. */
 async function fetchPreviewUrl(
   attachmentId: string,
   token: string | null,

--- a/frontend/src/conversation/useAttachmentPreview.ts
+++ b/frontend/src/conversation/useAttachmentPreview.ts
@@ -1,0 +1,143 @@
+import { useEffect, useState } from 'react';
+
+import userService from '../api/services/userService';
+import { isImageFileName } from '../constants/fileUpload';
+
+/**
+ * Session cache of attachment-id -> blob URL, so a conversation that shows
+ * the same image twice (re-render, scroll-back, duplicate turns) fetches
+ * its bytes once. Bounded: the least-recently-used entry is evicted (and
+ * revoked) past the cap, and a later revisit simply refetches.
+ */
+const previewCache = new Map<string, string>();
+const previewInflight = new Map<string, Promise<string | null>>();
+const PREVIEW_CACHE_CAP = 50;
+
+function cacheKey(attachmentId: string, shareId?: string | null): string {
+  return `${shareId ?? ''}:${attachmentId}`;
+}
+
+function cacheSet(key: string, url: string): void {
+  previewCache.delete(key);
+  previewCache.set(key, url);
+  while (previewCache.size > PREVIEW_CACHE_CAP) {
+    const oldest = previewCache.keys().next();
+    if (oldest.done) break;
+    const oldestUrl = previewCache.get(oldest.value);
+    previewCache.delete(oldest.value);
+    if (oldestUrl) {
+      try {
+        URL.revokeObjectURL(oldestUrl);
+      } catch {
+        // Already revoked — nothing to do.
+      }
+    }
+  }
+}
+
+function isPreviewableImage(attachment: {
+  mimeType?: string;
+  fileName?: string;
+}): boolean {
+  if (
+    attachment.mimeType &&
+    attachment.mimeType.toLowerCase().startsWith('image/')
+  ) {
+    return true;
+  }
+  if (attachment.fileName) {
+    return isImageFileName(attachment.fileName);
+  }
+  return false;
+}
+
+async function fetchPreviewUrl(
+  attachmentId: string,
+  token: string | null,
+  shareId?: string | null,
+): Promise<string | null> {
+  const key = cacheKey(attachmentId, shareId);
+  const cached = previewCache.get(key);
+  if (cached) {
+    // Refresh recency.
+    previewCache.delete(key);
+    previewCache.set(key, cached);
+    return cached;
+  }
+  const inflight = previewInflight.get(key);
+  if (inflight) return inflight;
+
+  const pending = (async () => {
+    try {
+      const response: Response = await userService.getAttachmentPreview(
+        attachmentId,
+        token,
+        shareId,
+      );
+      if (!response.ok) return null;
+      const blob = await response.blob();
+      if (blob.size === 0) return null;
+      const url = URL.createObjectURL(blob);
+      cacheSet(key, url);
+      return url;
+    } catch {
+      return null;
+    } finally {
+      previewInflight.delete(key);
+    }
+  })();
+  previewInflight.set(key, pending);
+  return pending;
+}
+
+export type AttachmentPreviewSource = {
+  id?: string;
+  fileName?: string;
+  mimeType?: string;
+  previewUrl?: string;
+};
+
+/**
+ * Resolve an attachment to a renderable image URL, in priority order:
+ * live snapshot ``previewUrl`` (instant, no fetch) -> fetched bytes for
+ * the attachment ID (session-cached) -> ``null`` (caller renders the
+ * generic icon).
+ *
+ * Non-image attachments never fetch. Failures resolve to ``null`` so the
+ * caller falls back gracefully. Blob URLs minted here are owned by the
+ * module cache (LRU-revoked); callers must NOT revoke them.
+ */
+export function useAttachmentPreviewUrl(
+  attachment: AttachmentPreviewSource | undefined,
+  token: string | null,
+  shareId?: string | null,
+): string | null {
+  const snapshotUrl = attachment?.previewUrl ?? null;
+  const attachmentId = attachment?.id;
+  const shouldFetch =
+    !snapshotUrl &&
+    !!attachmentId &&
+    isPreviewableImage({
+      mimeType: attachment?.mimeType,
+      fileName: attachment?.fileName,
+    });
+
+  const [fetchedUrl, setFetchedUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!shouldFetch || !attachmentId) {
+      setFetchedUrl(null);
+      return;
+    }
+    let cancelled = false;
+    setFetchedUrl(null);
+    fetchPreviewUrl(attachmentId, token, shareId).then((url) => {
+      if (!cancelled) setFetchedUrl(url);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [shouldFetch, attachmentId, token, shareId]);
+
+  return snapshotUrl ?? fetchedUrl;
+}

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -9,6 +9,7 @@ import {
 } from './conversation/conversationSlice';
 import { sharedConversationSlice } from './conversation/sharedConversationSlice';
 import notificationsReducer from './notifications/notificationsSlice';
+import { uploadListenerMiddleware } from './upload/uploadSlice';
 import { getStoredRecentDocs } from './preferences/preferenceApi';
 import {
   Preference,
@@ -85,6 +86,7 @@ const store = configureStore({
     getDefaultMiddleware().concat(
       prefListenerMiddleware.middleware,
       conversationListenerMiddleware.middleware,
+      uploadListenerMiddleware.middleware,
     ),
 });
 

--- a/frontend/src/upload/uploadSlice.test.ts
+++ b/frontend/src/upload/uploadSlice.test.ts
@@ -555,6 +555,7 @@ describe('attachment preview URL lifecycle', () => {
   const realRevoke = URL.revokeObjectURL;
   let revoked: string[];
 
+  /** Completed image-attachment fixture with a live preview URL. */
   const imgAtt = (over: Partial<Attachment> = {}): Attachment => ({
     id: 'a1',
     fileName: 'photo.png',
@@ -568,6 +569,7 @@ describe('attachment preview URL lifecycle', () => {
 
   // Reducers stay pure: revocation runs in uploadListenerMiddleware.
   // These tests drive a real store so the listeners fire.
+  /** Static slice stub holding a fixed query list for live-URL checks. */
   const stubScope = (
     queries: { attachments?: { previewUrl?: string }[] }[],
   ) => {
@@ -575,6 +577,7 @@ describe('attachment preview URL lifecycle', () => {
     return (state = initial) => state;
   };
 
+  /** Test store: real upload slice + query stubs + listener middleware. */
   const makeStore = (
     conversationQueries: { attachments?: { previewUrl?: string }[] }[] = [],
   ) =>
@@ -588,6 +591,7 @@ describe('attachment preview URL lifecycle', () => {
         getDefault().concat(uploadListenerMiddleware.middleware),
     });
 
+  /** Let queued listener effects run to completion. */
   const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
   beforeEach(() => {

--- a/frontend/src/upload/uploadSlice.test.ts
+++ b/frontend/src/upload/uploadSlice.test.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { configureStore } from '@reduxjs/toolkit';
 
 import notificationsReducer, {
   sseEventReceived,
@@ -7,9 +9,12 @@ import notificationsReducer, {
 import reducer, {
   addAttachment,
   addUploadTask,
+  clearAttachments,
   dismissUploadTask,
+  removeAttachment,
   updateAttachment,
   updateUploadTask,
+  uploadListenerMiddleware,
   type Attachment,
   type UploadTask,
 } from './uploadSlice';
@@ -543,5 +548,116 @@ describe('upload race — SSE auto-created duplicate absorbed on sourceId bind',
     expect(task.id).toBe('client-1');
     expect(task.status).toBe('completed');
     expect(task.progress).toBe(100);
+  });
+});
+
+describe('attachment preview URL lifecycle', () => {
+  const realRevoke = URL.revokeObjectURL;
+  let revoked: string[];
+
+  const imgAtt = (over: Partial<Attachment> = {}): Attachment => ({
+    id: 'a1',
+    fileName: 'photo.png',
+    progress: 100,
+    status: 'completed',
+    taskId: 't1',
+    mimeType: 'image/png',
+    previewUrl: 'blob:photo-1',
+    ...over,
+  });
+
+  // Reducers stay pure: revocation runs in uploadListenerMiddleware.
+  // These tests drive a real store so the listeners fire.
+  const stubScope = (
+    queries: { attachments?: { previewUrl?: string }[] }[],
+  ) => {
+    const initial = { queries, status: 'idle' as const };
+    return (state = initial) => state;
+  };
+
+  const makeStore = (
+    conversationQueries: { attachments?: { previewUrl?: string }[] }[] = [],
+  ) =>
+    configureStore({
+      reducer: {
+        upload: reducer,
+        conversation: stubScope(conversationQueries),
+        sharedConversation: stubScope([]),
+      },
+      middleware: (getDefault) =>
+        getDefault().concat(uploadListenerMiddleware.middleware),
+    });
+
+  const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  beforeEach(() => {
+    revoked = [];
+    URL.revokeObjectURL = ((url: string) => {
+      revoked.push(url);
+    }) as typeof URL.revokeObjectURL;
+  });
+
+  afterEach(() => {
+    URL.revokeObjectURL = realRevoke;
+  });
+
+  it('reducers stay pure: remove/clear change state without revoking', () => {
+    let state = reducer(undefined, addAttachment(imgAtt()));
+    state = reducer(state, removeAttachment('a1'));
+    expect(state.attachments).toHaveLength(0);
+    state = reducer(undefined, addAttachment(imgAtt()));
+    state = reducer(state, clearAttachments());
+    expect(state.attachments).toHaveLength(0);
+    expect(revoked).toEqual([]);
+  });
+
+  it('removeAttachment revokes the removed preview URL', async () => {
+    const store = makeStore();
+    store.dispatch(addAttachment(imgAtt()));
+    store.dispatch(removeAttachment('a1'));
+    await flush();
+    expect(store.getState().upload.attachments).toHaveLength(0);
+    expect(revoked).toEqual(['blob:photo-1']);
+  });
+
+  it('removeAttachment leaves other rows and their URLs alone', async () => {
+    const store = makeStore();
+    store.dispatch(addAttachment(imgAtt()));
+    store.dispatch(
+      addAttachment(imgAtt({ id: 'a2', previewUrl: 'blob:photo-2' })),
+    );
+    store.dispatch(removeAttachment('a1'));
+    await flush();
+    expect(store.getState().upload.attachments.map((a) => a.id)).toEqual([
+      'a2',
+    ]);
+    expect(revoked).toEqual(['blob:photo-1']);
+  });
+
+  it('clearAttachments revokes dropped previews but keeps query-referenced ones', async () => {
+    const store = makeStore([
+      { attachments: [{ previewUrl: 'blob:photo-2' }] },
+    ]);
+    store.dispatch(addAttachment(imgAtt()));
+    store.dispatch(
+      addAttachment(imgAtt({ id: 'a2', previewUrl: 'blob:photo-2' })),
+    );
+    store.dispatch(clearAttachments());
+    await flush();
+    expect(store.getState().upload.attachments).toHaveLength(0);
+    expect(revoked).toEqual(['blob:photo-1']);
+  });
+
+  it('clearAttachments keeps in-flight rows without revoking them', async () => {
+    const store = makeStore();
+    store.dispatch(
+      addAttachment(imgAtt({ id: 'up', status: 'uploading', progress: 10 })),
+    );
+    store.dispatch(clearAttachments());
+    await flush();
+    expect(store.getState().upload.attachments.map((a) => a.id)).toEqual([
+      'up',
+    ]);
+    expect(revoked).toEqual([]);
   });
 });

--- a/frontend/src/upload/uploadSlice.ts
+++ b/frontend/src/upload/uploadSlice.ts
@@ -1,5 +1,11 @@
-import { createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import {
+  createListenerMiddleware,
+  createSelector,
+  createSlice,
+  PayloadAction,
+} from '@reduxjs/toolkit';
 
+import { revokeImagePreviewUrl } from '../constants/fileUpload';
 import {
   DismissedEntry,
   isDismissed,
@@ -46,6 +52,15 @@ export interface Attachment {
    */
   attachmentId?: string;
   token_count?: number;
+  /** Picker-reported mime type (e.g. ``image/png``), when known. */
+  mimeType?: string;
+  /**
+   * Session-local ``blob:`` preview URL for image attachments, created at
+   * upload time. Never persisted — it dies with the document. Revoked when
+   * the chip is removed/cleared and, after a send transfers ownership to
+   * the query snapshot, when that query leaves the conversation state.
+   */
+  previewUrl?: string;
   /** Why a ``failed`` attachment failed, when known (server or client gate). */
   errorMessage?: string;
 }
@@ -426,5 +441,59 @@ export const selectCompletedAttachments = createSelector(
   (attachments) => attachments.filter((att) => att.status === 'completed'),
 );
 export const selectUploadTasks = (state: RootState) => state.upload.tasks;
+
+/** Preview URLs referenced by any live query snapshot (both chat scopes). */
+function collectLiveQueryPreviewUrls(state: RootState): Set<string> {
+  const live = new Set<string>();
+  const scopes = [state.conversation.queries, state.sharedConversation.queries];
+  for (const queries of scopes) {
+    for (const query of queries ?? []) {
+      for (const attachment of query.attachments ?? []) {
+        if (attachment.previewUrl) live.add(attachment.previewUrl);
+      }
+    }
+  }
+  return live;
+}
+
+// Listener (not a reducer): releasing an object URL is a browser side
+// effect, and reducers must stay replay-safe — re-running a reducer (Redux
+// DevTools time-travel) must never destroy URLs live state still shows.
+export const uploadListenerMiddleware = createListenerMiddleware();
+
+uploadListenerMiddleware.startListening({
+  actionCreator: removeAttachment,
+  effect: (action, listenerApi) => {
+    // A row still present in the composer was never snapshotted into a
+    // query (sends clear the composer in the same synchronous handler),
+    // so no bubble can reference this URL.
+    const original = listenerApi.getOriginalState() as RootState;
+    const removed = original.upload.attachments.find(
+      (att) => att.id === action.payload,
+    );
+    revokeImagePreviewUrl(removed?.previewUrl);
+  },
+});
+
+uploadListenerMiddleware.startListening({
+  actionCreator: clearAttachments,
+  effect: (_action, listenerApi) => {
+    const original = listenerApi.getOriginalState() as RootState;
+    const dropped = original.upload.attachments.filter(
+      (att) => att.status !== 'uploading' && att.status !== 'processing',
+    );
+    if (dropped.length === 0) return;
+    // A just-sent row's URL may already live on in its query snapshot
+    // (the send handler snapshotted first): the bubble fetches by ID as
+    // a fallback, but keeping the instant URL avoids a flash + refetch.
+    const state = listenerApi.getState() as RootState;
+    const live = collectLiveQueryPreviewUrls(state);
+    for (const att of dropped) {
+      if (att.previewUrl && !live.has(att.previewUrl)) {
+        revokeImagePreviewUrl(att.previewUrl);
+      }
+    }
+  },
+});
 
 export default uploadSlice.reducer;

--- a/tests/api/user/attachments/test_routes.py
+++ b/tests/api/user/attachments/test_routes.py
@@ -2865,7 +2865,10 @@ class TestAttachmentPreview:
         assert response.headers["Cache-Control"] == "no-store"
         assert response.headers.get("X-Content-Type-Options") == "nosniff"
         mock_storage.generate_presigned_url.assert_called_once_with(
-            self.upload_path, expires_in=300, content_type="image/png"
+            self.upload_path,
+            expires_in=300,
+            content_type="image/png",
+            cache_control="no-store",
         )
         mock_storage.get_file.assert_not_called()
 

--- a/tests/api/user/attachments/test_routes.py
+++ b/tests/api/user/attachments/test_routes.py
@@ -2517,3 +2517,391 @@ class TestStoreAttachmentTypeGate:
         ]
         assert mock_storage.save_file.call_count == 1
         assert mock_store_attachment.call_count == 1
+
+
+@pytest.mark.unit
+class TestAttachmentPreview:
+    """Tests for the AttachmentPreview endpoint (issue #2483)."""
+
+    attachment_id = "11111111-1111-4111-8111-111111111111"
+    upload_path = (
+        "inputs/user123/attachments/"
+        "11111111-1111-4111-8111-111111111111/photo.png"
+    )
+    png_bytes = b"\x89PNG\r\n\x1a\n"
+
+    def _row(self, **overrides):
+        row = {
+            "id": self.attachment_id,
+            "user_id": "user123",
+            "filename": "photo.png",
+            "upload_path": self.upload_path,
+            "mime_type": "image/png",
+            "size": len(self.png_bytes),
+        }
+        row.update(overrides)
+        return row
+
+    @staticmethod
+    def _patch_repos(attachment_row):
+        mock_repo = MagicMock()
+        mock_repo.get_any.return_value = attachment_row
+        return (
+            patch(
+                "application.api.user.attachments.routes.AttachmentsRepository",
+                return_value=mock_repo,
+            ),
+            patch(
+                "application.api.user.attachments.routes.db_readonly",
+                _fake_readonly,
+            ),
+            patch(
+                "application.api.user.attachments.routes.settings.STORAGE_TYPE",
+                "local",
+            ),
+        )
+
+    @staticmethod
+    def _mock_storage(body=None):
+        mock_storage = MagicMock()
+        payload = TestAttachmentPreview.png_bytes if body is None else body
+        mock_storage.get_file_size.return_value = len(payload)
+        mock_storage.get_file.return_value = io.BytesIO(payload)
+        return mock_storage
+
+    def test_preview_image_success(self, flask_app):
+        from application.api.user.attachments.routes import AttachmentPreview
+
+        app = Flask(__name__)
+        mock_storage = self._mock_storage()
+        p_repo, p_db, p_store = self._patch_repos(self._row())
+
+        with p_repo, p_db, p_store, patch(
+            "application.api.user.base.storage", mock_storage
+        ):
+            with app.test_request_context(
+                f"/api/attachment/{self.attachment_id}/preview",
+                method="GET",
+            ):
+                request.decoded_token = {"sub": "user123"}
+                response = AttachmentPreview().get(self.attachment_id)
+
+                assert _get_response_status(response) == 200
+                assert response.headers.get("Content-Type") == "image/png"
+                assert response.headers.get("X-Content-Type-Options") == "nosniff"
+                assert b"".join(response.response) == self.png_bytes
+                mock_storage.get_file.assert_called_once_with(self.upload_path)
+
+    def test_preview_prefers_stored_mime_type(self, flask_app):
+        from application.api.user.attachments.routes import AttachmentPreview
+
+        app = Flask(__name__)
+        mock_storage = self._mock_storage(b"\xff\xd8\xff\xe0")
+        row = self._row(filename="photo.jpg", mime_type="image/jpeg")
+        p_repo, p_db, p_store = self._patch_repos(row)
+
+        with p_repo, p_db, p_store, patch(
+            "application.api.user.base.storage", mock_storage
+        ):
+            with app.test_request_context(
+                f"/api/attachment/{self.attachment_id}/preview",
+                method="GET",
+            ):
+                request.decoded_token = {"sub": "user123"}
+                response = AttachmentPreview().get(self.attachment_id)
+
+                assert _get_response_status(response) == 200
+                assert response.headers.get("Content-Type") == "image/jpeg"
+
+    def test_preview_legacy_null_mime_falls_back_to_suffix(self, flask_app):
+        from application.api.user.attachments.routes import AttachmentPreview
+
+        app = Flask(__name__)
+        mock_storage = self._mock_storage()
+        row = self._row(mime_type=None)
+        p_repo, p_db, p_store = self._patch_repos(row)
+
+        with p_repo, p_db, p_store, patch(
+            "application.api.user.base.storage", mock_storage
+        ):
+            with app.test_request_context(
+                f"/api/attachment/{self.attachment_id}/preview",
+                method="GET",
+            ):
+                request.decoded_token = {"sub": "user123"}
+                response = AttachmentPreview().get(self.attachment_id)
+
+                assert _get_response_status(response) == 200
+                assert response.headers.get("Content-Type") == "image/png"
+
+    def test_preview_missing_attachment_returns_404(self, flask_app):
+        from application.api.user.attachments.routes import AttachmentPreview
+
+        app = Flask(__name__)
+        mock_storage = self._mock_storage()
+        p_repo, p_db, p_store = self._patch_repos(None)
+
+        with p_repo, p_db, p_store, patch(
+            "application.api.user.base.storage", mock_storage
+        ):
+            with app.test_request_context(
+                f"/api/attachment/{self.attachment_id}/preview",
+                method="GET",
+            ):
+                request.decoded_token = {"sub": "user123"}
+                response = AttachmentPreview().get(self.attachment_id)
+
+                assert _get_response_status(response) == 404
+                mock_storage.get_file.assert_not_called()
+
+    def test_preview_foreign_attachment_returns_404(self, flask_app):
+        # A row owned by another user resolves to None for this caller —
+        # same blanket 404, no existence oracle.
+        from application.api.user.attachments.routes import AttachmentPreview
+
+        app = Flask(__name__)
+        mock_storage = self._mock_storage()
+        p_repo, p_db, p_store = self._patch_repos(None)
+
+        with p_repo, p_db, p_store, patch(
+            "application.api.user.base.storage", mock_storage
+        ):
+            with app.test_request_context(
+                f"/api/attachment/{self.attachment_id}/preview",
+                method="GET",
+            ):
+                request.decoded_token = {"sub": "someone-else"}
+                response = AttachmentPreview().get(self.attachment_id)
+
+                assert _get_response_status(response) == 404
+                mock_storage.get_file.assert_not_called()
+
+    def test_preview_non_image_returns_404_without_reading_bytes(self, flask_app):
+        from application.api.user.attachments.routes import AttachmentPreview
+
+        app = Flask(__name__)
+        mock_storage = self._mock_storage(b"%PDF-1.4")
+        row = self._row(filename="doc.pdf", mime_type="application/pdf")
+        p_repo, p_db, p_store = self._patch_repos(row)
+
+        with p_repo, p_db, p_store, patch(
+            "application.api.user.base.storage", mock_storage
+        ):
+            with app.test_request_context(
+                f"/api/attachment/{self.attachment_id}/preview",
+                method="GET",
+            ):
+                request.decoded_token = {"sub": "user123"}
+                response = AttachmentPreview().get(self.attachment_id)
+
+                assert _get_response_status(response) == 404
+                mock_storage.get_file.assert_not_called()
+
+    def test_preview_no_auth_returns_401(self, flask_app):
+        from application.api.user.attachments.routes import AttachmentPreview
+
+        app = Flask(__name__)
+        mock_storage = self._mock_storage()
+        p_repo, p_db, p_store = self._patch_repos(self._row())
+
+        with p_repo, p_db, p_store, patch(
+            "application.api.user.base.storage", mock_storage
+        ):
+            with app.test_request_context(
+                f"/api/attachment/{self.attachment_id}/preview",
+                method="GET",
+            ):
+                request.decoded_token = None
+                response = AttachmentPreview().get(self.attachment_id)
+
+                assert _get_response_status(response) == 401
+                mock_storage.get_file.assert_not_called()
+
+    def test_preview_invalid_api_key_returns_401(self, flask_app):
+        from application.api.user.attachments.routes import AttachmentPreview
+
+        app = Flask(__name__)
+        mock_storage = self._mock_storage()
+        p_repo, p_db, p_store = self._patch_repos(self._row())
+        p1, p2 = _patch_agents_repo(None)
+
+        with p_repo, p_db, p_store, p1, p2, patch(
+            "application.api.user.base.storage", mock_storage
+        ):
+            with app.test_request_context(
+                f"/api/attachment/{self.attachment_id}/preview?api_key=bad",
+                method="GET",
+            ):
+                request.decoded_token = None
+                response = AttachmentPreview().get(self.attachment_id)
+
+                assert _get_response_status(response) == 401
+                mock_storage.get_file.assert_not_called()
+
+    def test_preview_oversized_attachment_returns_404(self, flask_app):
+        from application.api.user.attachments.routes import AttachmentPreview
+
+        app = Flask(__name__)
+        mock_storage = self._mock_storage(b"\x89PNG\r\n")
+        p_repo, p_db, p_store = self._patch_repos(self._row())
+
+        with p_repo, p_db, p_store, patch(
+            "application.api.user.base.storage", mock_storage
+        ), patch(
+            "application.api.user.attachments.routes.settings.UPLOAD_MAX_FILE_BYTES",
+            4,
+        ):
+            with app.test_request_context(
+                f"/api/attachment/{self.attachment_id}/preview",
+                method="GET",
+            ):
+                request.decoded_token = {"sub": "user123"}
+                response = AttachmentPreview().get(self.attachment_id)
+
+                assert _get_response_status(response) == 404
+                mock_storage.get_file.assert_not_called()
+
+    def test_preview_s3_redirects_without_downloading_object(self, flask_app):
+        from application.api.user.attachments.routes import AttachmentPreview
+
+        app = Flask(__name__)
+        mock_storage = MagicMock()
+        mock_storage.get_file_size.return_value = len(self.png_bytes)
+        mock_storage.generate_presigned_url.return_value = (
+            "https://bucket.example/preview.png?signature=short-lived"
+        )
+        p_repo, p_db, _ = self._patch_repos(self._row())
+
+        with p_repo, p_db, patch(
+            "application.api.user.attachments.routes.settings.STORAGE_TYPE", "s3"
+        ), patch("application.api.user.base.storage", mock_storage):
+            with app.test_request_context(
+                f"/api/attachment/{self.attachment_id}/preview",
+                method="GET",
+            ):
+                request.decoded_token = {"sub": "user123"}
+                response = AttachmentPreview().get(self.attachment_id)
+
+        assert response.status_code == 302
+        assert response.headers["Location"].startswith("https://bucket.example/")
+        assert response.headers["Cache-Control"] == "private, max-age=240"
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+        mock_storage.generate_presigned_url.assert_called_once_with(
+            self.upload_path, expires_in=300, content_type="image/png"
+        )
+        mock_storage.get_file.assert_not_called()
+
+    share_id = "22222222-2222-4222-8222-222222222222"
+    conv_id = "33333333-3333-4333-8333-333333333333"
+
+    def _patch_share(self, share_row, messages):
+        mock_shared = MagicMock()
+        mock_shared.find_by_uuid.return_value = share_row
+        mock_conv = MagicMock()
+        mock_conv.get_owned.return_value = {"id": self.conv_id}
+        mock_conv.get_messages.return_value = messages
+        return (
+            patch(
+                "application.api.user.attachments.routes.SharedConversationsRepository",
+                return_value=mock_shared,
+            ),
+            patch(
+                "application.api.user.attachments.routes.ConversationsRepository",
+                return_value=mock_conv,
+            ),
+        )
+
+    def _share_row(self, **overrides):
+        row = {
+            "uuid": self.share_id,
+            "conversation_id": self.conv_id,
+            "user_id": "owner1",
+            "first_n_queries": 2,
+            "is_promptable": False,
+            "api_key": None,
+        }
+        row.update(overrides)
+        return row
+
+    def test_preview_share_success(self, flask_app):
+        from application.api.user.attachments.routes import AttachmentPreview
+
+        app = Flask(__name__)
+        mock_storage = self._mock_storage()
+        p_repo, p_db, p_store = self._patch_repos(self._row(user_id="owner1"))
+        p_share, p_conv = self._patch_share(
+            self._share_row(),
+            [
+                {"attachments": ["other-id"]},
+                {"attachments": [self.attachment_id]},
+            ],
+        )
+
+        with p_repo, p_db, p_store, p_share, p_conv, patch(
+            "application.api.user.base.storage", mock_storage
+        ):
+            with app.test_request_context(
+                f"/api/attachment/{self.attachment_id}/preview"
+                f"?share={self.share_id}",
+                method="GET",
+            ):
+                request.decoded_token = None
+                response = AttachmentPreview().get(self.attachment_id)
+
+                assert _get_response_status(response) == 200
+                assert response.headers.get("Content-Type") == "image/png"
+                assert b"".join(response.response) == self.png_bytes
+                mock_storage.get_file.assert_called_once_with(self.upload_path)
+
+    def test_preview_share_nonmember_attachment_returns_404(self, flask_app):
+        # The share capability only covers attachments of the share's
+        # visible messages — never the owner's other files.
+        from application.api.user.attachments.routes import AttachmentPreview
+
+        app = Flask(__name__)
+        mock_storage = self._mock_storage()
+        p_repo, p_db, p_store = self._patch_repos(self._row(user_id="owner1"))
+        p_share, p_conv = self._patch_share(
+            self._share_row(),
+            [{"attachments": ["other-id"]}],
+        )
+
+        with p_repo, p_db, p_store, p_share, p_conv, patch(
+            "application.api.user.base.storage", mock_storage
+        ):
+            with app.test_request_context(
+                f"/api/attachment/{self.attachment_id}/preview"
+                f"?share={self.share_id}",
+                method="GET",
+            ):
+                request.decoded_token = None
+                response = AttachmentPreview().get(self.attachment_id)
+
+                assert _get_response_status(response) == 404
+                mock_storage.get_file.assert_not_called()
+
+    def test_preview_share_unknown_identifier_returns_404(self, flask_app):
+        from application.api.user.attachments.routes import AttachmentPreview
+
+        app = Flask(__name__)
+        mock_storage = self._mock_storage()
+        p_repo, p_db, p_store = self._patch_repos(self._row(user_id="owner1"))
+        mock_shared = MagicMock()
+        mock_shared.find_by_uuid.return_value = None
+        p_share = patch(
+            "application.api.user.attachments.routes.SharedConversationsRepository",
+            return_value=mock_shared,
+        )
+
+        with p_repo, p_db, p_store, p_share, patch(
+            "application.api.user.base.storage", mock_storage
+        ):
+            with app.test_request_context(
+                f"/api/attachment/{self.attachment_id}/preview?share={self.share_id}",
+                method="GET",
+            ):
+                request.decoded_token = None
+                response = AttachmentPreview().get(self.attachment_id)
+
+                assert _get_response_status(response) == 404
+                mock_storage.get_file.assert_not_called()

--- a/tests/api/user/attachments/test_routes.py
+++ b/tests/api/user/attachments/test_routes.py
@@ -2531,6 +2531,7 @@ class TestAttachmentPreview:
     png_bytes = b"\x89PNG\r\n\x1a\n"
 
     def _row(self, **overrides):
+        """Attachment DB row fixture (image PNG owned by user123)."""
         row = {
             "id": self.attachment_id,
             "user_id": "user123",
@@ -2544,6 +2545,7 @@ class TestAttachmentPreview:
 
     @staticmethod
     def _patch_repos(attachment_row):
+        """Patch the attachments repo, readonly session, and local storage."""
         mock_repo = MagicMock()
         mock_repo.get_any.return_value = attachment_row
         return (
@@ -2563,6 +2565,7 @@ class TestAttachmentPreview:
 
     @staticmethod
     def _mock_storage(body=None):
+        """Storage double serving the given (default PNG) bytes."""
         mock_storage = MagicMock()
         payload = TestAttachmentPreview.png_bytes if body is None else body
         mock_storage.get_file_size.return_value = len(payload)
@@ -2589,8 +2592,83 @@ class TestAttachmentPreview:
                 assert _get_response_status(response) == 200
                 assert response.headers.get("Content-Type") == "image/png"
                 assert response.headers.get("X-Content-Type-Options") == "nosniff"
+                assert response.headers.get("Cache-Control") == "no-store"
                 assert b"".join(response.response) == self.png_bytes
                 mock_storage.get_file.assert_called_once_with(self.upload_path)
+
+    def test_preview_webp_octet_stream_served_via_suffix_map(self, flask_app):
+        # The stdlib MIME table names no type for .webp on some supported
+        # Pythons, so the worker stores application/octet-stream; the
+        # controlled suffix map must still serve the preview.
+        from application.api.user.attachments.routes import AttachmentPreview
+
+        app = Flask(__name__)
+        webp_bytes = b"RIFF\x00\x00\x00\x00WEBPVP8 "
+        mock_storage = self._mock_storage(webp_bytes)
+        row = self._row(
+            filename="photo.webp", mime_type="application/octet-stream"
+        )
+        p_repo, p_db, p_store = self._patch_repos(row)
+
+        with p_repo, p_db, p_store, patch(
+            "application.api.user.base.storage", mock_storage
+        ):
+            with app.test_request_context(
+                f"/api/attachment/{self.attachment_id}/preview",
+                method="GET",
+            ):
+                request.decoded_token = {"sub": "user123"}
+                response = AttachmentPreview().get(self.attachment_id)
+
+                assert _get_response_status(response) == 200
+                assert response.headers.get("Content-Type") == "image/webp"
+                assert b"".join(response.response) == webp_bytes
+
+    def test_preview_svg_stored_mime_returns_404_without_reading_bytes(
+        self, flask_app
+    ):
+        # SVG admitted via the text fallthrough must never be served: a
+        # navigated-to SVG would execute script in the application origin.
+        from application.api.user.attachments.routes import AttachmentPreview
+
+        app = Flask(__name__)
+        mock_storage = self._mock_storage(b"<svg></svg>")
+        row = self._row(filename="diagram.svg", mime_type="image/svg+xml")
+        p_repo, p_db, p_store = self._patch_repos(row)
+
+        with p_repo, p_db, p_store, patch(
+            "application.api.user.base.storage", mock_storage
+        ):
+            with app.test_request_context(
+                f"/api/attachment/{self.attachment_id}/preview",
+                method="GET",
+            ):
+                request.decoded_token = {"sub": "user123"}
+                response = AttachmentPreview().get(self.attachment_id)
+
+                assert _get_response_status(response) == 404
+                mock_storage.get_file.assert_not_called()
+
+    def test_preview_svg_suffix_without_mime_returns_404(self, flask_app):
+        from application.api.user.attachments.routes import AttachmentPreview
+
+        app = Flask(__name__)
+        mock_storage = self._mock_storage(b"<svg></svg>")
+        row = self._row(filename="diagram.svg", mime_type=None)
+        p_repo, p_db, p_store = self._patch_repos(row)
+
+        with p_repo, p_db, p_store, patch(
+            "application.api.user.base.storage", mock_storage
+        ):
+            with app.test_request_context(
+                f"/api/attachment/{self.attachment_id}/preview",
+                method="GET",
+            ):
+                request.decoded_token = {"sub": "user123"}
+                response = AttachmentPreview().get(self.attachment_id)
+
+                assert _get_response_status(response) == 404
+                mock_storage.get_file.assert_not_called()
 
     def test_preview_prefers_stored_mime_type(self, flask_app):
         from application.api.user.attachments.routes import AttachmentPreview
@@ -2784,7 +2862,7 @@ class TestAttachmentPreview:
 
         assert response.status_code == 302
         assert response.headers["Location"].startswith("https://bucket.example/")
-        assert response.headers["Cache-Control"] == "private, max-age=240"
+        assert response.headers["Cache-Control"] == "no-store"
         assert response.headers.get("X-Content-Type-Options") == "nosniff"
         mock_storage.generate_presigned_url.assert_called_once_with(
             self.upload_path, expires_in=300, content_type="image/png"
@@ -2795,6 +2873,7 @@ class TestAttachmentPreview:
     conv_id = "33333333-3333-4333-8333-333333333333"
 
     def _patch_share(self, share_row, messages):
+        """Patch the share/conversation repos for share-scoped requests."""
         mock_shared = MagicMock()
         mock_shared.find_by_uuid.return_value = share_row
         mock_conv = MagicMock()
@@ -2812,6 +2891,7 @@ class TestAttachmentPreview:
         )
 
     def _share_row(self, **overrides):
+        """Share row fixture covering the test attachment's message."""
         row = {
             "uuid": self.share_id,
             "conversation_id": self.conv_id,
@@ -2850,6 +2930,7 @@ class TestAttachmentPreview:
 
                 assert _get_response_status(response) == 200
                 assert response.headers.get("Content-Type") == "image/png"
+                assert response.headers.get("Cache-Control") == "no-store"
                 assert b"".join(response.response) == self.png_bytes
                 mock_storage.get_file.assert_called_once_with(self.upload_path)
 

--- a/tests/storage/test_s3_storage.py
+++ b/tests/storage/test_s3_storage.py
@@ -308,6 +308,33 @@ class TestS3StoragePresignedUrl:
             ExpiresIn=300,
         )
 
+    @pytest.mark.unit
+    def test_generate_presigned_url_can_override_cache_control(
+        self, s3_storage, mock_boto3_client
+    ):
+        """ResponseCacheControl must reach the signed params so identity-
+        authorized previews are not left cacheable at the object level."""
+        mock_boto3_client.generate_presigned_url.return_value = "https://signed"
+
+        result = s3_storage.generate_presigned_url(
+            "inputs/user123/attachments/photo.png",
+            expires_in=300,
+            content_type="image/png",
+            cache_control="no-store",
+        )
+
+        assert result == "https://signed"
+        mock_boto3_client.generate_presigned_url.assert_called_once_with(
+            "get_object",
+            Params={
+                "Bucket": "test-bucket",
+                "Key": "inputs/user123/attachments/photo.png",
+                "ResponseContentType": "image/png",
+                "ResponseCacheControl": "no-store",
+            },
+            ExpiresIn=300,
+        )
+
 
 class TestS3StorageDeleteFile:
     """Test file deletion functionality."""


### PR DESCRIPTION
## Summary
- Add image thumbnails for uploaded attachments.
- Add image previews for historical conversation attachments.
- Add an authenticated attachment preview endpoint.
- Support image previews in shared conversations.
- Add session-level preview caching and object URL lifecycle management.
- Preserve existing document attachment behavior.

## Security
- Attachment previews require owner authentication or a valid share capability.
- Shared previews are restricted to attachments belonging to messages visible through that share.
- Missing, foreign, non-image, and oversized attachments return 404.
- Image responses use the stored MIME type with legacy fallback.
- `X-Content-Type-Options: nosniff` is applied.

## Validation
- Backend attachment tests: 103/103 passing
- New attachment preview tests: 13/13 passing
- Frontend tests: 614/614 passing
- TypeScript: clean
- ESLint: 0 errors
- Ruff: clean
- Vite build: successful

## Notes
- S3-backed deployments require the appropriate bucket CORS configuration for browser-side preview fetching.
- Shared conversations intentionally expose previews only for messages within the share visible `first_n` range.
- Non-image attachments continue to use the existing document/icon representation.

Fixes #2483

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added image previews for attachments in conversations and shared conversations.
  * Image uploads now display thumbnails while uploading and after completion.
  * Attachment data includes MIME type information.
  * Non-image attachments continue to use document icons.

* **Bug Fixes**
  * Improved fallback behavior when image previews cannot be loaded.
  * Preview loading now supports only approved raster image formats.
  * Preview resources are cleaned up when attachments are removed or conversations reset.
  * Preview responses are no longer cached by browsers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->