### PR TITLE
feat(tts): make ElevenLabs voice and language configurable

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -11,6 +11,12 @@ INTERNAL_KEY=<internal key for worker-to-backend authentication>
 # NOVITA_API_KEY=<your-novita-api-key>
 # OPEN_ROUTER_API_KEY=<your-openrouter-api-key>
 
+# Text-to-speech (optional)
+# TTS_PROVIDER=elevenlabs
+# ELEVENLABS_API_KEY=<your-elevenlabs-api-key>
+# ELEVENLABS_VOICE_ID=nPczCjzI2devNBz1zQrb
+# ELEVENLABS_LANGUAGE=en
+
 # Embedding model. Leave it commented out and DocsGPT picks one for you: a
 # fresh install is pinned to granite (multilingual, 32k context, the same 768
 # dimensions as the legacy model), and an install that already has sources

--- a/docsgpt/core/settings.py
+++ b/docsgpt/core/settings.py
@@ -359,6 +359,8 @@ class Settings(BaseSettings):
 
     TTS_PROVIDER: str = "google_tts"  # google_tts or elevenlabs
     ELEVENLABS_API_KEY: Optional[str] = None
+    ELEVENLABS_VOICE_ID: str = "nPczCjzI2devNBz1zQrb"
+    ELEVENLABS_LANGUAGE: str = "en"
     STT_PROVIDER: str = "openai"  # openai or faster_whisper
     OPENAI_STT_MODEL: str = "gpt-4o-mini-transcribe"
     STT_LANGUAGE: Optional[str] = None

--- a/docsgpt/tts/elevenlabs.py
+++ b/docsgpt/tts/elevenlabs.py
@@ -1,7 +1,8 @@
-from io import BytesIO
 import base64
-from docsgpt.tts.base import BaseTTS
+from io import BytesIO
+
 from docsgpt.core.settings import settings
+from docsgpt.tts.base import BaseTTS
 
 
 class ElevenlabsTTS(BaseTTS):
@@ -10,22 +11,20 @@ class ElevenlabsTTS(BaseTTS):
 
         self.client = ElevenLabs(
             api_key=settings.ELEVENLABS_API_KEY,
-            )
-    
+        )
 
     def text_to_speech(self, text):
-        lang = "en"
+        lang = settings.ELEVENLABS_LANGUAGE
         audio = self.client.text_to_speech.convert(
-            voice_id="nPczCjzI2devNBz1zQrb",             
+            voice_id=settings.ELEVENLABS_VOICE_ID,
             model_id="eleven_multilingual_v2",
             text=text,
-            output_format="mp3_44100_128"
+            output_format="mp3_44100_128",
         )
         audio_data = BytesIO()
         for chunk in audio:
             audio_data.write(chunk)
         audio_bytes = audio_data.getvalue()
 
-        # Encode to base64
         audio_base64 = base64.b64encode(audio_bytes).decode("utf-8")
         return audio_base64, lang

--- a/tests/tts/test_elevenlabs_tts.py
+++ b/tests/tts/test_elevenlabs_tts.py
@@ -8,7 +8,11 @@ from docsgpt.tts.elevenlabs import ElevenlabsTTS
 def test_elevenlabs_text_to_speech_monkeypatched_client(monkeypatch):
     monkeypatch.setattr(
         "docsgpt.tts.elevenlabs.settings",
-        SimpleNamespace(ELEVENLABS_API_KEY="api-key"),
+        SimpleNamespace(
+            ELEVENLABS_API_KEY="api-key",
+            ELEVENLABS_VOICE_ID="custom-voice-id",
+            ELEVENLABS_LANGUAGE="fr",
+        ),
     )
 
     created = {}
@@ -50,12 +54,11 @@ def test_elevenlabs_text_to_speech_monkeypatched_client(monkeypatch):
     assert created["api_key"] == "api-key"
     assert tts.client.convert_calls == [
         {
-            "voice_id": "nPczCjzI2devNBz1zQrb",
+            "voice_id": "custom-voice-id",
             "model_id": "eleven_multilingual_v2",
             "text": "Speak",
             "output_format": "mp3_44100_128",
         }
     ]
-    assert lang == "en"
+    assert lang == "fr"
     assert base64.b64decode(audio_base64.encode()) == b"chunk-onechunk-two"
-


### PR DESCRIPTION
## Summary

Make ElevenLabs voice ID and language configurable through environment variables.

- Add `ELEVENLABS_VOICE_ID` and `ELEVENLABS_LANGUAGE` settings with backward-compatible defaults.
- Use the settings in the ElevenLabs TTS provider instead of hard-coded values.
- Document the optional TTS configuration in `.env-template`.
- Add regression coverage for custom voice and language values.

Fixes #2562

## Validation

- `uv run pytest tests/tts/test_elevenlabs_tts.py -q --no-cov`
- Result: `1 passed`
- The test uses a mocked ElevenLabs client to verify that configured voice ID and language values are passed through correctly.

## Screenshot

<img width="586" height="130" alt="image" src="https://github.com/user-attachments/assets/ef293850-fd92-4e1b-bbb0-004017cca83c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable ElevenLabs text-to-speech voice and language settings.
  * Added environment template placeholders for selecting the TTS provider, API key, voice ID, and language.

* **Bug Fixes**
  * ElevenLabs speech generation now uses the configured voice and language instead of fixed defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->