### PR TITLE
Clarify docs directory description in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ git clone https://github.com/arc53/DocsGPT.git
 cd DocsGPT/docs
 ```
 
-The docs folder contains the markdown files that make up the documentation. The majority of the files are in the pages directory. Some notable files in this folder include:
+The docs directory houses the markdown source files for this documentation, with the core content primarily organized within the pages sub-directory.
 
 `index.mdx`: The main documentation file.
 `_app.js`: This file is used to customize the default Next.js application shell.


### PR DESCRIPTION
Updated the description of the docs directory for clarity.

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- **Why was this change needed?** (You can also link to an open issue here)

- **Other information**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the documentation overview to clarify that Markdown content is primarily organized in the `pages` subdirectory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->