### PR TITLE
feat(docs): mount the DocsGPT chat widget

### DIFF
--- a/docs/app/layout.jsx
+++ b/docs/app/layout.jsx
@@ -5,6 +5,7 @@ import { getPageMap } from 'nextra/page-map';
 import { Footer, Layout, Navbar } from 'nextra-theme-docs';
 import 'nextra-theme-docs/style.css';
 
+import { DocsGPTChatWidget } from '../components/DocsGPTChatWidget';
 import CuteLogo from '../public/cute-docsgpt.png';
 import themeConfig from '../theme.config';
 
@@ -79,6 +80,7 @@ export default async function RootLayout({ children }) {
         >
           {children}
         </Layout>
+        <DocsGPTChatWidget />
         <Analytics />
       </body>
     </html>

--- a/docs/components/DocsGPTChatWidget.jsx
+++ b/docs/components/DocsGPTChatWidget.jsx
@@ -1,0 +1,40 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
+
+// The widget reads window/navigator on mount and ships its own styled-components
+// trees, so it must never be prerendered.
+const DocsGPTWidget = dynamic(
+  () => import('docsgpt-react').then((mod) => mod.DocsGPTWidget),
+  { ssr: false },
+);
+
+const apiHost =
+  process.env.NEXT_PUBLIC_DOCSGPT_API_HOST || 'https://gptcloud.arc53.com';
+const apiKey = process.env.NEXT_PUBLIC_DOCSGPT_API_KEY;
+
+export function DocsGPTChatWidget() {
+  const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  // No key means no widget. Falling through would silently use the demo key
+  // baked into the package default.
+  if (!apiKey || !mounted) return null;
+
+  return (
+    <DocsGPTWidget
+      apiHost={apiHost}
+      apiKey={apiKey}
+      theme={resolvedTheme === 'light' ? 'light' : 'dark'}
+      buttonText="Ask the docs"
+      title="Ask DocsGPT"
+      description="Answers drawn from these docs"
+      heroTitle="Ask anything about DocsGPT"
+      heroDescription="Answers are generated from this documentation. Check the sources for anything you plan to rely on."
+    />
+  );
+}

--- a/docs/components/DocsGPTChatWidget.jsx
+++ b/docs/components/DocsGPTChatWidget.jsx
@@ -13,7 +13,15 @@ const DocsGPTWidget = dynamic(
 
 const apiHost =
   process.env.NEXT_PUBLIC_DOCSGPT_API_HOST || 'https://gptcloud.arc53.com';
-const apiKey = process.env.NEXT_PUBLIC_DOCSGPT_API_KEY;
+
+// Public embed token for the docs agent, the same way every documented
+// DocsGPT embed carries one. It reaches the browser either way, since
+// NEXT_PUBLIC_* is inlined at build time. Abuse is capped by the agent's
+// daily request and token limits, so rotate the agent key if it needs
+// revoking. NEXT_PUBLIC_DOCSGPT_API_KEY overrides it for staging.
+const apiKey =
+  process.env.NEXT_PUBLIC_DOCSGPT_API_KEY ||
+  '0e714713-1bc6-4aae-a595-aa0b3bf317b3';
 
 export function DocsGPTChatWidget() {
   const { resolvedTheme } = useTheme();
@@ -21,9 +29,9 @@ export function DocsGPTChatWidget() {
 
   useEffect(() => setMounted(true), []);
 
-  // No key means no widget. Falling through would silently use the demo key
-  // baked into the package default.
-  if (!apiKey || !mounted) return null;
+  // Hold off until next-themes has resolved, so the widget does not flash
+  // the wrong theme on first paint.
+  if (!mounted) return null;
 
   return (
     <DocsGPTWidget

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -7,8 +7,9 @@
       "license": "MIT",
       "dependencies": {
         "@vercel/analytics": "^2.0.1",
-        "docsgpt-react": "^0.6.3",
+        "docsgpt-react": "^0.7.0",
         "next": "^16.3.0",
+        "next-themes": "^0.4.6",
         "nextra": "^4.6.1",
         "nextra-theme-docs": "^4.6.1",
         "react": "^19.2.8",
@@ -310,13 +311,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@bpmn-io/snarkdown": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/snarkdown/-/snarkdown-2.2.0.tgz",
-      "integrity": "sha512-bVD7FIoaBDZeCJkMRgnBPDeptPlto87wt2qaCjf5t8iLaevDmTPaREd6FpBEGsHlUdHFFZWRk4qAoEC5So2M0Q==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT"
     },
     "node_modules/@braintree/sanitize-url": {
       "version": "7.1.2",
@@ -4389,13 +4383,12 @@
       }
     },
     "node_modules/docsgpt-react": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/docsgpt-react/-/docsgpt-react-0.6.3.tgz",
-      "integrity": "sha512-sG2sb129O76ux2KbQJLEJ/rD1CCaO3vAKC4fN8/Ks5GaATC9lbavZy/PH75Y/q0bOMsPkh/Kdq6xSfGTfTIAuA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/docsgpt-react/-/docsgpt-react-0.7.0.tgz",
+      "integrity": "sha512-/noRUe3+5pudINS+nGYq4aN5NwNI9LC+teU8g23r8QxKubk8/xybFt6HS0ZK9JnCnMC/2GbnNL4kSP0IGw0vaA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/plugin-transform-flow-strip-types": "^7.23.3",
-        "@bpmn-io/snarkdown": "^2.2.0",
         "@parcel/resolver-glob": "^2.16.4",
         "@parcel/transformer-svg-react": "^2.16.4",
         "@parcel/transformer-typescript-tsc": "^2.16.4",
@@ -4404,45 +4397,11 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "dompurify": "^3.1.5",
-        "flow-bin": "^0.306.0",
+        "flow-bin": "^0.326.0",
         "markdown-it": "^14.1.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5",
         "styled-components": "^6.1.8"
-      }
-    },
-    "node_modules/docsgpt-react/node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/docsgpt-react/node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "node_modules/docsgpt-react/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/dompurify": {
@@ -4765,9 +4724,9 @@
       }
     },
     "node_modules/flow-bin": {
-      "version": "0.306.1",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.306.1.tgz",
-      "integrity": "sha512-xcLHE4dGHbsFio7/55YcFgeWttMEvpoC0T9FHj6xDB7frXvi+IQTWuBQtXpWrHPFflaUGF4jpQ1l6Rnlsev+Gw==",
+      "version": "0.326.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.326.0.tgz",
+      "integrity": "sha512-2WUYp7px5GeXLX+c2iFAUbr7093ta2c7bjox0pVTWaA6guMP91WFq3mkGKKzbKCIjqgDJepmMF5UPLafaJGE/A==",
       "license": "MIT",
       "bin": {
         "flow": "cli.js"
@@ -5542,18 +5501,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
       }
     },
     "node_modules/lower-case": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,8 +8,9 @@
   "license": "MIT",
   "dependencies": {
     "@vercel/analytics": "^2.0.1",
-    "docsgpt-react": "^0.6.3",
+    "docsgpt-react": "^0.7.0",
     "next": "^16.3.0",
+    "next-themes": "^0.4.6",
     "nextra": "^4.6.1",
     "nextra-theme-docs": "^4.6.1",
     "react": "^19.2.8",

--- a/extensions/react-widget/src/components/DocsGPTWidget.tsx
+++ b/extensions/react-widget/src/components/DocsGPTWidget.tsx
@@ -1,4 +1,3 @@
-'use client';
 import React, { useRef } from 'react';
 import DOMPurify from 'dompurify';
 import styled, { keyframes, css } from 'styled-components';


### PR DESCRIPTION
Adds a floating "Ask the docs" bubble to every page of the docs site, and fixes the packaging bug that blocked it.

## Docs site

`docsgpt-react` was already listed as a dependency but nothing imported it, so no widget rendered. This wires it up:

- `docs/components/DocsGPTChatWidget.jsx` is a client wrapper that lazy-loads `DocsGPTWidget` with `ssr: false`. The widget reads `window` and `navigator` on mount, so it must never be prerendered.
- Mounted from `app/layout.jsx`, so the bubble appears site-wide.
- Light/dark follows the site toggle through `next-themes`, promoted here from a transitive dependency of `nextra-theme-docs` to a declared one.
- Nextra's search and the pagefind postbuild step are untouched.

## Configuration

The widget ships with the docs agent's embed token, so the site works with no environment configuration. `NEXT_PUBLIC_DOCSGPT_API_KEY` overrides it for staging, and `NEXT_PUBLIC_DOCSGPT_API_HOST` overrides the host, which defaults to `https://gptcloud.arc53.com`.

The key is public either way. `NEXT_PUBLIC_*` is inlined at build time, so it reaches the client bundle whichever way it is supplied, and every documented DocsGPT embed carries its key in the page the same way. Abuse is bounded by the agent's daily request and token limits, enforced by `check_usage` on the answer and stream routes. Rotate the agent key if it ever needs revoking.

## Widget fix

The docs build failed against published `docsgpt-react`:

```
./node_modules/docsgpt-react/dist/module.js
x The "use client" directive must be placed before other expressions.
  1168 | 'use client';
```

`DocsGPTWidget.tsx` opened with `'use client'`, and Parcel's library build concatenates modules, stranding the directive a thousand lines into both `dist/module.js` and `dist/main.js`. webpack rejects a directive that is not the first expression in the file, so this broke every Next.js consumer of the package, not just this site. There was no import path around it since both the CommonJS and ESM outputs were affected.

The directive is removed from the source. It could not work from inside a bundle anyway, because a React Server Components boundary has to be declared by the importing module, which is what the new wrapper does.

## Duplicate React

The old `^0.6.3` pin depended on React 18 and npm installed a nested 18.3.1 beside the app's 19.2.8. Mounting the widget would have thrown an invalid hook call, since the bundle externalizes `require("react")` and would have resolved the nested copy. Bumping to `^0.7.0` dedupes to a single React and drops `loose-envify`, `scheduler` and the stale `@bpmn-io/snarkdown` from the lockfile.

## Deploy order

1. Merge #2757, the open version bump that still leaves `main` reading 0.6.3 while npm has 0.7.0.
2. Merge this PR.
3. Dispatch **Publish npm libraries** with `patch` to ship 0.7.1 with the directive fix.
4. Run `npm update docsgpt-react` in `docs/` to relock onto 0.7.1.
5. Confirm `limited_request_mode` is enabled on the docs agent. Both limit modes default to off, and the caps only apply once the matching mode is on.

Until 0.7.1 is published a fresh `npm install` in `docs/` will fail the build, because the released 0.7.0 bundle still carries the stranded directive.

## Validation

- `docs`: `npm run build` passes with the widget mounted, 48 pages indexed, key confirmed inlined into the layout chunk.
- `extensions/react-widget`: `npm run build:react` clean, no `use client` in either output bundle. `tsc --noEmit` and eslint both clean.

## Follow-up, not in this PR

`docsgpt-react` declares `react`, `react-dom`, `styled-components` and the whole Parcel and `flow-bin` toolchain as runtime `dependencies` rather than peer and dev ones. That is the root cause of the React nesting above, and it pushes build tooling into every consumer's install.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a DocsGPT chat widget to the documentation site.
  * The widget supports light and dark themes and displays customized interface text.
  * The widget is available without requiring users to configure an API key.
* **Bug Fixes**
  * Improved compatibility for rendering the DocsGPT widget within the documentation site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
