### PR TITLE
docs: add anonymous Parallel Search MCP setup example

### DIFF
--- a/docs/content/Guides/Integrations/mcp-tool-integration.mdx
+++ b/docs/content/Guides/Integrations/mcp-tool-integration.mdx
@@ -36,7 +36,7 @@ In your agent configuration, enable the MCP tools you want the agent to use.
 
 ## Example: Parallel Search
 
-[Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) provides public web search and page extraction without a Parallel account or API key. Free access is rate limited.
+[Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) provides public web search and page extraction without a Parallel account or API key. Free access is rate-limited.
 
 1. Follow **Step 2** above and name the server **Parallel Search**.
 2. Enter `https://search.parallel.ai/mcp` as the server URL and select **None** for authentication. DocsGPT automatically uses Streamable HTTP for this URL.

--- a/docs/content/Guides/Integrations/mcp-tool-integration.mdx
+++ b/docs/content/Guides/Integrations/mcp-tool-integration.mdx
@@ -34,6 +34,21 @@ In your agent configuration, enable the MCP tools you want the agent to use.
 
 </Steps>
 
+## Example: Parallel Search
+
+[Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) provides public web search and page extraction without a Parallel account or API key. Free access is rate limited.
+
+1. Follow **Step 2** above and name the server **Parallel Search**.
+2. Enter `https://search.parallel.ai/mcp` as the server URL and select **None** for authentication. DocsGPT automatically uses Streamable HTTP for this URL.
+3. Click **Test Connection**. The discovered tools should include `web_search` and `web_fetch`. Click **Save**.
+4. Enable the saved MCP tool in your agent configuration. Start a conversation and ask, for example: "Search the web for the official Python documentation on virtual environments and fetch the relevant page."
+
+`web_search` returns web results with source URLs and excerpts. `web_fetch` extracts text from public URLs. To stop an agent from using these tools, remove the MCP tool from that agent's configuration.
+
+<Callout type="warning">
+Once enabled, the agent can call these tools during conversations. Queries, requested URLs, and any supplied objectives or context are sent to Parallel. Only enable the connection for agents whose data may be shared with this service.
+</Callout>
+
 ## Authentication Types
 
 | Auth Type | Config Fields |


### PR DESCRIPTION
- **What kind of change does this PR introduce?**

Documentation: adds a Parallel Search example to the existing MCP Tool Integration guide.

- **Why was this change needed?**

The guide explains authentication choices but has no concrete anonymous server example. This shows users how to connect public web search and page extraction through the existing MCP setup without a Parallel account or API key, verify the two tools, and enable or remove the connection for an agent.

DocsGPT already offers Brave and DuckDuckGo as [built-in search tools](https://github.com/arc53/DocsGPT/blob/4b56e56649befade4a7752c5b9be8cd5dff0a8a0/docs/content/Tools/basics.mdx), but neither is [enabled by default](https://github.com/arc53/DocsGPT/blob/4b56e56649befade4a7752c5b9be8cd5dff0a8a0/application/core/settings.py#L380-L388). Brave is the only one of those two covered by Artificial Analysis. The existing [Brave adapter uses its web-search endpoint](https://github.com/arc53/DocsGPT/blob/4b56e56649befade4a7752c5b9be8cd5dff0a8a0/application/agents/tools/brave.py#L51), so Brave Search (web) is the relevant comparison.

There's a useful quality gap here: in [Artificial Analysis's Aug 31 results](https://artificialanalysis.ai/agents/search-api), Parallel Search (advanced) scores **80.6 vs 62.3** for Brave Search (web) on DeepSearchQA F1, an **18.3-point lead**. Its overall Search Index is **74.8 vs 64.6**. That makes Parallel worth trying for agents doing web research, and this example gives users a simple way to do that without setting up an API key. These are Search API results in [AA's test harness](https://artificialanalysis.ai/methodology/search-api), not measured scores for this free MCP connection or DocsGPT.

The example explains that enabled agents can send queries, URLs, and supplied context to Parallel, and that free access is rate limited. This changes no runtime behavior, dependencies, defaults, or permissions.

- **Other information**:

I work at Parallel, which operates this service.

Validation on this commit:

- Ran the existing `MCPTool` with `fastmcp==3.4.6`, using the fields generated by `MCPServerModal` for authentication **None**. Automatic transport selection chose Streamable HTTP; `test_connection()` discovered `web_search` and `web_fetch`.
- Called both actions through `MCPTool.execute_action()`: search returned 10 results including the official Python `venv` documentation; fetch returned that page with excerpts and no per-URL errors. No Parallel credentials were present.
- Reviewed the UI configuration path in source and checked `git diff --check`.

The lightweight client check isolated unused OAuth, encryption, and Redis imports with fail-if-called placeholders and a minimal settings object. It did not run the UI, database persistence, or full application. The docs build and full test suite were not run. The screenshot below is a lightweight Markdown preview of the added section plus captured native-client output, not the built DocsGPT site or running app.

![Lightweight guide preview and live native-client results](https://raw.githubusercontent.com/georgeatparallel/DocsGPT/bb7f454c0fcbb459a5869a5634f0e5a8885e2da4/parallel-search-preview.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Parallel Search” MCP integration example.
  * Documented server setup, Streamable HTTP usage, discovered tools, agent configuration, supported capabilities, and data-sharing considerations.
  * Corrected the spelling of “rate-limited” in the example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->