### PR TITLE
chore(docs): relock docsgpt-react onto 0.7.1

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "@vercel/analytics": "^2.0.1",
-        "docsgpt-react": "^0.7.0",
+        "docsgpt-react": "^0.7.1",
         "next": "^16.3.0",
         "next-themes": "^0.4.6",
         "nextra": "^4.6.1",
@@ -4383,9 +4383,9 @@
       }
     },
     "node_modules/docsgpt-react": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/docsgpt-react/-/docsgpt-react-0.7.0.tgz",
-      "integrity": "sha512-/noRUe3+5pudINS+nGYq4aN5NwNI9LC+teU8g23r8QxKubk8/xybFt6HS0ZK9JnCnMC/2GbnNL4kSP0IGw0vaA==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/docsgpt-react/-/docsgpt-react-0.7.1.tgz",
+      "integrity": "sha512-sxxkU9mo0r2yx3jT7PI0F9n7QvkSmPJDDepdAqtSTkZZZnz/SoQObKcfDSV9+jcaSLgllXxbkohiZLJbseXq0g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/plugin-transform-flow-strip-types": "^7.23.3",

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "dependencies": {
     "@vercel/analytics": "^2.0.1",
-    "docsgpt-react": "^0.7.0",
+    "docsgpt-react": "^0.7.1",
     "next": "^16.3.0",
     "next-themes": "^0.4.6",
     "nextra": "^4.6.1",


### PR DESCRIPTION
Fixes the docs site build, which has been failing on `main` since the chat widget landed in #2758.

## Why

The published `docsgpt-react@0.7.0` bundle carries a `'use client'` directive stranded mid-file by Parcel's module concatenation, which webpack rejects:

```
./node_modules/docsgpt-react/dist/module.js
x The "use client" directive must be placed before other expressions.
  1168 | 'use client';
```

0.7.1 ships the fix from #2758. Publishing it was not enough on its own, because `docs/package-lock.json` pinned 0.7.0 exactly and Vercel installs from the lockfile. This relocks onto 0.7.1 and raises the range to `^0.7.1` so a fresh install cannot land back on the broken build.

## Validation

- `npm run build` in `docs/` passes against the real published 0.7.1 tarball, not a locally patched copy. 48 pages indexed.
- Confirmed the installed 0.7.1 bundle has no stranded directive.

## Follow-up

`limited_request_mode` still needs enabling on the docs agent. Both limit modes default to off and `check_usage` returns early when neither is on, so the daily caps do nothing until then. The embed key is public by design, but it is worth having the cap actually active.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation site’s Docsgpt React package to version 0.7.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->