### PR TITLE
ci: fix PyPI publishing from the release chain, make image builds recoverable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,25 @@ on:
         description: Release tag to build and push (the images are tagged with it)
         type: string
         required: true
+      move_latest:
+        description: Also move the `latest` tag onto this build
+        type: boolean
+        default: true
     secrets:
       DOCKER_USERNAME:
         required: true
       DOCKER_PASSWORD:
         required: true
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release tag to build and push (the images are tagged with it)
+        type: string
+        required: true
+      move_latest:
+        description: Also move the `latest` tag onto this build
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -142,15 +156,24 @@ jobs:
       - name: Create and push multi-arch manifests
         env:
           TAG: ${{ env.RELEASE_TAG }}${{ matrix.variant }}
-          # A stable release moves `latest`; a prerelease published by hand
-          # moves only its own tag (the release trigger fires for those too).
-          LATEST: ${{ (inputs.version || !github.event.release.prerelease) && format('latest{0}', matrix.variant) || '' }}
+          VARIANT: ${{ matrix.variant }}
+          # Raw facts; the shell below decides from them what `latest` does.
+          IS_PRERELEASE: ${{ github.event.release.prerelease || false }}
+          MOVE_LATEST: ${{ inputs.move_latest }}
         run: |
           set -e
-          # $LATEST is deliberately unquoted: it is empty for a prerelease, and
-          # an empty word would create a manifest named "$repo:".
+          # `latest` follows this build, except for a release marked prerelease
+          # (the release trigger fires for those too) or a manual run that asked
+          # it not to. MOVE_LATEST is empty for a release event, where only the
+          # prerelease flag decides.
+          moving="latest${VARIANT}"
+          if [ "$IS_PRERELEASE" = true ] || [ "$MOVE_LATEST" = false ]; then
+            moving=""
+          fi
+          # $moving is deliberately unquoted: an empty word would create a
+          # manifest named "$repo:".
           for repo in "$DOCKERHUB_NAMESPACE/docsgpt" "ghcr.io/${{ github.repository_owner }}/docsgpt"; do
-            for name in "$TAG" $LATEST; do
+            for name in "$TAG" $moving; do
               docker manifest create "$repo:$name" \
                 --amend "$repo:$TAG-amd64" \
                 --amend "$repo:$TAG-arm64"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,11 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
+          # Build the source the tag names, not whatever the run was started
+          # from: a manual run dispatched off main would otherwise publish the
+          # current branch under an older version's tags. Empty for a push,
+          # where the checked-out commit is the one being tagged `develop`.
+          ref: ${{ inputs.version || github.ref }}
           persist-credentials: false
 
       - name: Set up Docker Buildx
@@ -190,6 +195,11 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
+          # Build the source the tag names, not whatever the run was started
+          # from: a manual run dispatched off main would otherwise publish the
+          # current branch under an older version's tags. Empty for a push,
+          # where the checked-out commit is the one being tagged `develop`.
+          ref: ${{ inputs.version || github.ref }}
           persist-credentials: false
 
       - name: Attach the standalone compose file to the release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,11 @@ jobs:
         with:
           # Build the source the tag names, not whatever the run was started
           # from: a manual run dispatched off main would otherwise publish the
-          # current branch under an older version's tags. Empty for a push,
-          # where the checked-out commit is the one being tagged `develop`.
-          ref: ${{ inputs.version || github.ref }}
+          # current branch under an older version's tags. Resolved under
+          # refs/tags/ so a version that is also a branch name cannot win, and a
+          # version with no tag fails here instead of mislabelling an image.
+          # Falls back to the run's own ref for the push that tags `develop`.
+          ref: ${{ inputs.version && format('refs/tags/{0}', inputs.version) || github.ref }}
           persist-credentials: false
 
       - name: Set up Docker Buildx
@@ -197,9 +199,11 @@ jobs:
         with:
           # Build the source the tag names, not whatever the run was started
           # from: a manual run dispatched off main would otherwise publish the
-          # current branch under an older version's tags. Empty for a push,
-          # where the checked-out commit is the one being tagged `develop`.
-          ref: ${{ inputs.version || github.ref }}
+          # current branch under an older version's tags. Resolved under
+          # refs/tags/ so a version that is also a branch name cannot win, and a
+          # version with no tag fails here instead of mislabelling an image.
+          # Falls back to the run's own ref for the push that tags `develop`.
+          ref: ${{ inputs.version && format('refs/tags/{0}', inputs.version) || github.ref }}
           persist-credentials: false
 
       - name: Attach the standalone compose file to the release

--- a/.github/workflows/cife.yml
+++ b/.github/workflows/cife.yml
@@ -14,11 +14,25 @@ on:
         description: Release tag to build and push (the images are tagged with it)
         type: string
         required: true
+      move_latest:
+        description: Also move the `latest` tag onto this build
+        type: boolean
+        default: true
     secrets:
       DOCKER_USERNAME:
         required: true
       DOCKER_PASSWORD:
         required: true
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release tag to build and push (the images are tagged with it)
+        type: string
+        required: true
+      move_latest:
+        description: Also move the `latest` tag onto this build
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -26,10 +40,6 @@ permissions:
 env:
   # The tag being published: passed in by the caller, or the release's own.
   RELEASE_TAG: ${{ inputs.version || github.event.release.tag_name }}
-  # A stable release also moves `latest`. A prerelease published by hand moves
-  # only its own tag: the release trigger fires for those too, and they must not
-  # become `latest`.
-  MOVING_TAG: ${{ (inputs.version || !github.event.release.prerelease) && 'latest' || '' }}
 
 jobs:
   build:
@@ -143,13 +153,23 @@ jobs:
       - name: Create and push multi-arch manifests
         env:
           TAG: ${{ env.RELEASE_TAG }}
-          MOVING: ${{ env.MOVING_TAG }}
+          # Raw facts; the shell below decides from them what `latest` does.
+          IS_PRERELEASE: ${{ github.event.release.prerelease || false }}
+          MOVE_LATEST: ${{ inputs.move_latest }}
         run: |
           set -e
-          # $MOVING is deliberately unquoted: it is empty for a prerelease, and
-          # an empty word would create a manifest named "$repo:".
+          # `latest` follows this build, except for a release marked prerelease
+          # (the release trigger fires for those too) or a manual run that asked
+          # it not to. MOVE_LATEST is empty for a release event, where only the
+          # prerelease flag decides.
+          moving=latest
+          if [ "$IS_PRERELEASE" = true ] || [ "$MOVE_LATEST" = false ]; then
+            moving=""
+          fi
+          # $moving is deliberately unquoted: an empty word would create a
+          # manifest named "$repo:".
           for repo in "$DOCKERHUB_NAMESPACE/docsgpt-fe" "ghcr.io/${{ github.repository_owner }}/docsgpt-fe"; do
-            for name in "$TAG" $MOVING; do
+            for name in "$TAG" $moving; do
               docker manifest create "$repo:$name" \
                 --amend "$repo:$TAG-amd64" \
                 --amend "$repo:$TAG-arm64"

--- a/.github/workflows/cife.yml
+++ b/.github/workflows/cife.yml
@@ -68,6 +68,11 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
+          # Build the source the tag names, not whatever the run was started
+          # from: a manual run dispatched off main would otherwise publish the
+          # current branch under an older version's tags. Empty for a push,
+          # where the checked-out commit is the one being tagged `develop`.
+          ref: ${{ inputs.version || github.ref }}
           persist-credentials: false
 
       - name: Set up Docker Buildx

--- a/.github/workflows/cife.yml
+++ b/.github/workflows/cife.yml
@@ -70,9 +70,11 @@ jobs:
         with:
           # Build the source the tag names, not whatever the run was started
           # from: a manual run dispatched off main would otherwise publish the
-          # current branch under an older version's tags. Empty for a push,
-          # where the checked-out commit is the one being tagged `develop`.
-          ref: ${{ inputs.version || github.ref }}
+          # current branch under an older version's tags. Resolved under
+          # refs/tags/ so a version that is also a branch name cannot win, and a
+          # version with no tag fails here instead of mislabelling an image.
+          # Falls back to the run's own ref for the push that tags `develop`.
+          ref: ${{ inputs.version && format('refs/tags/{0}', inputs.version) || github.ref }}
           persist-credentials: false
 
       - name: Set up Docker Buildx

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -6,6 +6,13 @@ name: Publish to PyPI
 # creates with GITHUB_TOKEN never fires the release trigger); a release created
 # by hand publishes through that trigger; a manual run publishes to TestPyPI
 # by default.
+#
+# Attestations are on only when this file is the workflow that STARTED the run.
+# A PEP 740 attestation records the entry workflow in its certificate, while
+# trusted publishing matches the called workflow, so when backend-release calls
+# this one the two disagree and PyPI rejects the upload with "Certificate's
+# Build Config URI ... does not match expected Trusted Publisher". No publisher
+# configuration satisfies both, so the release chain publishes unattested.
 
 on:
   release:
@@ -116,6 +123,9 @@ jobs:
           path: dist/
 
       - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          # Only when this workflow is the entry point: see the note at the top.
+          attestations: ${{ contains(github.workflow_ref, '/pypi-publish.yml@') }}
 
   publish-testpypi:
     if: inputs.target == 'testpypi'
@@ -134,6 +144,8 @@ jobs:
 
       - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
+          # Only when this workflow is the entry point: see the note at the top.
+          attestations: ${{ contains(github.workflow_ref, '/pypi-publish.yml@') }}
           repository-url: https://test.pypi.org/legacy/
           # TestPyPI is a rehearsal target: a version that is already there
           # must not fail the run.

--- a/.github/workflows/sandbox-image.yml
+++ b/.github/workflows/sandbox-image.yml
@@ -80,6 +80,11 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
+          # Build the source the tag names, not whatever the run was started
+          # from: a manual run dispatched off main would otherwise publish the
+          # current branch under an older version's tags. Empty for a push,
+          # where the checked-out commit is the one being tagged `develop`.
+          ref: ${{ inputs.version || github.ref }}
           persist-credentials: false
 
       - name: Set up Docker Buildx

--- a/.github/workflows/sandbox-image.yml
+++ b/.github/workflows/sandbox-image.yml
@@ -21,11 +21,25 @@ on:
         description: Release tag to build and push (the images are tagged with it)
         type: string
         required: true
+      move_latest:
+        description: Also move the `latest` tag onto this build
+        type: boolean
+        default: true
     secrets:
       DOCKER_USERNAME:
         required: true
       DOCKER_PASSWORD:
         required: true
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release tag to build and push (the images are tagged with it)
+        type: string
+        required: true
+      move_latest:
+        description: Also move the `latest` tag onto this build
+        type: boolean
+        default: true
   push:
     branches: [main]
     paths:
@@ -38,10 +52,6 @@ permissions:
 env:
   # The version being published, or `develop` for a push to main.
   RELEASE_TAG: ${{ inputs.version || github.event.release.tag_name || 'develop' }}
-  # A stable release also moves `latest`. A push to main moves nothing but
-  # `develop`, and a prerelease published by hand moves only its own tag: the
-  # release trigger fires for those too, and they must not become `latest`.
-  MOVING_TAG: ${{ (inputs.version || (github.event.release.tag_name && !github.event.release.prerelease)) && 'latest' || '' }}
 
 jobs:
   build:
@@ -155,13 +165,23 @@ jobs:
       - name: Create and push multi-arch manifests
         env:
           TAG: ${{ env.RELEASE_TAG }}
-          MOVING: ${{ env.MOVING_TAG }}
+          # Raw facts; the shell below decides from them what `latest` does.
+          IS_PRERELEASE: ${{ github.event.release.prerelease || false }}
+          MOVE_LATEST: ${{ inputs.move_latest }}
         run: |
           set -e
-          # $MOVING is deliberately unquoted: it is empty for a push to main,
-          # and an empty word would create a manifest named "$repo:".
+          # `latest` follows this build, except for the rolling `develop` build,
+          # a release marked prerelease (the release trigger fires for those
+          # too), or a manual run that asked it not to. MOVE_LATEST is empty for
+          # a release event and for a push, where the other two rules decide.
+          moving=latest
+          if [ "$TAG" = develop ] || [ "$IS_PRERELEASE" = true ] || [ "$MOVE_LATEST" = false ]; then
+            moving=""
+          fi
+          # $moving is deliberately unquoted: an empty word would create a
+          # manifest named "$repo:".
           for repo in "$DOCKERHUB_NAMESPACE/docsgpt-sandbox" "ghcr.io/${{ github.repository_owner }}/docsgpt-sandbox"; do
-            for name in "$TAG" $MOVING; do
+            for name in "$TAG" $moving; do
               docker manifest create "$repo:$name" \
                 --amend "$repo:$TAG-amd64" \
                 --amend "$repo:$TAG-arm64"

--- a/.github/workflows/sandbox-image.yml
+++ b/.github/workflows/sandbox-image.yml
@@ -82,9 +82,11 @@ jobs:
         with:
           # Build the source the tag names, not whatever the run was started
           # from: a manual run dispatched off main would otherwise publish the
-          # current branch under an older version's tags. Empty for a push,
-          # where the checked-out commit is the one being tagged `develop`.
-          ref: ${{ inputs.version || github.ref }}
+          # current branch under an older version's tags. Resolved under
+          # refs/tags/ so a version that is also a branch name cannot win, and a
+          # version with no tag fails here instead of mislabelling an image.
+          # Falls back to the run's own ref for the push that tags `develop`.
+          ref: ${{ inputs.version && format('refs/tags/{0}', inputs.version) || github.ref }}
           persist-credentials: false
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
- **What kind of change does this PR introduce?** Bug fix (release automation).

- **Why was this change needed?**

  Both halves come out of the 0.20.0 release.

  **1. PyPI publishing from the release chain cannot work as written.** The 0.20.0 upload failed with:

  ```
  400 Invalid attestations supplied during upload: Could not verify the uploaded artifact
  using the included attestation: Verification failed: Certificate's Build Config URI
  (...backend-release.yml@refs/heads/main) does not match expected Trusted Publisher
  (pypi-publish.yml @ arc53/DocsGPT)
  ```

  Authentication was not the problem. Trusted publishing matches `job_workflow_ref`, which is the called workflow, `pypi-publish.yml`, exactly what PyPI is configured with. The PEP 740 attestation that `gh-action-pypi-publish` attaches by default records the workflow that *started* the run, `backend-release.yml`, and PyPI verifies that against the same publisher entry. Those two claims can never agree while the publish runs as a called workflow, and no publisher configuration satisfies both, since they are different values. The rehearsal in #2748 went to TestPyPI and passed, so it only showed up on the real index.

  **2. No image workflow could be started by hand.** 0.20.0 tagged half an hour before #2763 merged, so the release ran against the old chain and built no `docsgpt-fe:0.20.0` and no `docsgpt-sandbox:0.20.0`. Neither workflow had a `workflow_dispatch` trigger, so the only recovery was deleting and recreating the release, which would also re-run the PyPI publish.

- **Other information**

  Attestations are now on only when `pypi-publish.yml` is the entry point, which covers the manual dispatch and a release published by hand. The release chain uploads unattested rather than failing. The alternative, having `backend-release.yml` start the publish by dispatch instead of calling it, needs a token that can trigger workflows, which `GITHUB_TOKEN` cannot.

  All three image workflows now take a `workflow_dispatch` with the version to build, plus a `move_latest` switch so rebuilding an older tag does not drag `latest` backwards. The moving-tag rule moved out of a nested expression into the manifest step's shell, where it reads as three plain conditions: `latest` follows the build unless the release is a prerelease, the run asked it not to, or it is the rolling `develop` build. I exercised that shell locally across the release, prerelease, called, dispatched and push cases, including under `set -e`, which the earlier `[ ... ] && var=` form would have tripped over.

  **After merge**, these two runs give 0.20.0 its missing images:

  ```
  gh workflow run cife.yml --ref main -f version=0.20.0
  gh workflow run sandbox-image.yml --ref main -f version=0.20.0
  ```

  Verified with `zizmor` (no findings across all five release workflows) and a YAML parse of each.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added manual release workflow triggers with a required version and optional control over updating the `latest` tag.
  - Release workflows can publish specific versions without moving `latest`.
  - Manual releases now build from the selected version.

- **Bug Fixes**
  - Prereleases no longer update the `latest` tag automatically.
  - Publishing workflows now handle package attestations correctly across direct and chained releases.

- **Documentation**
  - Added guidance explaining attestation requirements for package publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

  **Added after review.** CodeRabbit caught that a manual run bound the version only to the published tags, not to the source: the checkout had no `ref`, so dispatching off main to rebuild an older release would have published current main under that release's tags and moved `latest` onto it. Every checkout in the three workflows now uses `ref: ${{ inputs.version || github.ref }}`, so a manual run builds the tagged source while still using the workflow definition from the dispatch ref. The release and call paths already resolved to the right commit; this makes it explicit and fails loudly on a version with no tag. The compose file attached to a release now comes from the tag as well.
